### PR TITLE
[提测] mip video支持play和pause方法

### DIFF
--- a/packages/mip/examples/builtin-components/mip-video.html
+++ b/packages/mip/examples/builtin-components/mip-video.html
@@ -1398,7 +1398,7 @@
     <span class="hljs-built_in">type</span>=<span class="hljs-string">"video/ogg"</span>&gt;
 &lt;/mip-video&gt;</code></pre>
 
-<h3>增加控制视屏的方法</h3>
+<h3>增加控制视频的方法</h3>
 <pre><code class="hljs lang-html">&lt;mip-video controls id="testvideo"
   layout="responsive" width="640" height="360"
   src="https://mip-doc.bj.bcebos.com/sample_video.mp4"&gt;

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -84,11 +84,11 @@ class MipVideo extends CustomElement {
     this.addEventAction('seekTo', (e, currentTime) => {
       this.videoElement.currentTime = currentTime
     })
-    this.addEventAction('play', (e) => {
+    this.addEventAction('play', () => {
       // renderPlayElsewhere 的 videoElement 是 div，没有 play
       this.videoElement.play && this.videoElement.play()
     })
-    this.addEventAction('pause', (e) => {
+    this.addEventAction('pause', () => {
       // renderPlayElsewhere 的 videoElement 是 div，没有 pause
       this.videoElement.pause && this.videoElement.pause()
     })

--- a/packages/mip/test/specs/components/mip-video.spec.js
+++ b/packages/mip/test/specs/components/mip-video.spec.js
@@ -133,7 +133,7 @@ describe('mip-video', function () {
 
       let videoEl = mipVideo.querySelector('video')
       videoEl.pause()
-      let event = document.creaźeEvent('MouseEvents')
+      let event = document.createEvent('MouseEvents')
       event.initEvent('click', true, true)
       button.dispatchEvent(event)
       expect(videoEl.paused).to.be.false


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#160 
**1、升级点** （清晰准确的描述升级的功能点）

mip-video支持play和pause方法

**2、影响范围** （描述该需求上线会影响什么功能）

新增功能，不会影响线上功能

**3、自测 Checklist**

examples/builtin-components下的mip-video.html中有个视频下方具有播放、暂停和跳转按钮。

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
