### PR TITLE
修复class绑定数组写法中变量指向内容为多个class的问题

### DIFF
--- a/packages/mip/examples/page/class-style-binding.html
+++ b/packages/mip/examples/page/class-style-binding.html
@@ -64,7 +64,11 @@
     <mip-data>
         <script type="application/json">
             {
-              "iconClass": "grey   lighten1 white--text",
+              "items": [
+                {
+                  "iconClass": "grey   lighten1 white--text"
+                }
+              ],
               "loading": false,
               "danger": true,
               "loadingClass": "m-loading",
@@ -110,7 +114,7 @@
     <p>打开 Chrome-Elements 面板查看 class/style 变化情况</p>
 
     <!-- class example -->
-    <div m-bind:class="iconClass"></div>
+    <div m-bind:class="[items[0].iconClass, errorClass]"></div>
     <br />
     <div class="static" m-bind:class="{loading: loading, 'text-danger': danger }"></div>
     <br />

--- a/packages/mip/examples/page/test.html
+++ b/packages/mip/examples/page/test.html
@@ -11,13 +11,18 @@
     </style>
 </head>
 <body>
-    <mip-iframe
-        layout="fixed-height"
-        src="./not-mip.html"
-        allowfullscreen
-        width="400"
-        height="300"
-        allowtransparency="true">
-    </mip-iframe>
+    <mip-data>
+        <script type="application/json">
+            {
+              "items": [
+                {
+                  "iconClass": "grey   lighten1 white--text"
+                }
+              ],
+              "errorClass": "m-error"
+            }
+        </script>
+    </mip-data>
+    <div m-bind:class="[items[0].iconClass, errorClass]"></div>
     <script src="../../dist/mip.js"></script>
 </body>

--- a/packages/mip/examples/page/test.html
+++ b/packages/mip/examples/page/test.html
@@ -11,18 +11,13 @@
     </style>
 </head>
 <body>
-    <mip-data>
-        <script type="application/json">
-            {
-              "items": [
-                {
-                  "iconClass": "grey   lighten1 white--text"
-                }
-              ],
-              "errorClass": "m-error"
-            }
-        </script>
-    </mip-data>
-    <div m-bind:class="[items[0].iconClass, errorClass]"></div>
+    <mip-iframe
+        layout="fixed-height"
+        src="./not-mip.html"
+        allowfullscreen
+        width="400"
+        height="300"
+        allowtransparency="true">
+    </mip-iframe>
     <script src="../../dist/mip.js"></script>
 </body>

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -81,7 +81,7 @@ export function parseStyle (styleSpecs) {
   // parse Object only
   if (isArray(styleSpecs)) {
     styleSpecs.forEach(styleObj => {
-      styles = Object.assign(styles, parseStyle(styleObj))
+      Object.assign(styles, parseStyle(styleObj))
     })
     return styles
   }

--- a/packages/mip/src/components/mip-bind/util.js
+++ b/packages/mip/src/components/mip-bind/util.js
@@ -26,8 +26,10 @@ export function arrayToObject (arr) {
   arr.forEach(item => {
     if (isObject(item)) {
       Object.assign(obj, item)
-    } else {
-      obj[item] = true
+    } else if (isArray(item)) {
+      Object.assign(obj, arrayToObject(item))
+    } else if (typeof item === 'string') {
+      Object.assign(obj, classSplit(item))
     }
   })
   return obj
@@ -39,15 +41,13 @@ export function arrayToObject (arr) {
  * @param {Object|Array} oldSpecs old classObject
  */
 export function parseClass (classSpecs, oldSpecs = {}) {
+  // reset old classes
+  Object.keys(oldSpecs).forEach(k => {
+    oldSpecs[k] = false
+  })
   if (typeof classSpecs === 'string') {
     // deal with multiple class-defined case
-    classSpecs = classSpecs.trim().split(/\s+/).reduce((res, target) => {
-      return Object.assign(res, {[target]: true})
-    }, {})
-    // reset old classes
-    Object.keys(oldSpecs).forEach(k => {
-      oldSpecs[k] = false
-    })
+    classSpecs = classSplit(classSpecs)
     // set new classes
     return Object.assign({}, oldSpecs, classSpecs)
   }
@@ -62,7 +62,13 @@ export function parseClass (classSpecs, oldSpecs = {}) {
       typeof classSpecs[k] !== 'undefined' && k && (newClasses[k] = classSpecs[k])
     })
   }
-  return newClasses
+  return Object.assign({}, oldSpecs, newClasses)
+}
+
+function classSplit (classSpecs) {
+  return classSpecs.trim().split(/\s+/).reduce((res, target) => {
+    return Object.assign(res, {[target]: true})
+  }, {})
 }
 
 /*

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -459,11 +459,13 @@ describe('mip-bind', function () {
       eles.push(createEle('p', ['style', '{fontSize: `${fontSize}px`}'], 'bind')) // eslint-disable-line
       eles.push(createEle('p', ['style', '[baseStyles, styleObject]'], 'bind'))
       eles.push(createEle('p', ['style', `{border: list[2].item + 'px'}`], 'bind'))
+      eles.push(createEle('p', ['class', 'iconClass'], 'bind'))
       eles.push(createEle('p', ['class', '[items[0].iconClass, errorClass]'], 'bind'))
       eles.push(createEle('p', ['class', '[classObject, [items[0].iconClass]]'], 'bind'))
 
       MIP.$set({
         loading: false,
+        iconClass: 'grey    lighten1 white--text',
         items: [{iconClass: 'grey    lighten1 white--text'}],
         classObject: {
           'warning-class': true,
@@ -495,8 +497,9 @@ describe('mip-bind', function () {
       expect(eles[2].getAttribute('class')).to.equal('class-text')
       expect(eles[3].getAttribute('class')).to.equal('m-error')
       expect(eles[4].getAttribute('class')).to.be.empty
-      expect(eles[11].getAttribute('class')).to.equal('grey lighten1 white--text m-error')
-      expect(eles[12].getAttribute('class')).to.equal('warning-class loading-class grey lighten1 white--text')
+      expect(eles[11].getAttribute('class')).to.equal('grey lighten1 white--text')
+      expect(eles[12].getAttribute('class')).to.equal('grey lighten1 white--text m-error')
+      expect(eles[13].getAttribute('class')).to.equal('warning-class loading-class grey lighten1 white--text')
 
       MIP.setData({
         tab: 'test'
@@ -521,6 +524,7 @@ describe('mip-bind', function () {
           'loading-class': false
         },
         classText: 'class-text-new',
+        iconClass: 'nothing',
         items: [{
           iconClass: 'nothing'
         }]
@@ -530,8 +534,9 @@ describe('mip-bind', function () {
       expect(eles[1].getAttribute('class')).to.equal('m-error loading')
       expect(eles[2].getAttribute('class')).to.equal('class-text-new')
       expect(eles[3].getAttribute('class')).to.equal('m-error m-loading')
-      expect(eles[11].getAttribute('class')).to.equal('m-error nothing')
-      expect(eles[12].getAttribute('class')).to.equal('warning-class active-class nothing')
+      expect(eles[11].getAttribute('class')).to.equal('nothing')
+      expect(eles[12].getAttribute('class')).to.equal('m-error nothing')
+      expect(eles[13].getAttribute('class')).to.equal('warning-class active-class nothing')
     })
 
     it('should update style', function () {

--- a/packages/mip/test/specs/components/mip-bind.spec.js
+++ b/packages/mip/test/specs/components/mip-bind.spec.js
@@ -459,11 +459,12 @@ describe('mip-bind', function () {
       eles.push(createEle('p', ['style', '{fontSize: `${fontSize}px`}'], 'bind')) // eslint-disable-line
       eles.push(createEle('p', ['style', '[baseStyles, styleObject]'], 'bind'))
       eles.push(createEle('p', ['style', `{border: list[2].item + 'px'}`], 'bind'))
-      eles.push(createEle('p', ['class', 'iconClass'], 'bind'))
+      eles.push(createEle('p', ['class', '[items[0].iconClass, errorClass]'], 'bind'))
+      eles.push(createEle('p', ['class', '[classObject, [items[0].iconClass]]'], 'bind'))
 
       MIP.$set({
         loading: false,
-        iconClass: 'grey    lighten1 white--text',
+        items: [{iconClass: 'grey    lighten1 white--text'}],
         classObject: {
           'warning-class': true,
           'active-class': false,
@@ -494,7 +495,8 @@ describe('mip-bind', function () {
       expect(eles[2].getAttribute('class')).to.equal('class-text')
       expect(eles[3].getAttribute('class')).to.equal('m-error')
       expect(eles[4].getAttribute('class')).to.be.empty
-      expect(eles[11].getAttribute('class')).to.equal('grey lighten1 white--text')
+      expect(eles[11].getAttribute('class')).to.equal('grey lighten1 white--text m-error')
+      expect(eles[12].getAttribute('class')).to.equal('warning-class loading-class grey lighten1 white--text')
 
       MIP.setData({
         tab: 'test'
@@ -519,14 +521,17 @@ describe('mip-bind', function () {
           'loading-class': false
         },
         classText: 'class-text-new',
-        iconClass: 'nothing'
+        items: [{
+          iconClass: 'nothing'
+        }]
       })
 
       expect(eles[0].getAttribute('class')).to.equal('default-class warning-class active-class')
       expect(eles[1].getAttribute('class')).to.equal('m-error loading')
       expect(eles[2].getAttribute('class')).to.equal('class-text-new')
       expect(eles[3].getAttribute('class')).to.equal('m-error m-loading')
-      expect(eles[11].getAttribute('class')).to.equal('nothing')
+      expect(eles[11].getAttribute('class')).to.equal('m-error nothing')
+      expect(eles[12].getAttribute('class')).to.equal('warning-class active-class nothing')
     })
 
     it('should update style', function () {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#225 
上次 pr 直接根据问题描述修复了基础变量绑定的多个class的问题，没有发现 issue 中还有其他写法的叠加场景

**1、升级点** （清晰准确的描述升级的功能点）
如 issue 中的写法, 数组写法绑定 class，其中数组内的变量绑定多个 class 的值，预期应该解析成功

**2、影响范围** （描述该需求上线会影响什么功能）
数组写法中，某个数组内 item 的变量绑定多个 class 的值

**3、自测 Checklist**
单测+case 自测

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
