### PR TITLE
✨ 修改组件布尔属性的转换规则

### DIFF
--- a/packages/mip/README.md
+++ b/packages/mip/README.md
@@ -6,8 +6,10 @@ MIP
 - Clone 代码之后运行
 
 ```sh
-$ cnpm install # npm install
+$ npm install # 安装依赖
 ```
+
+> 建议使用 [淘宝NPM 镜像](https://npm.taobao.org/) 安装速度更快: `cnpm install`
 
 ## Test and coverage
 
@@ -27,7 +29,7 @@ $ npm run test:cover
 # watch and auto re-build dist/mip.js
 $ npm run dev
 ```
-监控代码改动并编译代码到 `dist/mip.js`，可通过 `open examples/simple/index.html` 预览效果
+监控代码改动并编译代码到 `dist/mip.js`，可通过 http://localhost:8080/examples/ 预览效果
 
 ```sh
 # build all dist files, including npm packages

--- a/packages/mip/src/vue-custom-element/utils/props.js
+++ b/packages/mip/src/vue-custom-element/utils/props.js
@@ -36,7 +36,7 @@ function getPropType (prop) {
  */
 export function convertAttributeValue (value, type) {
   if (type === Boolean) {
-    return value === 'false' ? false : !!value
+    return value !== 'false'
   }
 
   if (type === Number) {

--- a/packages/mip/test/specs/vue-custom-element/utils/props.spec.js
+++ b/packages/mip/test/specs/vue-custom-element/utils/props.spec.js
@@ -322,8 +322,12 @@ describe('vue-custom-element/utils/props', function () {
     it('convert boolean', function () {
       expect(convertAttributeValue('true', Boolean)).to.be.equal(true)
       expect(convertAttributeValue('false', Boolean)).to.be.equal(false)
-      expect(convertAttributeValue('', Boolean)).to.be.equal(false)
+
+      expect(convertAttributeValue('', Boolean)).to.be.equal(true)
       expect(convertAttributeValue('1', Boolean)).to.be.equal(true)
+      expect(convertAttributeValue('0', Boolean)).to.be.equal(true)
+      expect(convertAttributeValue('NaN', Boolean)).to.be.equal(true)
+      expect(convertAttributeValue('[]', Boolean)).to.be.equal(true)
     })
 
     it('convert array', function () {
@@ -343,38 +347,6 @@ describe('vue-custom-element/utils/props', function () {
       let str = '{"name": -"mip"}'
       convertAttributeValue(str, Object)
       sinon.assert.calledWith(warn, str + ' attribute content should be a valid JSON string!')
-    })
-
-    describe('props#reactiveProps', function () {
-      it('convert string', function () {
-        expect(convertAttributeValue('str')).to.be.equal('str')
-        expect(convertAttributeValue('str', String)).to.be.equal('str')
-      })
-
-      it('convert number', function () {
-        expect(convertAttributeValue('123', Number)).to.be.equal(123)
-        expect(convertAttributeValue('1.23', Number)).to.be.equal(1.23)
-        expect(convertAttributeValue('0.23', Number)).to.be.equal(0.23)
-      })
-
-      it('convert boolean', function () {
-        expect(convertAttributeValue('true', Boolean)).to.be.equal(true)
-        expect(convertAttributeValue('false', Boolean)).to.be.equal(false)
-        expect(convertAttributeValue('', Boolean)).to.be.equal(false)
-        expect(convertAttributeValue('1', Boolean)).to.be.equal(true)
-      })
-
-      it('convert array', function () {
-        expect(convertAttributeValue('[123]', Array)).to.deep.equal([123])
-        expect(convertAttributeValue('[true]', Array)).to.deep.equal([true])
-        expect(convertAttributeValue('["huang", "test"]', Array)).to.deep.equal(['huang', 'test'])
-      })
-
-      it('convert object', function () {
-        expect(convertAttributeValue('{"name": "mip"}', Object)).to.deep.equal({
-          name: 'mip'
-        })
-      })
     })
   })
 


### PR DESCRIPTION
 **相关 ISSUE:** （ISSUE 链接地址）
#134

**1、升级点** （清晰准确的描述升级的功能点）
见 issue

**2、影响范围** （描述该需求上线会影响什么功能）
所有 MIP 组件布尔值属性，只有明确写将属性值设置为 false 才会被转换成 false 值

**3、自测 Checklist**

mac Chrome 模拟器

iOS 11.4 IPhone X:
手百
QQ
UC
Chrome
Safari

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百