### PR TITLE
【免测】调整 mipDataPromises 的 resolve 时机

### DIFF
--- a/packages/mip/examples/page/data.html
+++ b/packages/mip/examples/page/data.html
@@ -145,7 +145,7 @@
             }
         </script>
     </mip-data>
-    <!-- <mip-data src="./data/testData.json"></mip-data> -->
+    <mip-data src="./data/testData.json"></mip-data>
     <mip-data>
         <script type="application/json">
             {

--- a/packages/mip/src/components/mip-bind/mip-data.js
+++ b/packages/mip/src/components/mip-bind/mip-data.js
@@ -56,20 +56,17 @@ class MipData extends CustomElement {
             MIP.$set(data)
             dropPromise(stuckPromise)
             stuckResolve()
-            stuckResolve = null
           })
         } else {
           console.error('Fetch request failed!')
           dropPromise(stuckPromise)
           stuckReject()
-          stuckReject = null
         }
       })
       .catch(e => {
         console.error(e)
         dropPromise(stuckPromise)
         stuckReject()
-        stuckReject = null
       })
   }
 

--- a/packages/mip/src/components/mip-bind/mip-data.js
+++ b/packages/mip/src/components/mip-bind/mip-data.js
@@ -27,7 +27,7 @@ class MipData extends CustomElement {
     /* istanbul ignore if */
     if (src) {
       this.getData(src)
-    } else if (ele) {``
+    } else if (ele) {
       let data = ele.textContent.toString()
       if (data) {
         MIP.$set(jsonParse(data))

--- a/packages/mip/src/components/mip-bind/mip-data.js
+++ b/packages/mip/src/components/mip-bind/mip-data.js
@@ -15,12 +15,8 @@ import jsonParse from '../../util/json-parse'
  * @param {Promise} target promise need to be removed
  */
 function dropPromise (target) {
-  for (let i = 0; i < mipDataPromises.length; i++) {
-    if (mipDataPromises[i] === target) {
-      mipDataPromises.splice(i, 1)
-      break
-    }
-  }
+  let index = mipDataPromises.indexOf(target)
+  mipDataPromises.splice(index, ~index ? 1 : 0)
 }
 
 class MipData extends CustomElement {
@@ -31,7 +27,7 @@ class MipData extends CustomElement {
     /* istanbul ignore if */
     if (src) {
       this.getData(src)
-    } else if (ele) {
+    } else if (ele) {``
       let data = ele.textContent.toString()
       if (data) {
         MIP.$set(jsonParse(data))
@@ -58,20 +54,20 @@ class MipData extends CustomElement {
         if (res.ok) {
           res.json().then(data => {
             MIP.$set(data)
-            dropPromise(mipDataPromises, stuckPromise)
+            dropPromise(stuckPromise)
             stuckResolve()
             stuckResolve = null
           })
         } else {
           console.error('Fetch request failed!')
-          dropPromise(mipDataPromises, stuckPromise)
+          dropPromise(stuckPromise)
           stuckReject()
           stuckReject = null
         }
       })
       .catch(e => {
         console.error(e)
-        dropPromise(mipDataPromises, stuckPromise)
+        dropPromise(stuckPromise)
         stuckReject()
         stuckReject = null
       })

--- a/packages/mip/src/components/mip-bind/mip-data.js
+++ b/packages/mip/src/components/mip-bind/mip-data.js
@@ -10,10 +10,15 @@
 import CustomElement from '../../custom-element'
 import jsonParse from '../../util/json-parse'
 
-function dropPromise (promiseArr, target) {
-  for (let i = 0; i < promiseArr.length; i++) {
-    if (promiseArr[i] === target) {
-      promiseArr.splice(i, 1)
+/*
+ * Remove promise from global mipDataPromises array
+ * @param {Promise} target promise need to be removed
+ */
+function dropPromise (target) {
+  for (let i = 0; i < mipDataPromises.length; i++) {
+    if (mipDataPromises[i] === target) {
+      mipDataPromises.splice(i, 1)
+      break
     }
   }
 }

--- a/packages/mip/src/components/mip-bind/mip-data.js
+++ b/packages/mip/src/components/mip-bind/mip-data.js
@@ -37,12 +37,7 @@ class MipData extends CustomElement {
   /*
    * get initial data asynchronouslly
    */
-  /* istanbul ignore next */
   getData (url) {
-    if (!url) {
-      return
-    }
-
     let stuckResolve
     let stuckReject
     // only resolve/reject when sth truly comes to a result
@@ -58,22 +53,22 @@ class MipData extends CustomElement {
         if (res.ok) {
           res.json().then(data => {
             MIP.$set(data)
+            dropPromise(mipDataPromises, stuckPromise)
             stuckResolve()
             stuckResolve = null
-            dropPromise(mipDataPromises, stuckPromise)
           })
         } else {
           console.error('Fetch request failed!')
+          dropPromise(mipDataPromises, stuckPromise)
           stuckReject()
           stuckReject = null
-          dropPromise(mipDataPromises, stuckPromise)
         }
       })
       .catch(e => {
         console.error(e)
+        dropPromise(mipDataPromises, stuckPromise)
         stuckReject()
         stuckReject = null
-        dropPromise(mipDataPromises, stuckPromise)
       })
   }
 

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -129,6 +129,94 @@ describe('mip-bind', function () {
     })
   })
 
+  describe('async mip-data', function () {
+    const json = (body, status) => {
+      const mockResponse = new window.Response(JSON.stringify(body), {
+        status: status,
+        headers: {
+          'Content-type': 'application/json'
+        }
+      })
+      return mockResponse
+    }
+
+    let fetchOrigin
+    before(function () {
+      fetchOrigin = window.fetch
+      sinon.stub(window, 'fetch')
+    })
+
+    after(function () {
+      window.fetch = fetchOrigin
+    })
+
+    it('should fetch async data', function (done) {
+      window.fetch.returns(
+        Promise.resolve(
+          json({tabs: [1, 2, 3]}, 200)
+        )
+      )
+
+      let mipData = new MipData()
+      let mipDataTag = document.createElement('mip-data')
+      mipDataTag.setAttribute('src', '/testData')
+      mipData.element = mipDataTag
+
+      mipData.build.bind(mipData)()
+      expect(window.mipDataPromises.length).to.equal(1)
+
+      Promise.all(window.mipDataPromises).then(function () {
+        expect(MIP.getData('tabs')).to.have.lengthOf(3)
+        expect(window.mipDataPromises.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should fetch async data 404', function (done) {
+      window.fetch.returns(
+        Promise.resolve(
+          json({status: 404}, 404)
+        )
+      )
+
+      let mipData = new MipData()
+      let mipDataTag = document.createElement('mip-data')
+      mipDataTag.setAttribute('src', '/testData')
+      mipData.element = mipDataTag
+
+      mipData.build.bind(mipData)()
+      expect(window.mipDataPromises.length).to.equal(1)
+
+      Promise.all(window.mipDataPromises).catch(function () {
+        expect(MIP.getData('status')).to.be.undefined
+        expect(window.mipDataPromises.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should fetch async data failed', function (done) {
+      window.fetch.returns(
+        Promise.reject(
+          json({status: 'failed'}, 200)
+        )
+      )
+
+      let mipData = new MipData()
+      let mipDataTag = document.createElement('mip-data')
+      mipDataTag.setAttribute('src', '/testData')
+      mipData.element = mipDataTag
+
+      mipData.build.bind(mipData)()
+      expect(window.mipDataPromises.length).to.equal(1)
+
+      Promise.all(window.mipDataPromises).catch(function () {
+        expect(MIP.getData('status')).to.be.undefined
+        expect(window.mipDataPromises.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
   describe('setData', function () {
     let ct = 0
     before(function () {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#181 

**1、升级点** （清晰准确的描述升级的功能点）
修复 bug：
mip-data 为异步数据提供了一个 window.mipDataPromises 的 promise 数组，用于检测是否异步设置数据成功
但目前 then 的触发发生在获取数据，而非设置数据
此次提交调整了该数组暴露的 promise，当数据加载成功时，需要真正获取到其中的 json 数据并设置成功后才会 resolve

**2、影响范围** （描述该需求上线会影响什么功能）
使用 <mip-data src=""> 标签异步获取数据
（暂时没发现线上 case，此 case 是一位同学迁移页面时发现，对方还未上线）

**3、自测 Checklist**
已新增 testcase 并跑过

**4、需要覆盖的场景和 Case**
- [] 是否覆盖了 sf 打开 MIP 页
- [] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
