### PR TITLE
【免测】非 MIP 链接也支持 replace

### DIFF
--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -207,16 +207,13 @@ let viewer = {
     // Jump in top window directly
     // 1. Cross origin and NOT in SF
     // 2. Not MIP page and not only hash change
-    if ((this._isCrossOrigin(to) && window.MIP.standalone)) {
+    if ((this._isCrossOrigin(to) && window.MIP.standalone)
+      || (!isMipLink && !isHashInCurrentPage)) {
       if (replace) {
         window.top.location.replace(to)
       } else {
         window.top.location.href = to
       }
-      return
-    }
-    if (!isMipLink && !isHashInCurrentPage) {
-      window.top.location.href = to
       return
     }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#266 
**1、升级点** （清晰准确的描述升级的功能点）
使用 `viewer.open` 时如果目标链接是非 MIP 页面也可以使 `replace` 参数生效
**2、影响范围** （描述该需求上线会影响什么功能）
线上暂无这样的使用方式
**3、自测 Checklist**
和 @zhuguoxi 在 BOS 上测试过新的用法，一切正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
