### PR TITLE
增加 autoprefixer 的配置扩大浏览器兼容范围

### DIFF
--- a/packages/mip/postcss.config.js
+++ b/packages/mip/postcss.config.js
@@ -1,6 +1,12 @@
 module.exports = {
   plugins: {
     // to edit target browsers: use "browserslist" field in package.json
-    'autoprefixer': {}
+    autoprefixer: {
+      browsers: [
+        '> 1%',
+        'last 2 versions',
+        'ie 9-10'
+      ]
+    }
   }
 }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#231 

**1、升级点** （清晰准确的描述升级的功能点）
1. 增加 postcss 的 autoprefixer 的配置，扩大 autoprefixer 的兼容范围
**2、影响范围** （描述该需求上线会影响什么功能）
1. 增加华为默认浏览器等低端浏览器对 flex 属性的兼容
**3、自测 Checklist**
- [x] css flex 属性编译后生成 display:-webkit-box
