### PR TITLE
remove node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: node_js
 node_js:
-  - "7"
   - "8"
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
     <a href='https://coveralls.io/github/mipengine/mip2'>
         <img src='https://coveralls.io/repos/github/mipengine/mip2/badge.svg?branch=master' title='Coverage Status' alt='Coverage Status' />
     </a>
-	<a href='https://opensource.org/licenses/MIT'>
-		<img src='https://img.shields.io/github/license/mipengine/mip2.svg'  title='license' alt='license'>
-	</a>
+    <a href='https://opensource.org/licenses/MIT'>
+        <img src='https://img.shields.io/github/license/mipengine/mip2.svg'  title='license' alt='license'>
+    </a>
 </p>
 
 # MIP 2


### PR DESCRIPTION
travis 运行单测时， node7 环境下安装依赖经常出错，影响构建状态。mip 本身和 node 版本无关，所以留一个就行了。