### PR TITLE
🐛 添加mip2的图片提前一屏渲染

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -321,6 +321,20 @@ class MipImg extends CustomElement {
     }
   }
 
+  /**
+   * Check whether the element need to be rendered in advance
+   *
+   * @param {Object} elementRect element rect
+   * @param {Object} viewportRect viewport rect
+   *
+   * @return {boolean}
+   */
+  prerenderAllowed (elementRect, viewportRect) {
+    let threshold = viewportRect.height
+    return viewportRect.top + viewportRect.height + threshold >= elementRect.top &&
+      elementRect.top + elementRect.height + threshold >= viewportRect.top
+  }
+
   firstInviewCallback () {
     let ele = this.element
     let img = new Image()

--- a/packages/mip/src/register-element.js
+++ b/packages/mip/src/register-element.js
@@ -116,12 +116,15 @@ class BaseElement extends HTMLElement {
   }
 
   /**
-   * Check whether the element need to be rendered in advance.
+   * Check whether the element need to be rendered in advance
+   *
+   * @param {Object} elementRect element rect
+   * @param {Object} viewportRect viewport rect
    *
    * @return {boolean}
    */
-  prerenderAllowed () {
-    return this.customElement.prerenderAllowed()
+  prerenderAllowed (elementRect, viewportRect) {
+    return this.customElement.prerenderAllowed(elementRect, viewportRect)
   }
 
   /**


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#276 

**1、升级点** （清晰准确的描述升级的功能点）
图片提前一屏加载

**2、影响范围** （描述该需求上线会影响什么功能）
图片加载

**3、自测 Checklist**
chrome 模拟器 小说

IOS11.4  uc浏览器  手百

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
