### PR TITLE
增加 mip-cli 对低版本 nodejs 兼容支持

### DIFF
--- a/packages/mip-cli/README.md
+++ b/packages/mip-cli/README.md
@@ -107,6 +107,8 @@ module.exports = {
 更多的配置选项可以参考 [Workbox 配置项](https://developers.google.com/web/tools/workbox/modules/workbox-build#generateswstring_mode)
 
 ## changelog
+- 1.2.6
+    1. 增加低于 7.6 版本的 node 支持
 - 1.2.5
     1. 更新 mip-component-validator 依赖版本，修复白名单 bug
 - 1.2.4

--- a/packages/mip-cli/bin/mip2
+++ b/packages/mip-cli/bin/mip2
@@ -1,18 +1,10 @@
 #!/usr/bin/env node
 
+require('../lib/utils/compat')
+
 const cli = require('../lib/cli')
-const semver = require('semver')
-const requiredNodeVersion = require('../package').engines.node
 const version = require('../package').version
 const checkVersion = require('../lib/check-version')
-
-if (!semver.satisfies(process.version, requiredNodeVersion)) {
-  console.log(cli.chalk.red(
-    `You are using Node ${process.version}, but this version of mip-cli ` +
-        `requires Node ${requiredNodeVersion}.\nPlease upgrade your Node version.`
-  ))
-  process.exit(1)
-}
 
 checkVersion().then(() => {
   cli.program

--- a/packages/mip-cli/bin/mip2-add
+++ b/packages/mip-cli/bin/mip2-add
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const add = require('../lib/add')
 const fs = require('fs')

--- a/packages/mip-cli/bin/mip2-addPlugin
+++ b/packages/mip-cli/bin/mip2-addPlugin
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const addPlugin = require('../lib/addPlugin')
 

--- a/packages/mip-cli/bin/mip2-build
+++ b/packages/mip-cli/bin/mip2-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const build = require('../lib/build')
 const validator = require('mip-component-validator')

--- a/packages/mip-cli/bin/mip2-dev
+++ b/packages/mip-cli/bin/mip2-dev
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const dev = require('../lib/dev')
 const validator = require('mip-component-validator')

--- a/packages/mip-cli/bin/mip2-init
+++ b/packages/mip-cli/bin/mip2-init
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const init = require('../lib/init')
 

--- a/packages/mip-cli/bin/mip2-sw
+++ b/packages/mip-cli/bin/mip2-sw
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const generateSw = require('../lib/sw')
 const fs = require('fs')

--- a/packages/mip-cli/bin/mip2-validate
+++ b/packages/mip-cli/bin/mip2-validate
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require('../lib/utils/compat')
 const cli = require('../lib/cli')
 const validate = require('../lib/validate')
 

--- a/packages/mip-cli/lib/utils/compat.js
+++ b/packages/mip-cli/lib/utils/compat.js
@@ -10,7 +10,7 @@ const {resolveModule} = require('./helper')
 if (!semver.satisfies(process.version, requiredNodeVersion)) {
   require('babel-register')({
     babelrc: false,
-    ignore: /node_modules\/(?!(mip-component-validator|koa))/,
+    ignore: /node_modules\/(?!(mip-component-validator|mip-cli-|koa))/,
     presets: [
       [
         require.resolve('babel-preset-env'),

--- a/packages/mip-cli/lib/utils/compat.js
+++ b/packages/mip-cli/lib/utils/compat.js
@@ -1,0 +1,43 @@
+/**
+ * @file compat.js
+ * @author clark-t (clarktanglei@163.com)
+ */
+
+const semver = require('semver')
+const requiredNodeVersion = require('../../package').engines.node
+const {resolveModule} = require('./helper')
+
+if (!semver.satisfies(process.version, requiredNodeVersion)) {
+  require('babel-register')({
+    babelrc: false,
+    ignore: /node_modules\/(?!(mip-component-validator|koa))/,
+    presets: [
+      [
+        require.resolve('babel-preset-env'),
+        {
+          // modules: false,
+          targets: {
+            node: 'current'
+          }
+        }
+      ],
+      require.resolve('babel-preset-stage-2')
+    ],
+    plugins: [
+      [
+        require.resolve('babel-plugin-transform-runtime'),
+        {
+          helpers: true,
+          polyfill: true,
+          regenerator: true,
+          moduleName: 'babel-runtime'
+        }
+      ]
+    ]
+  })
+  // console.log(cli.chalk.red(
+  //   `You are using Node ${process.version}, but this version of mip-cli ` +
+  //       `requires Node ${requiredNodeVersion}.\nPlease upgrade your Node version.`
+  // ))
+  // process.exit(1)
+}

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {
@@ -37,6 +37,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
+    "babel-register": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",
@@ -84,7 +85,7 @@
     "wrapper-webpack-plugin": "^2.0.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=7.6"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）
1. mip-cli 在低于 nodejs 7.6 以下的版本会自动调用 babel-register 做兼容处理

**2、影响范围** （描述该需求上线会影响什么功能）
1. mip-cli
**3、自测 Checklist**
- [x] mip2 dev
- [x] mip2 build
- [x] mip2 help
