### PR TITLE
【免测】修复 mip-sandbox@1.0.23 旧接口引用路径错误的 bug

### DIFF
--- a/packages/mip-sandbox/lib/sandbox.js
+++ b/packages/mip-sandbox/lib/sandbox.js
@@ -6,6 +6,6 @@
 
 // only use in browser env
 
-var sandboxGenerate = require('sandbox-generate')
+var sandboxGenerate = require('./sandbox-generate')
 
 module.exports = sandboxGenerate()

--- a/packages/mip-sandbox/package-lock.json
+++ b/packages/mip-sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mip-sandbox/package.json
+++ b/packages/mip-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "sandbox tools for MIP project",
   "main": "lib/sandbox.js",
   "scripts": {

--- a/packages/mip-sandbox/test/spec/sandbox.spec.js
+++ b/packages/mip-sandbox/test/spec/sandbox.spec.js
@@ -13,7 +13,7 @@ window.MIP = {
 
 // var chai = require('chai')
 // var expect = chai.expect
-// var sandbox = require('../../lib/sandbox')
+var oldSandbox = require('../../lib/sandbox')
 var generate = require('../../lib/sandbox-generate')
 
 // 假定 MIP 在 sandbox 后定义
@@ -60,5 +60,7 @@ describe('sandbox', function () {
   it('sandbox.watch', function () {
     expect(sandbox.MIP.watch()).to.be.equal('watch')
     expect(sandbox.strict.MIP.watch()).to.be.equal('watch')
+    expect(oldSandbox.MIP.watch()).to.be.equal('fall')
+    expect(oldSandbox.strict.MIP.watch()).to.be.equal('fall')
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#270 
**1、升级点** （清晰准确的描述升级的功能点）
1. 修复 mip-sandbox 旧接口引用路径错误的 bug
2. 增加 test case 覆盖旧接口

**2、影响范围** （描述该需求上线会影响什么功能）
1. 修复安装了 mip-sandbox@1.0.23 的 mip 核心编译产物报错的 bug

**3、自测 Checklist**
- [x] test case 全覆盖
