### PR TITLE
Fix resize

### DIFF
--- a/packages/mip/examples/page/iframe/input-iframed.html
+++ b/packages/mip/examples/page/iframe/input-iframed.html
@@ -36,6 +36,8 @@
         of Lorem Ipsum.
     </div>
     <input type="text" />
+    <input type="text" />
+    <input type="text" />
     <div class="page disable-scrolling">
             Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's
             standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make

--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -194,5 +194,9 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
         window.addEventListener('myEvent', e => {
             console.log('receive myEvent in index.html', e)
         })
+        // iOS 下滚动页面居然会触发 resize 事件
+        // window.addEventListener('resize', () => {
+        //     window.alert(window.MIP.viewport.getHeight())
+        // })
     </script>
 </body>

--- a/packages/mip/src/page/const/index.js
+++ b/packages/mip/src/page/const/index.js
@@ -37,6 +37,7 @@ export const MESSAGE_UPDATE_MIP_SHELL_CONFIG = 'update-mip-shell-config'
 export const MESSAGE_SYNC_PAGE_CONFIG = 'sync-page-config'
 export const MESSAGE_CROSS_ORIGIN = 'page-cross-origin'
 export const MESSAGE_BROADCAST_EVENT = 'page-broadcast-event'
+export const MESSAGE_PAGE_RESIZE = 'page-resize'
 
 export const NON_EXISTS_PAGE_ID = 'non-exists-page-id'
 export const CUSTOM_EVENT_SCROLL_TO_ANCHOR = 'scroll-to-anchor'

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -131,6 +131,7 @@ class Page {
 
   initAppShell () {
     if (this.isRootPage) {
+      this.currentViewportHeight = viewport.getHeight()
       this.globalComponent = new GlobalComponent()
       this.messageHandlers.push((type, data) => {
         if (type === MESSAGE_SET_MIP_SHELL_CONFIG) {
@@ -169,10 +170,14 @@ class Page {
           console.log('register global component')
           // this.globalComponent.register(data)
         } else if (type === MESSAGE_PAGE_RESIZE) {
-          Array.prototype.slice.call(document.querySelectorAll('.mip-page__iframe')).forEach($el => {
-            $el.style.height = `${data.height}px`
-          })
+          this.resizeAllPages()
         }
+      })
+
+      // update every iframe's height when viewport resizing
+      viewport.on('resize', () => {
+        this.currentViewportHeight = viewport.getHeight()
+        this.resizeAllPages()
       })
 
       // Set iframe height when resizing
@@ -541,6 +546,10 @@ class Page {
               toggle: true
             }
           })
+          if (this.direction === 'back') {
+            document.documentElement.classList.add('mip-no-scroll')
+            Array.prototype.slice.call(this.getElementsInRootPage()).forEach(e => e.classList.add('hide'))
+          }
           options.onComplete && options.onComplete()
         }
       }
@@ -665,6 +674,12 @@ class Page {
     ]
     let notInWhitelistSelector = whitelist.map(selector => `:not(${selector})`).join('')
     return document.body.querySelectorAll(`body > ${notInWhitelistSelector}`)
+  }
+
+  resizeAllPages () {
+    Array.prototype.slice.call(document.querySelectorAll('.mip-page__iframe')).forEach($el => {
+      $el.style.height = `${this.currentViewportHeight}px`
+    })
   }
 
   /**

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -35,7 +35,8 @@ import {
   MESSAGE_SYNC_PAGE_CONFIG,
   MESSAGE_REGISTER_GLOBAL_COMPONENT,
   MESSAGE_CROSS_ORIGIN,
-  MESSAGE_BROADCAST_EVENT
+  MESSAGE_BROADCAST_EVENT,
+  MESSAGE_PAGE_RESIZE
 } from './const/index'
 
 import {customEmit} from '../vue-custom-element/utils/custom-event'
@@ -167,6 +168,10 @@ class Page {
           // Register global component (Not finished)
           console.log('register global component')
           // this.globalComponent.register(data)
+        } else if (type === MESSAGE_PAGE_RESIZE) {
+          Array.prototype.slice.call(document.querySelectorAll('.mip-page__iframe')).forEach($el => {
+            $el.style.height = `${data.height}px`
+          })
         }
       })
 
@@ -324,11 +329,12 @@ class Page {
 
     // ========================= Some HACKs =========================
 
-    // prevent bouncy scroll in iOS 7 & 8
+    // prevent bouncy scroll in iOS 7 & 8 & (Shoubai iOS 9,10)
     if (platform.isIos()) {
       let iosVersion = platform.getOsVersion()
       iosVersion = iosVersion ? iosVersion.split('.')[0] : ''
-      if (iosVersion !== '8' && iosVersion !== '7') {
+      if (!(iosVersion === '8' || iosVersion === '7' ||
+        (platform.isBaidu && (iosVersion === '9' || iosVersion === '10')))) {
         document.documentElement.classList.add('mip-i-ios-scroll')
       }
     }

--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -9,6 +9,7 @@ import platform from '../../util/platform'
 import {MIP_IFRAME_CONTAINER} from '../const/index'
 import {raf, transitionEndEvent, animationEndEvent} from './feature-detect'
 import {normalizeLocation} from './route'
+import viewport from '../../viewport'
 
 let activeZIndex = 10000
 
@@ -43,7 +44,7 @@ export function createIFrame ({fullpath, pageId}, {onLoad, onError} = {}) {
    * Fix an iOS iframe width bug, see examples/mip1/test.html
    * https://stackoverflow.com/questions/23083462/how-to-get-an-iframe-to-be-responsive-in-ios-safari
    */
-  // container.style.height = `${viewport.getHeight()}px`
+  container.style.height = `${viewport.getHeight()}px`
   container.setAttribute('width', '100%')
   container.setAttribute('scrolling', platform.isIos() ? 'no' : 'yes')
 

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -16,7 +16,7 @@ import {getOriginalUrl} from './util'
 import {supportsPassive, isPortrait} from './page/util/feature-detect'
 import viewport from './viewport'
 import Page from './page/index'
-import {MESSAGE_ROUTER_PUSH, MESSAGE_ROUTER_REPLACE} from './page/const/index'
+import {MESSAGE_ROUTER_PUSH, MESSAGE_ROUTER_REPLACE, MESSAGE_PAGE_RESIZE} from './page/const/index'
 import Messager from './messager'
 import fixedElement from './fixed-element'
 
@@ -90,6 +90,15 @@ let viewer = {
         title: encodeURIComponent(document.title)
       })
     }
+
+    event.delegate(document, 'input', 'blur', event => {
+      this.page.notifyRootPage({
+        type: MESSAGE_PAGE_RESIZE,
+        data: {
+          height: viewport.getHeight()
+        }
+      })
+    }, true)
 
     // proxy <a mip-link>
     this._proxyLink(this.page)

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -93,10 +93,7 @@ let viewer = {
 
     event.delegate(document, 'input', 'blur', event => {
       this.page.notifyRootPage({
-        type: MESSAGE_PAGE_RESIZE,
-        data: {
-          height: viewport.getHeight()
-        }
+        type: MESSAGE_PAGE_RESIZE
       })
     }, true)
 

--- a/packages/mip/src/viewport.js
+++ b/packages/mip/src/viewport.js
@@ -66,7 +66,6 @@ let viewport = {
   init () {
     this.scroller = platform.needSpecialScroll ? document.body : win
 
-    // fixedElement.init()
     this.scroller.addEventListener('scroll', scrollHandle.bind(this), false)
 
     win.addEventListener('resize', resizeEvent.bind(this))


### PR DESCRIPTION
修复以下几个问题：
1. #29，原因是刷新之后，点击头部返回按钮（不是浏览器的返回按钮）时，没有隐藏掉原始页面中的内容。
2. 手百 iOS 9, 10 存在滑动之后白屏的现象，禁用掉弹性滚动特性。
3. 部分机型存在关闭软键盘后，iframe 高度没有恢复的问题。目前尝试的一种解决方案是监听 input 的 blur  事件，重新设置所有 iframe 的高度。