### PR TITLE
临时修复登录标题不对的问题

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -507,10 +507,10 @@ class MipShell extends CustomElement {
      * 3. <a mip-link></a> innerText (to.meta.defaultTitle)
      */
     let targetPageMeta = fn.extend(true, {}, this.findMetaByPageId(targetPageId))
-    this.targetPageTitle = to.meta.header
-      ? to.meta.header.title || targetPageMeta.header.title || to.meta.header.defaultTitle
-      : targetPageMeta.header.title
-    document.title = targetPageMeta.header.title = this.targetPageTitle
+    // this.targetPageTitle = to.meta.header
+    //   ? to.meta.header.title || targetPageMeta.header.title || to.meta.header.defaultTitle
+    //   : targetPageMeta.header.title
+    // document.title = targetPageMeta.header.title = this.targetPageTitle
 
     // Transition direction
     let isForward

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -286,9 +286,9 @@ class MipShell extends CustomElement {
       backgroundColor = '#ffffff'
     } = pageMeta.header
 
-    if (this.targetPageTitle && !this.alwaysUseTitleInShellConfig) {
-      title = pageMeta.header.title = this.targetPageTitle
-    }
+    // if (this.targetPageTitle && !this.alwaysUseTitleInShellConfig) {
+    //   title = pageMeta.header.title = this.targetPageTitle
+    // }
     let showBackIcon = !pageMeta.view.isIndex
 
     let headerHTML = `


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
临时修复预览机上的“登录”页面标题不对的问题
**1、升级点** （清晰准确的描述升级的功能点）
临时修复预览机上的“登录”页面标题不对的问题
**2、影响范围** （描述该需求上线会影响什么功能）
蓝犀牛跳转到登录页面时的标题
**3、自测 Checklist**
使用本地代理测试无误
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
