### PR TITLE
Fix invalid hash selector

### DIFF
--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -60,18 +60,20 @@ class Page {
    * @param {string} hash hash
    */
   scrollToHash (hash) {
-    if (hash) {
-      try {
-        let $hash = document.querySelector(decodeURIComponent(hash))
-        /* istanbul ignore next */
-        if ($hash) {
-          // scroll to current hash
-          scrollTo($hash.offsetTop, {
-            scrollTop: viewport.getScrollTop()
-          })
-        }
-      } catch (e) {}
+    if (typeof hash !== 'string' || hash[0] !== '#') {
+      return
     }
+
+    try {
+      const anchor = document.getElementById(decodeURIComponent(hash.slice(1)))
+
+      /* istanbul ignore next */
+      if (anchor) {
+        scrollTo(anchor.offsetTop, {
+          scrollTop: viewport.getScrollTop()
+        })
+      }
+    } catch (e) {}
   }
 
   /**


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/116

**1、升级点** `scrollToHash` 中 `document.querySelector` 替换为 `document.getElementById`

**2、影响范围** 所有滚动到 hash 的操作

**3、自测 Checklist** 官网上测过相关升级点

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
