### PR TITLE
【免测】mip2 cli plugin 容错及输出信息格式修复

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - sh -e /etc/init.d/xvfb start
 - cd packages/mip
 install:
-- npm install
+- travis_retry npm install
 script:
 - npm run test:cover
 after_success:

--- a/packages/mip-cli/lib/addPlugin.js
+++ b/packages/mip-cli/lib/addPlugin.js
@@ -71,7 +71,7 @@ module.exports = async function addPlugin ({pluginName, options = {}, context = 
     const cmdPath = resolveCmdPath(cliPath, options.args)
     commandModule = require(cmdPath)
   } catch (e) {
-    cli.error(`Cannot find command module`)
+    cli.error('Cannot find command module', e)
     return
   }
 

--- a/packages/mip-cli/lib/check-version.js
+++ b/packages/mip-cli/lib/check-version.js
@@ -25,6 +25,7 @@ module.exports = function checkVersion () {
           console.log('  当前版本: ' + chalk.red(localVersion))
           console.log()
           console.log(' 您可以使用 npm update -g mip2 进行更新')
+          console.log()
         }
       }
       resolve()

--- a/packages/mip-cli/lib/server/index.js
+++ b/packages/mip-cli/lib/server/index.js
@@ -20,6 +20,8 @@ module.exports = class Server {
     Object.keys(options).forEach(key => {
       this[key] = options[key]
     })
+
+    this.router = new Router()
   }
 
   run () {
@@ -33,7 +35,6 @@ module.exports = class Server {
     let scriptMiddlewares = script(options)
     let htmlMiddlewares = html(options)
 
-    this.router = new Router()
     this.router
       .get(['/:id([^\\.]*)', '/:id([^\\.]+\\.html)'], ...htmlMiddlewares)
       .get('*', ...scriptMiddlewares, koaStatic(this.dir))

--- a/packages/mip-cli/lib/utils/plugin.js
+++ b/packages/mip-cli/lib/utils/plugin.js
@@ -64,7 +64,12 @@ exports.resolve = pkg => {
     return dir
   }
 
-  return fix(require.resolve(pkg))
+  // handle: plugin package without index.js as main entry
+  try {
+    return fix(require.resolve(pkg))
+  } catch (e) {
+    return path.resolve(__dirname, '..', '..', '..', pkg)
+  }
 }
 
 exports.resolveCommand = pkg => {


### PR DESCRIPTION
**相关 ISSUE:**  https://github.com/mipengine/mip2/issues/257

**1、升级点** （清晰准确的描述升级的功能点）

- mip2 cli plugin 兼容入口文件 index.js 被移除的情况
- mip2 cli plugin 模块查找失败时输出错误信息详情
- mip2 cli 版本提示格式调整
- mip2 travis 构建增加 retry 机制

**2、影响范围** （描述该需求上线会影响什么功能）

此次改动只涉及 mip2 cli ，对线上 mip 核心无影响


