### PR TITLE
[提测] 修复轮播图mip-img嵌套问题，增加mip-img长图浏览效果

### DIFF
--- a/packages/mip/examples/builtin-components/mip-img.html
+++ b/packages/mip/examples/builtin-components/mip-img.html
@@ -140,6 +140,26 @@
   src="https://www.mipengine.org/static/img/sample_03.jpg">
 </mip-img>
 
+<h2>长图浏览</h2>
+
+<pre class="code">&lt;mip-img
+  layout="responsive"
+  width="200"
+  height="500"
+  popup
+  alt="baidu mip img"
+  src="http://bos.nj.bpc.baidu.com/v1/assets/mip/mip2-component-lifecycle.png"&gt;
+&lt;/mip-img&gt;</pre>
+
+<mip-img
+  layout="responsive"
+  width="200"
+  height="500"
+  popup
+  alt="baidu mip img"
+  src="http://bos.nj.bpc.baidu.com/v1/assets/mip/mip2-component-lifecycle.png">
+</mip-img>
+
 </body>
 <script src="../../dist/mip.js"></script>
 </html>

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -487,7 +487,7 @@ class MIPCarousel extends CustomElement {
         setTimeout(function () {
           translateFn(curGestureClientx, '0ms', wrapBox)
           btnLock.stop = 1
-        }, 300)
+        }, 400)
       }
       btnLock.stop = 1
       indicatorChange(imgIndex)

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -78,10 +78,6 @@ function getAllMipImgSrc (childNodes) {
       let node = childNodes[i].querySelector('mip-img')
       if (node) {
         arr.push(node.getAttribute('src'))
-      } else {
-        // 没有mip-img的情况，理论上应该报错
-        arr.push('')
-        console.warn(`childNodes[${i}] of mip-carousel can't find mip-img`)
       }
     }
   }

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -42,31 +42,50 @@ function prerenderSetSrc (allMipImgs, index, num, arraySrc) {
       for (let j = 0; j < imgs.length; j++) {
         imgs[j].setAttribute('src', arraySrc[i])
       }
+    } else {
+      allMipImgs[i].querySelector('mip-img').setAttribute('src', arraySrc[i])
     }
   }
 }
 /**
  * 修改 src 为某张图的 src
  * @param  {NodeList} childList 一般是 mip-img 标签的集合
- * @param  {number } j         j
+ * @param  {number} j         j
+ * param   {Array} arraySrc arraySrc
  * @return {NodeList}           返回 childList
  */
-function changeSrc (childList, j) {
-  let src = ''
-  // 考虑 mip-img 是被嵌套在 a 里面的情况
-  if (childList[j].tagName === 'MIP-IMG') {
-    src = childList[j].getAttribute('src')
-  } else {
-    src = childList[j].querySelector('mip-img').getAttribute('src')
-  }
+function changeSrc (childList, j, arraySrc) {
   for (let i = 0; i < childList.length; i++) {
     if (childList[i].tagName === 'MIP-IMG') {
-      childList[i].setAttribute('src', src)
+      childList[i].setAttribute('src', arraySrc[j])
+    } else {
+      childList[i].querySelector('mip-img').setAttribute('src', arraySrc[j])
     }
   }
   return childList
 }
-
+/**
+ * 获取carousel下所有mip-img的src，目前只处理一层和两层的，3层也当两层处理
+ * @param  {Array.<HTMLElement>} childNodes getChildNodes函数得出的数组
+ * @return {Array.<string>}                 mip-img中的src组成的数组
+ */
+function getAllMipImgSrc (childNodes) {
+  let arr = []
+  for (let i = 0; i < childNodes.length; i++) {
+    if (childNodes[i].tagName === 'MIP-IMG') {
+      arr.push(childNodes[i].getAttribute('src'))
+    } else {
+      let node = childNodes[i].querySelector('mip-img')
+      if (node) {
+        arr.push(node.getAttribute('src'))
+      } else {
+        // 没有mip-img的情况，理论上应该报错
+        arr.push('')
+      }
+    }
+  }
+  return arr
+}
 // 按tagName创建一个固定class的tag
 function createTagWithClass (className, tagName) {
   tagName = tagName || 'div'
@@ -228,8 +247,8 @@ class MIPCarousel extends CustomElement {
     // 获取carousel下的所有节点
     let childNodes = getChildNodes(ele)
     // 获取所有的 src
-    let arraySrc = childNodes.map(value => value.getAttribute('src'))
-    childNodes = changeSrc(childNodes, imgIndex)
+    let arraySrc = getAllMipImgSrc(childNodes)
+    childNodes = changeSrc(childNodes, imgIndex, arraySrc)
 
     // 图片显示个数
     // 其实图片个数应该为实际个数+2.copy了头和尾的两部分

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -50,16 +50,16 @@ function prerenderSetSrc (allMipImgs, index, num, arraySrc) {
 /**
  * 修改 src 为某张图的 src
  * @param  {NodeList} childList 一般是 mip-img 标签的集合
- * @param  {number} j         j
- * @param   {Array} arraySrc arraySrc
+ * @param  {number} imgIndex    imgIndex是显示的第一张图片的在arraySrc中的index
+ * @param   {Array} arraySrc    所有图片的src组成的数组
  * @return {NodeList}           返回 childList
  */
-function changeSrc (childList, j, arraySrc) {
+function changeSrc (childList, imgIndex, arraySrc) {
   for (let i = 0; i < childList.length; i++) {
     if (childList[i].tagName === 'MIP-IMG') {
-      childList[i].setAttribute('src', arraySrc[j])
+      childList[i].setAttribute('src', arraySrc[imgIndex])
     } else {
-      childList[i].querySelector('mip-img').setAttribute('src', arraySrc[j])
+      childList[i].querySelector('mip-img').setAttribute('src', arraySrc[imgIndex])
     }
   }
   return childList

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -51,7 +51,7 @@ function prerenderSetSrc (allMipImgs, index, num, arraySrc) {
  * 修改 src 为某张图的 src
  * @param  {NodeList} childList 一般是 mip-img 标签的集合
  * @param  {number} j         j
- * param   {Array} arraySrc arraySrc
+ * @param   {Array} arraySrc arraySrc
  * @return {NodeList}           返回 childList
  */
 function changeSrc (childList, j, arraySrc) {
@@ -81,6 +81,7 @@ function getAllMipImgSrc (childNodes) {
       } else {
         // 没有mip-img的情况，理论上应该报错
         arr.push('')
+        console.warn(`childNodes[${i}] of mip-carousel can't find mip-img`)
       }
     }
   }

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -106,6 +106,7 @@ function createPopup (element, img) {
   // 计算 wrapper 窗口大小
   let imgOffset = getImgOffset(img)
   let PopupImgPos = getPopupImgPos(imgOffset.width, imgOffset.height)
+  PopupImgPos.top = 0
   css(carouselWrapper, {
     'position': 'absolute'
   })
@@ -181,7 +182,6 @@ function bindPopup (element, img) {
     window.addEventListener('resize', onResize)
 
     css(popupImg, imgOffset)
-    css(popupImg, 'position', 'fixed')
     css(popupBg, 'opacity', 1)
 
     naboo.animate(popupImg, getPopupImgPos(imgOffset.width, imgOffset.height)).start()

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -86,7 +86,7 @@ function getImgsSrc () {
 /**
  * 找出当前视口下的图片
  * @param  {HTMLElement} carouselWrapper carouselWrapper
- * @return {HTMLElement}                 img
+ * @return {HTMLElement} img
  */
 function getCurrentImg (carouselWrapper) {
   // 例如：'translate3d(-90px,0,0)'
@@ -113,19 +113,19 @@ function createPopup (element, img) {
   let carouselWrapper = document.createElement('div')
   // 计算 wrapper 窗口大小
   let imgOffset = getImgOffset(img)
-  let PopupImgPos = getPopupImgPos(imgOffset.width, imgOffset.height)
-  PopupImgPos.top = 0
+  let popupImgPos = getPopupImgPos(imgOffset.width, imgOffset.height)
+  popupImgPos.top = 0
   css(carouselWrapper, {
     'position': 'absolute'
   })
-  css(carouselWrapper, PopupImgPos)
+  css(carouselWrapper, popupImgPos)
   // 创建 mip-carousel
   let carousel = document.createElement('mip-carousel')
 
   carousel.setAttribute('layout', 'height-fixed')
   carousel.setAttribute('index', index + 1)
-  carousel.setAttribute('width', PopupImgPos.width)
-  carousel.setAttribute('height', PopupImgPos.height)
+  carousel.setAttribute('width', popupImgPos.width)
+  carousel.setAttribute('height', popupImgPos.height)
 
   for (let i = 0; i < imgsSrcArray.length; i++) {
     let mipImg = document.createElement('mip-img')

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -189,7 +189,7 @@ function bindPopup (element, img) {
       }).start()
 
       naboo.animate(popup, {'display': 'none'})
-      naboo.animate(popupImg, previousPos).start(function () {
+      naboo.animate(popupImg, previousPos).start(() => {
         css(img, 'visibility', 'visible')
         css(popup, 'display', 'none')
         popup.removeEventListener('click', imagePop, false)

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -84,6 +84,18 @@ function getImgOffset (img) {
 function getImgsSrc () {
   return [...document.querySelectorAll('mip-img')].filter(value => value.hasAttribute('popup')).map(value => value.getAttribute('src'))
 }
+/**
+ * 找出当前视口下的图片
+ * @param  {HTMLElement} carouselWrapper carouselWrapper
+ * @return {HTMLElement}                 img
+ */
+function getCurrentImg (carouselWrapper) {
+  // 例如：'translate3d(-90px,0,0)'
+  let str = carouselWrapper.style.webkitTransform
+  let result = /translate3d\(-?([0-9]+)/i.exec(str)
+  let number = parseInt(result[1]) / viewport.getWidth()
+  return carouselWrapper.querySelectorAll('mip-img')[number]
+}
 // 创建弹层 dom
 function createPopup (element, img) {
   // 获取图片数组
@@ -151,7 +163,10 @@ function bindPopup (element, img) {
     })
     let popup = createPopup(element, img)
     let popupBg = popup.querySelector('.mip-img-popUp-bg')
-    let popupImg = popup.querySelector('mip-carousel')
+    let mipCarousel = popup.querySelector('mip-carousel')
+    let popupImg = new Image()
+    popupImg.setAttribute('src', img.src)
+    popup.appendChild(popupImg)
 
     let imgOffset = getImgOffset(img)
 
@@ -163,6 +178,11 @@ function bindPopup (element, img) {
         skipTransition: true,
         extraClass: 'black'
       })
+      // 找出当前视口下的图片
+      let currentImg = getCurrentImg(popup.querySelector('.mip-carousel-wrapper'))
+      popupImg.setAttribute('src', currentImg.getAttribute('src'))
+      css(popupImg, 'display', 'block')
+      css(mipCarousel, 'display', 'none')
       naboo.animate(popupBg, {
         opacity: 0
       }).start()
@@ -182,9 +202,14 @@ function bindPopup (element, img) {
     window.addEventListener('resize', onResize)
 
     css(popupImg, imgOffset)
+    css(mipCarousel, getPopupImgPos(imgOffset.width, imgOffset.height))
+    css(mipCarousel, 'display', 'none')
     css(popupBg, 'opacity', 1)
 
-    naboo.animate(popupImg, getPopupImgPos(imgOffset.width, imgOffset.height)).start()
+    naboo.animate(popupImg, getPopupImgPos(imgOffset.width, imgOffset.height)).start(() => {
+      css(popupImg, 'display', 'none')
+      css(mipCarousel, 'display', 'block')
+    })
     css(img, 'visibility', 'hidden')
     css(img.parentNode, 'zIndex', 'inherit')
   }, false)

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -14,7 +14,6 @@ import viewer from '../viewer'
 const naboo = util.naboo
 
 let errHandle
-let Gesture = util.Gesture
 let css = util.css
 let rect = util.rect
 
@@ -104,10 +103,7 @@ function createPopup (element, img) {
 
   let popup = document.createElement('div')
   css(popup, 'display', 'block')
-  // 阻止纵向滑动
-  new Gesture(popup, {
-    preventY: true
-  })
+
   popup.className = 'mip-img-popUp-wrapper'
   popup.setAttribute('data-name', 'mip-img-popUp-name')
 
@@ -181,12 +177,19 @@ function bindPopup (element, img) {
       // 找出当前视口下的图片
       let currentImg = getCurrentImg(popup.querySelector('.mip-carousel-wrapper'))
       popupImg.setAttribute('src', currentImg.getAttribute('src'))
+      let previousPos = getImgOffset(img)
+      // 获取弹出图片滑动的距离，根据前面的设定，top大于0就不是长图，小于0才是滑动的距离
+      let currentImgPos = getImgOffset(currentImg)
+      currentImgPos.top < 0 && (previousPos.top -= currentImgPos.top)
+      currentImgPos.left < 0 && (previousPos.left -= currentImgPos.left)
       css(popupImg, 'display', 'block')
       css(mipCarousel, 'display', 'none')
       naboo.animate(popupBg, {
         opacity: 0
       }).start()
-      naboo.animate(popupImg, getImgOffset(img)).start(function () {
+
+      naboo.animate(popup, {'display': 'none'})
+      naboo.animate(popupImg, previousPos).start(function () {
         css(img, 'visibility', 'visible')
         css(popup, 'display', 'none')
         popup.removeEventListener('click', imagePop, false)

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -510,7 +510,7 @@ describe('mip-carousel', function () {
     let div
     let wrapBox
     let eventClick = document.createEvent('MouseEvents')
-    this.timeout(1000)
+    this.timeout(1100)
 
     before(function () {
       div = document.createElement('div')
@@ -564,7 +564,7 @@ describe('mip-carousel', function () {
       setTimeout(function () {
         expect(wrapBox.style.transform).to.equal('translate3d(-300px, 0px, 0px)')
         done()
-      }, 330)
+      }, 430)
     })
 
     after(function () {

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -756,4 +756,69 @@ describe('mip-carousel', function () {
       document.body.removeChild(div)
     })
   })
+
+  describe('with lazy loading when mip-img is nested inside of other element', function () {
+    let div
+    this.timeout(2000)
+
+    before(function () {
+      div = document.createElement('div')
+      div.innerHTML = `
+        <mip-carousel
+          buttonController
+          width="100"
+          height="80"
+          index="1">
+          <block>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_01.jpg">
+          </mip-img>
+          </block>
+          <block>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_02.jpg">
+          </mip-img>
+          </block>
+          <block>
+          <mip-img
+            src="https://www.mipengine.org/static/img/P2x1_457e18b.jpg">
+          </mip-img>
+          </block>
+          <block>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_03.jpg">
+          </mip-img>
+          </block>
+        </mip-carousel>
+      `
+      let theFirst = document.body.firstChild
+      document.body.insertBefore(div, theFirst)
+    })
+    // 一定要挑一张图片上面的代码都没用到过，并且不能在第一张和最后一张
+    it('should not load picture samplePX', function (done) {
+      setTimeout(() => {
+        let mipImg = div.querySelectorAll('mip-img')[3]
+        let img = mipImg.querySelector('img')
+        expect(img.getAttribute('src')).to.not.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
+        done()
+      }, 500);
+    })
+    it('should load picture samplePX when swiping', function (done) {
+      let eventClick = document.createEvent('MouseEvents')
+      let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
+      eventClick.initEvent('click', true, true)
+      nextBtn.dispatchEvent(eventClick)
+
+      setTimeout(() => {
+        let img = div.querySelectorAll('mip-img')[3].querySelector('img')
+        expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
+        done()
+      }, 1500);
+    })
+
+    after(function () {
+      document.body.removeChild(div)
+    })
+
+  })
 })

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -727,8 +727,7 @@ describe('mip-carousel', function () {
           </mip-img>
         </mip-carousel>
       `
-      let theFirst = document.body.firstChild
-      document.body.insertBefore(div, theFirst)
+      document.body.insertBefore(div, document.body.firstChild)
     })
     // 一定要挑一张图片上面的代码都没用到过，并且不能在第一张和最后一张
     it('should not load picture samplePX', function (done) {
@@ -791,8 +790,7 @@ describe('mip-carousel', function () {
           </block>
         </mip-carousel>
       `
-      let theFirst = document.body.firstChild
-      document.body.insertBefore(div, theFirst)
+      document.body.insertBefore(div, document.body.firstChild)
     })
     // 一定要挑一张图片上面的代码都没用到过，并且不能在第一张和最后一张
     it('should not load picture samplePX', function (done) {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#89 
**1、升级点** （清晰准确的描述升级的功能点）

- 修复轮播图mip-img嵌套问题，即mip-img被嵌套在其他元素下再被添加到mip-carousel中
- 增加mip-img长图浏览效果，在examples/mip-img下可以看到长图浏览效果

**2、影响范围** （描述该需求上线会影响什么功能）

不会影响旧功能

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
