### PR TITLE
修复 #125 刷新后滚动到锚点

### DIFF
--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -108,7 +108,7 @@
         <a class="link" href="./data.html" mip-link>Go to Data</a>
     </div>
 
-    <div id="简介2"></div>
+    <a id="anchor" href="./index.html#anchor">Anchor</a>
 
     <br><br>
 
@@ -141,7 +141,7 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
 Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
 Fast - Respond quickly to user interactions with silky smooth animations and no janky scrolling.
     </p>
-    <div id="简介"></div>
+
     <p>
     Progressive Web Apps are user experiences that have the reach of the web, and are:
 Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.

--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -109,6 +109,8 @@
     </div>
 
     <a id="anchor" href="./index.html#anchor">Anchor</a>
+    <a id="anchor-markdown-doc-responsive%20%E5%B8%83%E5%B1%80" href="./index.html#anchor-markdown-doc-responsive%20%E5%B8%83%E5%B1%80">Anchor2</a>
+    <a id="anchor-markdown-doc-设置轮播时间间隔" href="#anchor-markdown-doc-%E8%AE%BE%E7%BD%AE%E8%BD%AE%E6%92%AD%E6%97%B6%E9%97%B4%E9%97%B4%E9%9A%94">Anchor3</a>
 
     <br><br>
 

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -26,6 +26,7 @@ import {
 
 import {customEmit} from '../util/custom-event'
 import viewport from '../viewport'
+import performance from '../performance'
 import '../styles/mip.less'
 
 /**
@@ -170,8 +171,17 @@ class Page {
     ensureMIPShell()
     this.initPageId()
 
-    // scroll to current hash if exists
-    this.scrollToHash(window.location.hash)
+    /**
+     * scroll to anchor after all the elements loaded
+     * fix: https://github.com/mipengine/mip2/issues/125
+     */
+    performance.on('update', timing => {
+      if (timing.MIPFirstScreen) {
+        // scroll to current hash if exists
+        this.scrollToHash(window.location.hash)
+      }
+    })
+
     window.addEventListener(CUSTOM_EVENT_SCROLL_TO_ANCHOR, (e) => {
       this.scrollToHash(e.detail[0])
     })

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -66,7 +66,8 @@ class Page {
     }
 
     try {
-      const anchor = document.getElementById(decodeURIComponent(hash.slice(1)))
+      const anchor = document.getElementById(hash.slice(1)) ||
+        document.getElementById(decodeURIComponent(hash.slice(1)))
 
       /* istanbul ignore next */
       if (anchor) {

--- a/packages/mip/test/e2e/cases/scroll-to-anchor.html
+++ b/packages/mip/test/e2e/cases/scroll-to-anchor.html
@@ -35,9 +35,33 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
   <a class="link tree-link" href="./tree.html" mip-link>Go to Tree</a>
   <a class="link api-link" href="./api.html" mip-link>Go to API</a>
   <a class="link page-forward" onclick="window.MIP.viewer.page.forward()">page.forward()</a>
-  <a class="link scroll-to-anchor-link" href="./scroll-to-anchor.html" mip-link>Go to Scroll to Anchor</a>
 
   <mip-page-index></mip-page-index>
+
+  <a id="anchor" href="./scroll-to-anchor.html#anchor">Anchor</a>
+
+  <br><br>
+  <p>
+  Progressive Web Apps are user experiences that have the reach of the web, and are:
+Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
+Fast - Respond quickly to user interactions with silky smooth animations and no janky scrolling.
+  </p>
+  <p>
+  Progressive Web Apps are user experiences that have the reach of the web, and are:
+Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
+Fast - Respond quickly to user interactions with silky smooth animations and no janky scrolling.
+  </p>
+  <p>
+  Progressive Web Apps are user experiences that have the reach of the web, and are:
+Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
+Fast - Respond quickly to user interactions with silky smooth animations and no janky scrolling.
+  </p>
+
+  <p>
+  Progressive Web Apps are user experiences that have the reach of the web, and are:
+Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
+Fast - Respond quickly to user interactions with silky smooth animations and no janky scrolling.
+  </p>
 
   <mip-shell>
     <script type="application/json">

--- a/packages/mip/test/e2e/cases/scroll-to-anchor.html
+++ b/packages/mip/test/e2e/cases/scroll-to-anchor.html
@@ -26,6 +26,9 @@
   <div class="main-image">
     <mip-img src="https://ss0.bdstatic.com/70cFuHSh_Q1YnxGkpoWK1HF6hhy/it/u=3010417400,2137373730&fm=27&gp=0.jpg" width="300" height="300"></mip-img>
   </div>
+
+  <a id="anchor-%E8%AE" class="encoded-anchor" href="./scroll-to-anchor.html#anchor-%E8%AE">Anchor2</a>
+
   <p>
   Progressive Web Apps are user experiences that have the reach of the web, and are:
 Reliable - Load instantly and never show the downasaur, even in uncertain network conditions.
@@ -39,6 +42,7 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
   <mip-page-index></mip-page-index>
 
   <a id="anchor" href="./scroll-to-anchor.html#anchor">Anchor</a>
+  <a id="anchor-设置轮播时间间隔" href="./scroll-to-anchor.html#anchor-%E8%AE%BE%E7%BD%AE%E8%BD%AE%E6%92%AD%E6%97%B6%E9%97%B4%E9%97%B4%E9%9A%94">Anchor3</a>
 
   <br><br>
   <p>

--- a/packages/mip/test/e2e/specs/scroll-to-anchor.js
+++ b/packages/mip/test/e2e/specs/scroll-to-anchor.js
@@ -14,6 +14,8 @@
 let INDEX_PAGE_URL
 let SCROLL_PAGE_URL
 let positionY = 0 // anchor's position in Yaxis
+let positionY2 = 0
+let positionY3 = 0
 
 module.exports = {
   'open page': function (browser) {
@@ -27,16 +29,47 @@ module.exports = {
       .waitForElementVisible('body', 2000)
   },
   'scroll to correct position when click an anchor': function (browser) {
+    const anchor1 = '#anchor'
+    const anchor2 = '#anchor-%E8%AE'
+    const anchor3 = '#anchor-设置轮播时间间隔'
+    const hashOfAnchor3 = '#anchor-%E8%AE%BE%E7%BD%AE%E8%BD%AE%E6%92%AD%E6%97%B6%E9%97%B4%E9%97%B4%E9%9A%94'
+
     browser
       // save anchor's position
-      .getLocation('#anchor', function (result) {
+      .getLocation(anchor3, function (result) {
+        positionY2 = result.value.y
+      })
+      // click anchor
+      .waitForClick(anchor3)
+      .pause(1000)
+      // hash changed
+      .assert.urlContains(hashOfAnchor3)
+      .execute(function () {
+        // it should scroll to top
+        this.assert.equal(window.MIP.viewport.getScrollTop(), positionY3)
+      })
+      // save anchor's position
+      .getLocation('.encoded-anchor', function (result) {
+        positionY2 = result.value.y
+      })
+      // click anchor
+      .waitForClick('.encoded-anchor')
+      .pause(1000)
+      // hash changed
+      .assert.urlContains(anchor2)
+      .execute(function () {
+        // it should scroll to top
+        this.assert.equal(window.MIP.viewport.getScrollTop(), positionY2)
+      })
+      // save anchor's position
+      .getLocation(anchor1, function (result) {
         positionY = result.value.y
       })
       // click anchor
-      .waitForClick('#anchor')
+      .waitForClick(anchor1)
       .pause(1000)
       // hash changed
-      .assert.urlContains('#anchor')
+      .assert.urlContains(anchor1)
       .execute(function () {
         // it should scroll to top
         this.assert.equal(window.MIP.viewport.getScrollTop(), positionY)

--- a/packages/mip/test/e2e/specs/scroll-to-anchor.js
+++ b/packages/mip/test/e2e/specs/scroll-to-anchor.js
@@ -1,0 +1,74 @@
+/**
+ * @file scroll to anchor e2e test case (standalone 模式)
+ * @author panyuqi
+ * @description 测试流程：
+ * 1. 打开 scroll-to-anchor.html
+ * 2. 点击 <a id="anchor" href="./scroll-to-anchor.html#anchor"> 滚动到锚点处
+ * 3. 在当前页面刷新，滚动到锚点处
+ * 4. 打开 index.html 通过 mip-link 跳转到 scroll-to-anchor.html 验证 iframe 下的情况
+ * 5. 点击 iframe 中的 <a id="anchor"> 滚动到锚点处
+ *
+ * fix ISSUE: https://github.com/mipengine/mip2/issues/125
+ */
+
+let INDEX_PAGE_URL
+let SCROLL_PAGE_URL
+let positionY = 0 // anchor's position in Yaxis
+
+module.exports = {
+  'open page': function (browser) {
+    INDEX_PAGE_URL = `${browser.globals.devServerURL}/test/e2e/cases/index.html`
+    SCROLL_PAGE_URL = `${browser.globals.devServerURL}/test/e2e/cases/scroll-to-anchor.html`
+
+    browser
+      // open index.html
+      .url(SCROLL_PAGE_URL)
+      // show mip-shell
+      .waitForElementVisible('body', 2000)
+  },
+  'scroll to correct position when click an anchor': function (browser) {
+    browser
+      // save anchor's position
+      .getLocation('#anchor', function (result) {
+        positionY = result.value.y
+      })
+      // click anchor
+      .waitForClick('#anchor')
+      .pause(1000)
+      // hash changed
+      .assert.urlContains('#anchor')
+      .execute(function () {
+        // it should scroll to top
+        this.assert.equal(window.MIP.viewport.getScrollTop(), positionY)
+      })
+  },
+  'scroll to correct position when refresh': function (browser) {
+    browser
+      .refresh()
+      // hash contains #anchor
+      .assert.urlContains('#anchor')
+      .pause(1000)
+      .execute(function () {
+        // it should scroll to top
+        this.assert.equal(window.MIP.viewport.getScrollTop(), positionY)
+      })
+  },
+  'open scroll page in iframe': function (browser) {
+    browser
+      // open index.html
+      .url(INDEX_PAGE_URL)
+      // open tree.html
+      .waitForClick('.scroll-to-anchor-link')
+      .enterIframe(SCROLL_PAGE_URL, () => {
+        browser
+          // click anchor
+          .waitForClick('#anchor')
+          .pause(1000)
+          .execute(function () {
+            // it should scroll to top
+            this.assert.equal(window.MIP.viewport.getScrollTop(), positionY)
+          })
+      })
+      .end()
+  }
+}


### PR DESCRIPTION
**相关 ISSUE:**  #125

**1、升级点** （清晰准确的描述升级的功能点）
修复 #125 描述的 Bug，
点击页面中锚点，滚动到相应位置，
此时刷新页面后仍然能正确滚动到之前的锚点位置。

**2、影响范围** （描述该需求上线会影响什么功能）
目前线上除了 MIP 官网，没有其他产品线使用这个功能。

**3、自测 Checklist**
提交中包含了 e2e 测试用例。
 1. 打开 scroll-to-anchor.html
 2. 点击 `<a id="anchor">` 滚动到锚点处
 3. 在当前页面刷新，滚动到锚点处
 4. 打开 index.html 通过 mip-link 跳转到 scroll-to-anchor.html 验证 iframe 下的情况
 5. 点击 iframe 中的 `<a id="anchor">` 滚动到锚点处

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
