### PR TITLE
Dev 119 mipimg

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -42,8 +42,9 @@ let imgRatio = {
 function getPopupImgPos (imgWidth, imgHeight) {
   let width = viewport.getWidth()
   let height = Math.round(width * imgHeight / imgWidth)
-  let top = viewport.getHeight() > height
-    ? (viewport.getHeight() - height) / 2
+  let viewportH = viewport.getHeight()
+  let top = viewportH > height
+    ? (viewportH - height) / 2
     : 0
   return {
     width: width,

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -94,8 +94,6 @@ function createPopup (element, img) {
     preventY: true
   })
 
-
-
   popup.className = 'mip-img-popUp-wrapper'
   popup.setAttribute('data-name', 'mip-img-popUp-name')
 

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -42,7 +42,9 @@ let imgRatio = {
 function getPopupImgPos (imgWidth, imgHeight) {
   let width = viewport.getWidth()
   let height = Math.round(width * imgHeight / imgWidth)
-  let top = (viewport.getHeight() - height) / 2
+  let top = viewport.getHeight() > height
+    ? (viewport.getHeight() - height) / 2
+    : 0
   return {
     width: width,
     height: height,
@@ -91,6 +93,9 @@ function createPopup (element, img) {
   new Gesture(popup, {
     preventY: true
   })
+
+
+
   popup.className = 'mip-img-popUp-wrapper'
   popup.setAttribute('data-name', 'mip-img-popUp-name')
 

--- a/packages/mip/src/styles/mip-img.less
+++ b/packages/mip/src/styles/mip-img.less
@@ -106,7 +106,7 @@
     width: 100%;
     height: 100%;
     z-index: 20222;
-    overflow: scroll;
+    overflow: auto;
     img {
       position: absolute;
     }

--- a/packages/mip/src/styles/mip-img.less
+++ b/packages/mip/src/styles/mip-img.less
@@ -106,6 +106,7 @@
     width: 100%;
     height: 100%;
     z-index: 20222;
+    overflow: scroll;
     img {
       position: absolute;
     }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** 

mip-img 组件使用`popup `属性做图片过大弹层显示时，不会超出屏幕，默认从图片顶部显示且可通过滚动查看完整图片。

**2、影响范围** （描述该需求上线会影响什么功能）
使用mip-img 组件的popup 属性的相关页面

**3、自测 Checklist**
- 图片高度超出视口高度，情况PC弹层显示，从头展示可滚动浏览图片
```html
<mip-img popup src="http://bos.nj.bpc.baidu.com/v1/assets/mip/mip2-component-lifecycle.png"></mip-img>
```
- 图片高度小于等于视口高度，居中显示


**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
