### PR TITLE
fix: iOS QQ browser

### DIFF
--- a/packages/mip/src/page/router/history.js
+++ b/packages/mip/src/page/router/history.js
@@ -1,6 +1,7 @@
 import {START, normalizeLocation} from '../util/route'
 import {pushState, replaceState} from '../util/push-state'
 import {getLocation} from '../util/path'
+import platform from '../../util/platform';
 
 export default class HTML5History {
   constructor (router) {
@@ -51,8 +52,13 @@ export default class HTML5History {
 
   transitionTo (location, onComplete) {
     const route = normalizeLocation(location, this.current)
-    onComplete && onComplete(route)
-    this.updateRoute(route)
+    if (platform.isAndroid() && (platform.isQQ || platform.isQQApp)) {
+      onComplete && onComplete(route)
+      this.updateRoute(route)
+    } else {
+      this.updateRoute(route)
+      onComplete && onComplete(route)
+    }
   }
 
   updateRoute (route) {


### PR DESCRIPTION
Fix #36 
原本为了修复 安卓 QQ 浏览器特有的一个问题：必须先 `pushState`，再创建 iframe，否则此时后退不触发 `popstate`。因此我们修改了 router 中这两个操作的顺序。

但是影响到了 iOS QQ 浏览器，因此加上了精确的 UA 检测。