### PR TITLE
Do not override render in Vue.customElement

### DIFF
--- a/packages/mip/src/vue-custom-element/index.js
+++ b/packages/mip/src/vue-custom-element/index.js
@@ -13,12 +13,6 @@ function install (Vue) {
   Vue.config.ignoredElements = [/^mip-/i]
 
   Vue.customElement = (tag, componentDefinition) => {
-    // 如果不设置 template 和 render 函数，默认设置 render 函数返回 null，避免 warning
-    let {template, render} = componentDefinition
-    if (!template && typeof render !== 'function') {
-      componentDefinition.render = () => null
-    }
-
     const props = getProps(componentDefinition)
     function callLifeCycle (ctx, name) {
       if (typeof componentDefinition[name] === 'function') {


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/184

**1、升级点** 去除当 vue 组件缺少 template 和 render 时提供的默认 render 函数

**2、影响范围** 基本无影响

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
