### PR TITLE
fix: remove 'overflow-x:hidden' from html

### DIFF
--- a/packages/mip/src/styles/mip-base.less
+++ b/packages/mip/src/styles/mip-base.less
@@ -14,6 +14,7 @@ body {
   font: 14px Arial, Helvetica, sans-serif;
   box-sizing: border-box;
   -webkit-box-sizing: border-box;
+  overflow-x: hidden;
   &.with-header {
     padding-top: @shell-header-height;
   }
@@ -23,7 +24,6 @@ html,
 body {
   // height: 100% !important;
   overflow-y: auto;
-  overflow-x: hidden;
   position: relative;
   &.trigger-layout {
     height: 100% !important;


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
https://github.com/mipengine/mip2-extensions/issues/254

**1、升级点** （清晰准确的描述升级的功能点）
对 `<html>` 应用 `overflow-x:hidden` 会导致在页面高度不足的情况下（组件预览页面）无法显示菜单下拉内容。

**2、影响范围** （描述该需求上线会影响什么功能）
MIP 下拉菜单组件的[预览页面](https://www.mipengine.org/examples/mip-extensions/mip-nav-slidedown.html)

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
