### PR TITLE
bug fixed

### DIFF
--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -80,7 +80,7 @@ class MipVideo extends CustomElement {
     } else {
       // 再细分为 iframe 外层页面是否为百度搜索结果页，如果是就 renderPlayElsewhere，否则就 renderError
       // 考虑安全性，renderPlayElsewhere 可以在其他地方来打开视频，而renderError 则是直接显示X，不建议播放
-      if (window.parent.MIP && !window.parent.MIP.standalone) {
+      if (!window.MIP.standalone) {
         this.videoElement = this.renderPlayElsewhere()
       } else {
         this.videoElement = this.renderError()


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#297 

**1、升级点** （清晰准确的描述升级的功能点）
修复mip-video组件因跨域无法使用 

**2、影响范围** （描述该需求上线会影响什么功能）
百度搜索结果页打开后，有使用mip-video且页面是https，而video是http的页面

**3、自测 Checklist**
本地代理线上页面的mip.js 结果正确。但是手机自带浏览器会识别代理请求，所以无法自测，百度倒是可以。  
如果想要线下测试，严格意义来说需要https下的sf环境，目前没有办法。

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
