### PR TITLE
首屏渲染增加异步方式

### DIFF
--- a/packages/mip/examples/page/components/mip-shell-novel.js
+++ b/packages/mip/examples/page/components/mip-shell-novel.js
@@ -15,7 +15,7 @@ class MipShellNovel extends window.MIP.builtinComponents.MipShell {
     this.catalog = shellConfig.catalog
   }
 
-  renderOtherParts () {
+  renderOtherPartsAsync () {
     this.$footerWrapper = document.createElement('mip-fixed')
     this.$footerWrapper.setAttribute('type', 'bottom')
     this.$footerWrapper.classList.add('mip-shell-footer-wrapper')

--- a/packages/mip/src/page/util/feature-detect.js
+++ b/packages/mip/src/page/util/feature-detect.js
@@ -33,9 +33,6 @@ if (window.onanimationend === undefined &&
 export const transitionEndEvent = transitionEndEventName
 export const animationEndEvent = animationEndEventName
 
-/**
- * raf
- */
 export const raf = window.requestAnimationFrame
   ? window.requestAnimationFrame.bind(window)
   : /* istanbul ignore next */setTimeout
@@ -43,3 +40,7 @@ export const raf = window.requestAnimationFrame
 export function isPortrait () {
   return window.innerHeight > window.innerWidth
 }
+
+export const idleCallback = window.requestIdleCallback
+  ? window.requestIdleCallback.bind(window)
+  : /* istanbul ignore next */setTimeout


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#280 
**1、升级点** （清晰准确的描述升级的功能点）
提供给继承 SHELL 的子类一种异步渲染的方式，提升首屏性能
**2、影响范围** （描述该需求上线会影响什么功能）
绑定事件成为了异步，需验证SHELL的按钮可以正常点击即可
**3、自测 Checklist**
右上角的更多按钮可以点击，左上角后退按钮可以点击
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
