### PR TITLE
修复标题过长的问题

### DIFF
--- a/packages/mip/src/styles/mip-page.less
+++ b/packages/mip/src/styles/mip-page.less
@@ -103,7 +103,7 @@ body.with-header {
 .mip-page-fade-header-wrapper {
   top: 0;
   left: 0;
-  right: 95px;
+  right: 47px;
   height: @shell-header-height;
   background: #fff;
   z-index: 20001 !important;
@@ -118,7 +118,7 @@ body.with-header {
     opacity: 1;
   }
   .mip-shell-header {
-    padding-left: 95px;
+    padding-left: 47px;
     padding-right: 0;
   }
 }

--- a/packages/mip/src/styles/mip-shell.less
+++ b/packages/mip/src/styles/mip-shell.less
@@ -75,9 +75,22 @@ mip-shell * {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      max-width: 100%;
+      max-width: 320px;
+
+      @media screen and (max-width: 375px) {
+        & {
+          max-width: 280px;
+        }
+      }
+
+      @media screen and (max-width: 320px) {
+        & {
+          max-width: 200px;
+        }
+      }
     }
   }
+
   .mip-shell-header-button-group {
     width: 87px;
     height: 30px;

--- a/packages/mip/src/styles/mip-shell.less
+++ b/packages/mip/src/styles/mip-shell.less
@@ -75,17 +75,17 @@ mip-shell * {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      max-width: 320px;
+      max-width: 250px;
 
       @media screen and (max-width: 375px) {
         & {
-          max-width: 280px;
+          max-width: 210px;
         }
       }
 
       @media screen and (max-width: 320px) {
         & {
-          max-width: 200px;
+          max-width: 130px;
         }
       }
     }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#235 
**1、升级点** （清晰准确的描述升级的功能点）
调整样式，避免标题过长样式错乱
**2、影响范围** （描述该需求上线会影响什么功能）
所有标题过长的页面
**3、自测 Checklist**
标题超长+SF情况下+配置了更多按钮（例如SF下的极速服务，目的是右上角出胶囊按钮增加宽度）时能够不遮挡
普通标题能够正常居中
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
