### PR TITLE
mip-carousel可以渲染常规元素

### DIFF
--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -43,7 +43,8 @@ function prerenderSetSrc (allMipImgs, index, num, arraySrc) {
         imgs[j].setAttribute('src', arraySrc[i])
       }
     } else {
-      allMipImgs[i].querySelector('mip-img').setAttribute('src', arraySrc[i])
+      let mipImg = allMipImgs[i].querySelector('mip-img')
+      mipImg && mipImg.setAttribute('src', arraySrc[i])
     }
   }
 }
@@ -55,11 +56,13 @@ function prerenderSetSrc (allMipImgs, index, num, arraySrc) {
  * @return {NodeList}           返回 childList
  */
 function changeSrc (childList, imgIndex, arraySrc) {
+  let src = arraySrc[imgIndex] || arraySrc[0]
   for (let i = 0; i < childList.length; i++) {
     if (childList[i].tagName === 'MIP-IMG') {
-      childList[i].setAttribute('src', arraySrc[imgIndex])
+      childList[i].setAttribute('src', src)
     } else {
-      childList[i].querySelector('mip-img').setAttribute('src', arraySrc[imgIndex])
+      let mipImg = childList[i].querySelector('mip-img')
+      mipImg && mipImg.setAttribute('src', src)
     }
   }
   return childList
@@ -78,6 +81,8 @@ function getAllMipImgSrc (childNodes) {
       let node = childNodes[i].querySelector('mip-img')
       if (node) {
         arr.push(node.getAttribute('src'))
+      } else {
+        arr.push('?mip_img_ori=1')
       }
     }
   }

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -817,6 +817,39 @@ describe('mip-carousel', function () {
     after(function () {
       document.body.removeChild(div)
     })
+  })
+  describe('with no mip-img in the first child of mip-carousel', function () {
+    let div
+    this.timeout(500)
 
+    before(function () {
+      div = document.createElement('div')
+      div.innerHTML = `
+        <mip-carousel
+          buttonController
+          width="100"
+          height="80"
+          index="1">
+          <div>1</div>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_01.jpg">
+          </mip-img>
+        </mip-carousel>
+      `
+      document.body.insertBefore(div, document.body.firstChild)
+    })
+
+    it('should load picture correctly', function (done) {
+
+      setTimeout(() => {
+        let img = div.querySelectorAll('mip-img')[1].querySelector('img')
+        expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
+        done()
+      }, 300);
+    })
+
+    after(function () {
+      document.body.removeChild(div)
+    })
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#214 
**1、升级点** （清晰准确的描述升级的功能点）

mip-carousel内部可以渲染常规元素

**2、影响范围** （描述该需求上线会影响什么功能）

修正bug

**3、自测 Checklist**

自测页面

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
