### PR TITLE
【申请免测】修复 m-bind class 绑定问题

### DIFF
--- a/packages/mip/examples/page/class-style-binding.html
+++ b/packages/mip/examples/page/class-style-binding.html
@@ -64,6 +64,7 @@
     <mip-data>
         <script type="application/json">
             {
+              "iconClass": "grey lighten1 white--text",
               "loading": false,
               "danger": true,
               "loadingClass": "m-loading",
@@ -109,6 +110,8 @@
     <p>打开 Chrome-Elements 面板查看 class/style 变化情况</p>
 
     <!-- class example -->
+    <div m-bind:class="iconClass"></div>
+    <br />
     <div class="static" m-bind:class="{loading: loading, 'text-danger': danger }"></div>
     <br />
     <div m-bind:class="classObject"></div>

--- a/packages/mip/examples/page/class-style-binding.html
+++ b/packages/mip/examples/page/class-style-binding.html
@@ -64,7 +64,7 @@
     <mip-data>
         <script type="application/json">
             {
-              "iconClass": "grey lighten1 white--text",
+              "iconClass": "grey   lighten1 white--text",
               "loading": false,
               "danger": true,
               "loadingClass": "m-loading",

--- a/packages/mip/src/components/mip-bind/compile.js
+++ b/packages/mip/src/components/mip-bind/compile.js
@@ -210,8 +210,9 @@ class Compile {
     }
     let value
     try {
-      value = util.getter(this, exp).value
-      if (value !== '' && typeof value !== 'undefined') {
+      let res = util.getter(this, exp)
+      value = res.value
+      if (res.hadReadAll) {
         node.removeAttribute(attrName)
       }
     } catch (e) {

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -4,7 +4,6 @@
  */
 
 const regVar = /[\w\d-._]+/g
-const regTplLike = /`[^`]+`/g
 const regTpl = /(\${)([^}]+)(})/g
 const vendorNames = ['Webkit', 'Moz', 'ms']
 const RESERVED = ['Math', 'Number', 'String', 'Object', 'window']
@@ -223,8 +222,11 @@ export function namespaced (str) {
   let tpls = []
 
   // deal with template-like str first and save results
-  str = str.replace(regTplLike, (match) => {
-    match = match.replace(regTpl, tplMatch => namespaced(tplMatch))
+  str = str.replace(/(`[^`]+`|'[^']+')/g, match => {
+    // template need to recursively parse
+    if (match[0] === '`') {
+      match = match.replace(regTpl, tplMatch => namespaced(tplMatch))
+    }
     tpls.push(match)
     return `MIP-STR-TPL${tpls.length - 1}`
   })

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -5,7 +5,7 @@
 
 const regVar = /[\w\d-._]+/gmi
 const regTplLike = /`[^`]+`/gmi
-const regTpl = /(\${)([^}]+)(}.*)/gmi
+const regTpl = /(\${)([^}]+)(})/gmi
 const vendorNames = ['Webkit', 'Moz', 'ms']
 const RESERVED = ['Math', 'Number', 'String', 'Object', 'window']
 let emptyStyle
@@ -41,14 +41,16 @@ export function arrayToObject (arr) {
  */
 export function parseClass (classSpecs, oldSpecs = {}) {
   if (typeof classSpecs === 'string') {
+    // deal with multiple class-defined case
+    let classes = classSpecs.split(' ')
+    classSpecs = {}
+    classes.forEach(c => { classSpecs[c] = true })
     // reset old classes
     Object.keys(oldSpecs).forEach(k => {
       oldSpecs[k] = false
     })
     // set new classes
-    return Object.assign({}, oldSpecs, {
-      [classSpecs]: true
-    })
+    return Object.assign({}, oldSpecs, classSpecs)
   }
   // parse Object only
   if (isArray(classSpecs)) {
@@ -222,7 +224,7 @@ export function namespaced (str) {
 
   // deal with template-like str first and save results
   str = str.replace(regTplLike, (match) => {
-    match = match.replace(regTpl, '$1this.$2$3')
+    match = match.replace(regTpl, tplMatch => namespaced(tplMatch))
     tpls.push(match)
     return `MIP-STR-TPL${tpls.length - 1}`
   })

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -257,6 +257,7 @@ export function namespaced (str) {
     // to get the next not blankspace char of matched, to tell its nature
     let i = findChar(str, pointer, true)
     // not key of an obj or string warpped by quotes - vars
+    /* istanbul ignore else */
     if (i >= str.length || !/['`:]/.test(str[i])) {
       newExp += wrap(match[0])
     } else if (str[i] === ':') {

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -42,7 +42,7 @@ export function arrayToObject (arr) {
 export function parseClass (classSpecs, oldSpecs = {}) {
   if (typeof classSpecs === 'string') {
     // deal with multiple class-defined case
-    let classes = classSpecs.split(' ')
+    let classes = classSpecs.replace(/\s+/, ' ').split(' ')
     classSpecs = {}
     classes.forEach(c => { classSpecs[c] = true })
     // reset old classes

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -3,9 +3,9 @@
  * @author sfe
  */
 
-const regVar = /[\w\d-._]+/gmi
-const regTplLike = /`[^`]+`/gmi
-const regTpl = /(\${)([^}]+)(})/gmi
+const regVar = /[\w\d-._]+/g
+const regTplLike = /`[^`]+`/g
+const regTpl = /(\${)([^}]+)(})/g
 const vendorNames = ['Webkit', 'Moz', 'ms']
 const RESERVED = ['Math', 'Number', 'String', 'Object', 'window']
 let emptyStyle

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -42,9 +42,9 @@ export function arrayToObject (arr) {
 export function parseClass (classSpecs, oldSpecs = {}) {
   if (typeof classSpecs === 'string') {
     // deal with multiple class-defined case
-    let classes = classSpecs.replace(/\s+/, ' ').split(' ')
-    classSpecs = {}
-    classes.forEach(c => { classSpecs[c] = true })
+    classSpecs = classSpecs.trim().split(/\s+/).reduce((res, target) => {
+      return Object.assign(res, {[target]: true})
+    }, {})
     // reset old classes
     Object.keys(oldSpecs).forEach(k => {
       oldSpecs[k] = false

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -26,6 +26,7 @@ describe('mip-bind', function () {
   describe('init data', function () {
     let dumbDiv
     let eleFalse
+    let eleElse
 
     before(function () {
       // some normal bindings
@@ -33,6 +34,7 @@ describe('mip-bind', function () {
       eleBind = createEle('p', ['data-active', 'global.isGlobal'], 'bind')
       eleObject = createEle('p', ['data', 'global.data'], 'bind')
       eleFalse = createEle('p', ['editing', '!editing'], 'bind')
+      eleElse = createEle('a', ['href', `'./content.html?id=' + id + '&name=user#hash'`], 'bind')
 
       iframe = createEle('iframe', null)
 
@@ -60,7 +62,8 @@ describe('mip-bind', function () {
                   "province": "广东",
                   "city": "广州"
                 },
-                "list": ["a", "b", {"item": 2}]
+                "list": ["a", "b", {"item": 2}],
+                "id": 1
               }
             </script>
           </mip-data>
@@ -86,7 +89,8 @@ describe('mip-bind', function () {
           province: '广东',
           city: '广州'
         },
-        list: ['a', 'b', {item: 2}]
+        list: ['a', 'b', {item: 2}],
+        id: 1
       })
       expect(window.g).to.eql({
         global: {
@@ -102,6 +106,7 @@ describe('mip-bind', function () {
       expect(eleText.textContent).to.equal('广州')
       expect(eleBind.getAttribute('data-active')).to.equal('true')
       expect(eleObject.getAttribute('data')).to.equal('{"name":"level-1","age":1}')
+      expect(eleElse.getAttribute('href')).to.equal('./content.html?id=1&name=user#hash')
     })
 
     it('should bind data with delayed "false"', function () {
@@ -121,6 +126,7 @@ describe('mip-bind', function () {
     after(function () {
       document.body.removeChild(dumbDiv)
       document.body.removeChild(eleFalse)
+      document.body.removeChild(eleElse)
     })
   })
 

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -25,12 +25,14 @@ describe('mip-bind', function () {
 
   describe('init data', function () {
     let dumbDiv
+    let eleFalse
 
     before(function () {
       // some normal bindings
       eleText = createEle('p', ['loc.city'], 'text')
       eleBind = createEle('p', ['data-active', 'global.isGlobal'], 'bind')
       eleObject = createEle('p', ['data', 'global.data'], 'bind')
+      eleFalse = createEle('p', ['editing', '!editing'], 'bind')
 
       iframe = createEle('iframe', null)
 
@@ -102,8 +104,23 @@ describe('mip-bind', function () {
       expect(eleObject.getAttribute('data')).to.equal('{"name":"level-1","age":1}')
     })
 
+    it('should bind data with delayed "false"', function () {
+      MIP.$set({
+        editing: false
+      })
+
+      expect(eleFalse.getAttribute('editing')).to.equal('true')
+
+      MIP.setData({
+        editing: true
+      })
+
+      expect(eleFalse.getAttribute('editing')).to.equal('false')
+    })
+
     after(function () {
       document.body.removeChild(dumbDiv)
+      document.body.removeChild(eleFalse)
     })
   })
 
@@ -436,9 +453,11 @@ describe('mip-bind', function () {
       eles.push(createEle('p', ['style', '{fontSize: `${fontSize}px`}'], 'bind')) // eslint-disable-line
       eles.push(createEle('p', ['style', '[baseStyles, styleObject]'], 'bind'))
       eles.push(createEle('p', ['style', `{border: list[2].item + 'px'}`], 'bind'))
+      eles.push(createEle('p', ['class', 'iconClass'], 'bind'))
 
       MIP.$set({
         loading: false,
+        iconClass: 'grey lighten1 white--text',
         classObject: {
           'warning-class': true,
           'active-class': false,
@@ -469,6 +488,7 @@ describe('mip-bind', function () {
       expect(eles[2].getAttribute('class')).to.equal('class-text')
       expect(eles[3].getAttribute('class')).to.equal('m-error')
       expect(eles[4].getAttribute('class')).to.be.empty
+      expect(eles[11].getAttribute('class')).to.equal('grey lighten1 white--text')
 
       MIP.setData({
         tab: 'test'
@@ -492,13 +512,15 @@ describe('mip-bind', function () {
           'active-class': true,
           'loading-class': false
         },
-        classText: 'class-text-new'
+        classText: 'class-text-new',
+        iconClass: 'nothing'
       })
 
       expect(eles[0].getAttribute('class')).to.equal('default-class warning-class active-class')
       expect(eles[1].getAttribute('class')).to.equal('m-error loading')
       expect(eles[2].getAttribute('class')).to.equal('class-text-new')
       expect(eles[3].getAttribute('class')).to.equal('m-error m-loading')
+      expect(eles[11].getAttribute('class')).to.equal('nothing')
     })
 
     it('should update style', function () {

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -457,7 +457,7 @@ describe('mip-bind', function () {
 
       MIP.$set({
         loading: false,
-        iconClass: 'grey lighten1 white--text',
+        iconClass: 'grey    lighten1 white--text',
         classObject: {
           'warning-class': true,
           'active-class': false,


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#225 

**1、升级点** （清晰准确的描述升级的功能点）
- 单变量情况下，支持多个 class 的直接绑定
- 同时修复了一个如果 m-bind 绑定的数据再 mip-data 被延迟注册，将无法解析数据的问题
- 同时修复了 m-bind 绑定变量时叠加字符串解析失败的问题

**2、影响范围** （描述该需求上线会影响什么功能）
影响 issue 中提到的一个变量绑定了多个 class 的情况

**3、自测 Checklist**
已通过自测 case + 单测覆盖

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
