### PR TITLE
修改刷新范围

### DIFF
--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -411,8 +411,8 @@ let viewer = {
         // So we are forced to load the page in iphone 5s UC
         // and iOS 9 safari.
         let needBackReload = (iosVersion === '8' && platform.isUc() && screen.width === 320) ||
-          (iosVersion === '9' && platform.isSafari()) ||
-          (iosVersion === '10' && platform.isSafari())
+          ((iosVersion === '9' || iosVersion === '10') && platform.isSafari()) ||
+          ((iosVersion === '8' || iosVersion === '9' || iosVersion === '10') && (platform.isUc() || platform.isBaiduApp()))
         if (needBackReload) {
           window.addEventListener('pageshow', e => {
             if (e.persisted) {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -410,10 +410,10 @@ let viewer = {
         // So we are forced to load the page in below conditions:
         // 1. IOS 8 + UC
         // 2. IOS 9 & 10 + Safari
-        // 3. IOS 8 & 9 & 10 + UC & BaiduApp
+        // 3. IOS 8 & 9 & 10 + UC & BaiduApp & Baidu
         let needBackReload = (iosVersion === '8' && platform.isUc() && screen.width === 320) ||
           ((iosVersion === '9' || iosVersion === '10') && platform.isSafari()) ||
-          ((iosVersion === '8' || iosVersion === '9' || iosVersion === '10') && (platform.isUc() || platform.isBaiduApp()))
+          ((iosVersion === '8' || iosVersion === '9' || iosVersion === '10') && (platform.isUc() || platform.isBaiduApp() || platform.isBaidu()))
         if (needBackReload) {
           window.addEventListener('pageshow', e => {
             if (e.persisted) {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -405,11 +405,12 @@ let viewer = {
       if (this.isIframed) {
         this.lockBodyScroll()
 
-        // Fix iphone 5s UC and ios 9 safari bug.
         // While the back button is clicked,
         // the cached page has some problems.
-        // So we are forced to load the page in iphone 5s UC
-        // and iOS 9 safari.
+        // So we are forced to load the page in below conditions:
+        // 1. IOS 8 + UC
+        // 2. IOS 9 & 10 + Safari
+        // 3. IOS 8 & 9 & 10 + UC & BaiduApp
         let needBackReload = (iosVersion === '8' && platform.isUc() && screen.width === 320) ||
           ((iosVersion === '9' || iosVersion === '10') && platform.isSafari()) ||
           ((iosVersion === '8' || iosVersion === '9' || iosVersion === '10') && (platform.isUc() || platform.isBaiduApp()))


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#122 
**1、升级点** （清晰准确的描述升级的功能点）
为 IOS 8,9,10 下的 UC 和手百 添加刷新逻辑
**2、影响范围** （描述该需求上线会影响什么功能）
IOS 下所有跳往外链的链接，点回退后不再白屏
**3、自测 Checklist**
IOS 10 的 UC 和 手百 测试正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
