### PR TITLE
MIP 和 SF 消息格式统一

### DIFF
--- a/packages/mip/examples/performance/analyze.js
+++ b/packages/mip/examples/performance/analyze.js
@@ -6,7 +6,7 @@
 (function () {
   function processor (event) {
     var data = event.data
-    if (data.event === 'performance_update') {
+    if (data.event === 'performance-update') {
       // @TODO: MIP2 暂时有 bug
       if (data.data && data.data.data) {
         data = data.data.data

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -394,6 +394,9 @@ class MipShell extends CustomElement {
     viewer.onMessage('changeState', ({url}) => {
       router.replace(makeCacheUrl(url, 'url', true))
     })
+    viewer.onMessage('change-state', ({url}) => {
+      router.replace(makeCacheUrl(url, 'url', true))
+    })
 
     window.MIP_SHELL_OPTION = {
       allowTransition: false,

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -25,7 +25,6 @@ import {
   hideAllIFrames,
   createLoading,
   getLoading,
-  createFadeHeader,
   getFadeHeader,
   toggleFadeHeader,
   nextFrame,
@@ -46,7 +45,9 @@ import {
   MESSAGE_ROUTER_FORWARD,
   MESSAGE_CROSS_ORIGIN,
   MESSAGE_BROADCAST_EVENT,
-  MESSAGE_PAGE_RESIZE
+  MESSAGE_PAGE_RESIZE,
+  OUTER_MESSAGE_CHANGE_STATE,
+  OUTER_MESSAGE_CLOSE
 } from '../../page/const/index'
 import viewport from '../../viewport'
 import {customEmit} from '../../util/custom-event'
@@ -391,10 +392,11 @@ class MipShell extends CustomElement {
     this.router = router
 
     // Handle events emitted by SF
+    // DELETE ME
     viewer.onMessage('changeState', ({url}) => {
       router.replace(makeCacheUrl(url, 'url', true))
     })
-    viewer.onMessage('change-state', ({url}) => {
+    viewer.onMessage(OUTER_MESSAGE_CHANGE_STATE, ({url}) => {
       router.replace(makeCacheUrl(url, 'url', true))
     })
 
@@ -1229,7 +1231,7 @@ class MipShell extends CustomElement {
     } else if (buttonName === 'more') {
       this.toggleDropdown(true)
     } else if (buttonName === 'close') {
-      window.MIP.viewer.sendMessage('close')
+      window.MIP.viewer.sendMessage(OUTER_MESSAGE_CLOSE)
     } else if (buttonName === 'cancel') {
       this.toggleDropdown(false)
     }

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -182,7 +182,7 @@ class MipVideo extends CustomElement {
       /* istanbul ignore if */
       if (windowInIframe) {
         // mip_video_jump is written outside iframe
-        viewer.sendMessage('mip_video_jump', {
+        viewer.sendMessage('mip-video-jump', {
           poster: videoEl.dataset.videoPoster,
           src: urlSrc
         })

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -187,7 +187,6 @@ class MipVideo extends CustomElement {
           src: urlSrc
         }
         viewer.sendMessage('mip-video-jump', message)
-        viewer.sendMessage('video-jump', message)
       }
     }
     this.element.appendChild(videoEl)

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -7,6 +7,7 @@
 import util from '../util/index'
 import viewer from '../viewer'
 import CustomElement from '../custom-element'
+// import {OUTER_MESSAGE_CHANGE_STATE} from '../page/const/index'
 
 let windowInIframe = viewer.isIframed
 
@@ -182,11 +183,11 @@ class MipVideo extends CustomElement {
       /* istanbul ignore if */
       if (windowInIframe) {
         // mip_video_jump is written outside iframe
-        let message = {
+        // TODO 改成 OUTER_MESSAGE_VIDEO_JUMP
+        viewer.sendMessage('mip-video-jump', {
           poster: videoEl.dataset.videoPoster,
           src: urlSrc
-        }
-        viewer.sendMessage('mip-video-jump', message)
+        })
       }
     }
     this.element.appendChild(videoEl)

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -182,10 +182,12 @@ class MipVideo extends CustomElement {
       /* istanbul ignore if */
       if (windowInIframe) {
         // mip_video_jump is written outside iframe
-        viewer.sendMessage('mip-video-jump', {
+        let message = {
           poster: videoEl.dataset.videoPoster,
           src: urlSrc
-        })
+        }
+        viewer.sendMessage('mip-video-jump', message)
+        viewer.sendMessage('video-jump', message)
       }
     }
     this.element.appendChild(videoEl)

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -29,6 +29,7 @@ import performance from './performance'
 import templates from './util/templates'
 import mip1PolyfillInstall from './mip1-polyfill/index'
 import monitorInstall from './log/monitor'
+import {OUTER_MESSAGE_PERFORMANCE_UPDATE} from './page/const/index'
 
 let mip = {}
 
@@ -130,7 +131,7 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
     performance.start(window._mipStartTiming)
     // send performance data
     performance.on('update', timing => {
-      viewer.sendMessage('performance-update', timing)
+      viewer.sendMessage(OUTER_MESSAGE_PERFORMANCE_UPDATE, timing)
     })
 
     // Show page

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -130,7 +130,7 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
     performance.start(window._mipStartTiming)
     // send performance data
     performance.on('update', timing => {
-      viewer.sendMessage('performance_update', timing)
+      viewer.sendMessage('performance-update', timing)
     })
 
     // Show page

--- a/packages/mip/src/page/const/index.js
+++ b/packages/mip/src/page/const/index.js
@@ -52,3 +52,12 @@ export const BUILT_IN_COMPONENTS = [
 ]
 
 export const MAX_PAGE_NUM = 6
+
+// 和 SF 通讯的事件名称
+export const OUTER_MESSAGE_PERFORMANCE_UPDATE = 'performance-update'
+export const OUTER_MESSAGE_CHANGE_STATE = 'change-state'
+export const OUTER_MESSAGE_VIDEO_JUMP = 'video-jump'
+export const OUTER_MESSAGE_HISTORY_NAVIGATE = 'history-navigate'
+export const OUTER_MESSAGE_PUSH_STATE = 'push-state'
+export const OUTER_MESSAGE_REPLACE_STATE = 'replace-state'
+export const OUTER_MESSAGE_CLOSE = 'close'

--- a/packages/mip/src/page/router/index.js
+++ b/packages/mip/src/page/router/index.js
@@ -34,7 +34,7 @@ export default class Router {
       this.history.go(n)
     } else {
       // SF can help to navigate by 'changeState' when standalone = false
-      window.MIP.viewer.sendMessage('historyNavigate', {step: n})
+      window.MIP.viewer.sendMessage('history-navigate', {step: n})
     }
   }
 

--- a/packages/mip/src/page/router/index.js
+++ b/packages/mip/src/page/router/index.js
@@ -1,4 +1,5 @@
 import HTML5History from './history'
+import {OUTER_MESSAGE_HISTORY_NAVIGATE} from '../const/index'
 
 export default class Router {
   constructor (options = {}) {
@@ -34,7 +35,7 @@ export default class Router {
       this.history.go(n)
     } else {
       // SF can help to navigate by 'changeState' when standalone = false
-      window.MIP.viewer.sendMessage('history-navigate', {step: n})
+      window.MIP.viewer.sendMessage(OUTER_MESSAGE_HISTORY_NAVIGATE, {step: n})
     }
   }
 

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -17,7 +17,12 @@ import {supportsPassive} from './page/util/feature-detect'
 import {resolvePath} from './page/util/path'
 import viewport from './viewport'
 import Page from './page/index'
-import {CUSTOM_EVENT_SHOW_PAGE, CUSTOM_EVENT_HIDE_PAGE} from './page/const'
+import {
+  CUSTOM_EVENT_SHOW_PAGE,
+  CUSTOM_EVENT_HIDE_PAGE,
+  OUTER_MESSAGE_PUSH_STATE,
+  OUTER_MESSAGE_REPLACE_STATE
+} from './page/const'
 import Messager from './messager'
 import fixedElement from './fixed-element'
 import clientPrerender from './client-prerender'
@@ -211,7 +216,7 @@ let viewer = {
       url: parseCacheUrl(completeUrl),
       state
     }
-    this.sendMessage(replace ? 'replace-state' : 'push-state', pushMessage)
+    this.sendMessage(replace ? OUTER_MESSAGE_REPLACE_STATE : OUTER_MESSAGE_PUSH_STATE, pushMessage)
 
     // Create target route
     let targetRoute = {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -114,7 +114,7 @@ let viewer = {
    * 1. `pushState` when clicking a `<a mip-link>` element (called 'loadiframe')
    * 2. `mipscroll` when scrolling inside an iframe, try to let parent page hide its header.
    * 3. `mippageload` when current page loaded
-   * 4. `performance_update`
+   * 4. `performance-update`
    *
    * @param {string} eventName
    * @param {Object} data Message body
@@ -211,7 +211,7 @@ let viewer = {
       url: parseCacheUrl(completeUrl),
       state
     }
-    this.sendMessage(replace ? 'replaceState' : 'pushState', pushMessage)
+    this.sendMessage(replace ? 'replace-state' : 'push-state', pushMessage)
 
     // Create target route
     let targetRoute = {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -101,12 +101,10 @@ let viewer = {
 
     // notify SF hide its loading
     if (win.MIP.viewer.page.isRootPage) {
-      let message = {
+      this.sendMessage('mippageload', {
         time: Date.now(),
         title: encodeURIComponent(document.title)
-      }
-      this.sendMessage('mippageload', message)
-      this.sendMessage('page-load', message)
+      })
     }
   },
 

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -101,10 +101,12 @@ let viewer = {
 
     // notify SF hide its loading
     if (win.MIP.viewer.page.isRootPage) {
-      this.sendMessage('mippageload', {
+      let message = {
         time: Date.now(),
         title: encodeURIComponent(document.title)
-      })
+      }
+      this.sendMessage('mippageload', message)
+      this.sendMessage('page-load', message)
     }
   },
 

--- a/packages/mip/test/specs/page/router.spec.js
+++ b/packages/mip/test/specs/page/router.spec.js
@@ -126,13 +126,13 @@ describe('router', function () {
     spy = sinon.stub(window.MIP.viewer, 'sendMessage').returns(true)
 
     router.back()
-    expect(spy).to.have.been.calledWith('historyNavigate', {step: -1})
+    expect(spy).to.have.been.calledWith('history-navigate', {step: -1})
   })
 
   it('.forward will sendMessage to SF in SF mode', function () {
     spy = sinon.stub(window.MIP.viewer, 'sendMessage').returns(true)
 
     router.forward()
-    expect(spy).to.have.been.calledWith('historyNavigate', {step: 1})
+    expect(spy).to.have.been.calledWith('history-navigate', {step: 1})
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#215 
**1、升级点** （清晰准确的描述升级的功能点）
如 ISSUE 整理，MIP 和 SF 的通信的消息名称有各种形式（连写，驼峰，下划线等等）
为了后期的开放，需要进行统一。
**2、影响范围** （描述该需求上线会影响什么功能）
原则上和线上效果保持一致即可。
主要在于切换页面时的几个消息，SF目前改成新旧两种格式都接受。
**3、自测 Checklist**
使用线上环境代理本地脚本进行过自测。
蓝犀牛能够正常打开，能够进入地址选择页，能够后退，能够前进（浏览器上的），能够关闭页面
小说能够正常打开，能够切换到下一页，能够后退（浏览器上和 shell 上的）
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
