### PR TITLE
增加配置项，允许直接读取目标页面的配置以决定标题

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -69,6 +69,10 @@ class MipShell extends CustomElement {
     // If true, always load configures from `<mip-shell>` and overwrite shellConfig when opening new page
     this.alwaysReadConfigOnLoad = true
 
+    // If true, always use title in shell config of target page when switing page
+    // Otherwise, use title from last page (`data-title` and shell config and innerText)
+    this.alwaysUseTitleInShellConfig = false
+
     // If true, page switching transition contains header
     this.transitionContainsHeader = true
   }
@@ -269,8 +273,6 @@ class MipShell extends CustomElement {
 
     // Other parts
     this.renderOtherParts()
-
-    // window.MIP.viewer.fixedElement.init()
   }
 
   renderHeader (container) {
@@ -283,7 +285,7 @@ class MipShell extends CustomElement {
       borderColor,
       backgroundColor = '#ffffff'
     } = pageMeta.header
-    if (this.targetPageTitle) {
+    if (this.targetPageTitle && !this.alwaysUseTitleInShellConfig) {
       title = pageMeta.header.title = this.targetPageTitle
     }
     let showBackIcon = !pageMeta.view.isIndex

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -478,6 +478,9 @@ let viewer = {
       this.page.notifyRootPage({
         type: MESSAGE_PAGE_RESIZE
       })
+      if (event.target && typeof event.target.scrollIntoView === 'function') {
+        setTimeout(() => event.target.scrollIntoView(), 500)
+      }
     }, true)
     event.delegate(document, 'input', 'blur', event => {
       this.page.notifyRootPage({


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#187 
**1、升级点** （清晰准确的描述升级的功能点）
切换页面时，允许直接读取目标页面的配置并更新头部标题
**2、影响范围** （描述该需求上线会影响什么功能）
不影响线上的 case。需要子类增加配置才会生效。
**3、自测 Checklist**
和 @Espoir-L 在 BOS 环境上进行调试成功
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
