### PR TITLE
修复低端机无法触发事件

### DIFF
--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -337,7 +337,13 @@ export function whenTransitionEnds (el, type, cb) {
     el.removeEventListener(event, onEnd)
     cb()
   }
-  el.addEventListener(event, onEnd)
+
+  /* istanbul ignore next */
+  if (event) {
+    el.addEventListener(event, onEnd)
+  } else {
+    setTimeout(cb, 250)
+  }
 }
 
 /**

--- a/packages/mip/src/page/util/feature-detect.js
+++ b/packages/mip/src/page/util/feature-detect.js
@@ -17,19 +17,23 @@ export const supportsPassive = supportsPassiveFlag
 /**
  * transition & animation end event
  */
-let transitionEndEventName = 'transitionend'
-let animationEndEventName = 'animationend'
+let transitionEndEventName
+let animationEndEventName
 
 /* istanbul ignore next */
-if (window.ontransitionend === undefined &&
-    window.onwebkittransitionend !== undefined) {
+if (window.ontransitionend !== undefined) {
+  transitionEndEventName = 'transitionend'
+} else if (window.onwebkittransitionend !== undefined) {
   transitionEndEventName = 'webkitTransitionEnd'
 }
+
 /* istanbul ignore next */
-if (window.onanimationend === undefined &&
-    window.onwebkitanimationend !== undefined) {
+if (window.onanimationend !== undefined) {
+  animationEndEventName = 'animationend'
+} else if (window.onwebkitanimationend !== undefined) {
   animationEndEventName = 'webkitAnimationEnd'
 }
+
 export const transitionEndEvent = transitionEndEventName
 export const animationEndEvent = animationEndEventName
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#239 
**1、升级点** （清晰准确的描述升级的功能点）
在不支持动画相关事件的低端机上（ @zhuguoxi  有一个）能够正常切换页面
**2、影响范围** （描述该需求上线会影响什么功能）
低端机可以正常切换页面（目前因为不触发结束事件，loading不会消失）
其他线上效果不影响
**3、自测 Checklist**
发布到 BOS 上请 @zhuguoxi 测试
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
