### PR TITLE
【免测】修复性能日志可能存在丢失情况

### DIFF
--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -144,15 +144,9 @@ util.dom.waitDocumentReady(() => {
   builtinComponents.register()
   performance.start(window._mipStartTiming)
 
-  // send performance data until the data collection is completed
+  // send performance data
   performance.on('update', timing => {
-    if (timing.MIPDomContentLoaded &&
-      timing.MIPStart &&
-      timing.MIPPageShow &&
-      timing.MIPFirstScreen
-    ) {
-      viewer.sendMessage('performance_update', timing)
-    }
+    viewer.sendMessage('performance_update', timing)
   })
 
   // Show page


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#221 

**1、升级点** （清晰准确的描述升级的功能点）
现有性能日志是等所有字段收集完成后才一起发送消息至外层，可能造成了部分日志丢失。
去掉此处的判断，每次有字段更新就发送，由外层进行日志收集。

**2、影响范围** （描述该需求上线会影响什么功能）
不影响功能，可能会影响性能日志量

**3、自测 Checklist**
SF 下日志发送成功，字段正确。

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百

