### PR TITLE
增加 chromedriver 镜像地址，解决使用 npm 安装失败的问题

### DIFF
--- a/packages/mip/.npmrc
+++ b/packages/mip/.npmrc
@@ -1,0 +1,1 @@
+chromedriver_cdnurl=https://npm.taobao.org/mirrors/chromedriver


### PR DESCRIPTION
chromedriver 这个依赖要下载driver文件，直接 npm install 会失败，配置国内镜像地址，能快速下载