### PR TITLE
支持 prefetch，避免重复请求

### DIFF
--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -52,7 +52,7 @@ function registerVueCustomElement (tag, component) {
 let mip = {}
 
 // Ensure loaded only once
-/* istanbul ignore if */
+/* istanbul ignore next */
 if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefined') {
   monitorInstall()
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#230 
**1、升级点** （清晰准确的描述升级的功能点）
增加 `window.MIP` 和 `window.MIP.version` 的判断，如果两者有一个为 `undefined`，则表示之前没有加载过 mip.js，走正常逻辑；否则表示之前加载过（或者预取状态），不执行初始化逻辑，相当于没有执行。
**2、影响范围** （描述该需求上线会影响什么功能）
不影响线上页面展示（因为线上不存在重复引用）
待预取上线之后，在预取状态下不应该打印 mip-shell 的相关警告
**3、自测 Checklist**
* 在 mip.js 的引用之前添加 `<script>window.MIP = {version: 'preload'}</script>`，页面不执行初始化
* 重复2次 mip.js 的引用，页面效果正常
* 页面不作任何改动，效果正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
