### PR TITLE
【免测】修复滚动至 <a name=""> 锚点的行为

### DIFF
--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -65,9 +65,15 @@ class Page {
       return
     }
 
+    const hashContent = hash.slice(1)
+
     try {
-      const anchor = document.getElementById(hash.slice(1)) ||
-        document.getElementById(decodeURIComponent(hash.slice(1)))
+      /**
+       * @see {@link http://w3c.github.io/html/browsers.html#navigating-to-a-fragment-identifier}
+       */
+      const anchor = document.getElementById(hashContent) ||
+        document.getElementById(decodeURIComponent(hashContent)) ||
+        document.querySelector(`a[name="${hashContent}"]`)
 
       /* istanbul ignore next */
       if (anchor) {


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/248

**1、升级点**  支持滚动至 `<a name="">` 的锚点

**2、影响范围** 线上功能无影响

**3、自测 Checklist**

已于本地自测，主要用于官网文档，如
https://www.mipengine.org/v2/guide/mip-standard/mip-components-spec.html#4

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
