### PR TITLE
将shell的一些后续操作移动到异步中，不卡住和SF的通讯

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -17,7 +17,7 @@ import fn from '../../util/fn'
 import platform from '../../util/platform'
 import event from '../../util/dom/event'
 import CustomElement from '../../custom-element'
-import {supportsPassive, isPortrait, idleCallback} from '../../page/util/feature-detect'
+import {supportsPassive, isPortrait} from '../../page/util/feature-detect'
 import {isSameRoute, getFullPath} from '../../page/util/route'
 import {
   createIFrame,
@@ -226,12 +226,11 @@ class MipShell extends CustomElement {
       page.pageMeta = this.currentPageMeta
       this.initShell()
       this.initRouter()
-      this.bindRootEvents()
-      // idleCallback(() => this.bindRootEvents())
+      // 绑定事件改为异步，不阻塞发送 mippageload 事件，下同
+      setTimeout(() => this.bindRootEvents(), 0)
     }
 
-    this.bindAllEvents()
-    // idleCallback(() => this.bindAllEvents())
+    setTimeout(() => this.bindAllEvents(), 0)
   }
 
   disconnectedCallback () {
@@ -272,22 +271,22 @@ class MipShell extends CustomElement {
     // Other sync parts
     this.renderOtherParts()
 
-    // Button wrapper & mask
-    let buttonGroup = this.currentPageMeta.header.buttonGroup
-    let {mask, buttonWrapper} = createMoreButtonWrapper(buttonGroup)
-    this.$buttonMask = mask
-    this.$buttonWrapper = buttonWrapper
+    setTimeout(() => {
+      // Button wrapper & mask
+      let buttonGroup = this.currentPageMeta.header.buttonGroup
+      let {mask, buttonWrapper} = createMoreButtonWrapper(buttonGroup)
+      this.$buttonMask = mask
+      this.$buttonWrapper = buttonWrapper
 
-    // Page mask
-    this.$pageMask = createPageMask()
+      // Page mask
+      this.$pageMask = createPageMask()
 
-    // Loading
-    this.$loading = createLoading(this.currentPageMeta)
+      // Loading
+      this.$loading = createLoading(this.currentPageMeta)
 
-    idleCallback(() => {
       // Other async parts
       this.renderOtherPartsAsync()
-    })
+    }, 0)
   }
 
   renderHeader (container) {
@@ -1156,8 +1155,6 @@ class MipShell extends CustomElement {
         height: this.currentViewportHeight
       }
     })
-    // 3.notify SF to set the iframe outside
-    // viewer.sendMessage('resizeContainer', {height: this.currentViewportHeight})
   }
 
   bindHeaderEvents () {

--- a/packages/mip/src/page/util/feature-detect.js
+++ b/packages/mip/src/page/util/feature-detect.js
@@ -40,7 +40,3 @@ export const raf = window.requestAnimationFrame
 export function isPortrait () {
   return window.innerHeight > window.innerWidth
 }
-
-export const idleCallback = window.requestIdleCallback
-  ? window.requestIdleCallback.bind(window)
-  : /* istanbul ignore next */setTimeout


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#280 
**1、升级点** （清晰准确的描述升级的功能点）
把 shell 中一些后续操作（例如绑定事件，创建首屏不需要的图层等）移动为异步操作，这样不影响和 SF 的通讯
**2、影响范围** （描述该需求上线会影响什么功能）
并没有添加新功能，只需保证和线上效果一致即可。
因为蓝犀牛（极速服务）和小说各自拥有自己的子类 shell，且模式不同（极速服务含有异步更新机制），因此对这两者的 shell 头部的三个按钮（后退，更多，关闭）需要重点测试
另外PC模拟的安卓系统打开小说能够正常展现页面（之前使用 idleCallback 碰上过白屏的情况）
**3、自测 Checklist**
蓝犀牛打开页面后更多和关闭可以点击，切换到地址页面可以正常后退到蓝犀牛首页
小说页面能够正常打开，能够切换页面，之后能够正常后退到搜索页。
小说的shell可以切换黑夜模式。

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
