### PR TITLE
修改 mip-img 的大图浏览效果，and lint view.js

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -38,21 +38,39 @@ let imgRatio = {
   other: 1
 }
 
+/**
+ * 获取弹出图片的位置
+ * 2018-10-11 增加：由于浏览效果改为了 contain 效果，所以 carousel 内部采用 div 的 background-image 来显示图片。
+ * 所以 carousel 必须设置的高宽都固定成了视口的高宽。保留这个函数只是为了动画效果。
+ *
+ * @param  {number} imgWidth  原始图片的宽度
+ * @param  {number} imgHeight 原始图片的高度
+ * @return {Object}           包含定位信息的对象
+ */
 function getPopupImgPos (imgWidth, imgHeight) {
-  let width = viewport.getWidth()
-  let height = Math.round(width * imgHeight / imgWidth)
+  let viewportW = viewport.getWidth()
   let viewportH = viewport.getHeight()
-  let top = viewportH > height
-    ? (viewportH - height) / 2
-    : 0
+  let top = 0
+  let left = 0
+  if (viewportH / viewportW < imgHeight / imgWidth) {
+    let width = Math.round(viewportH * imgWidth / imgHeight)
+    left = (viewportW - width) / 2
+    return {
+      height: viewportH,
+      width: width,
+      left: left,
+      top: 0
+    }
+  }
+  let height = Math.round(viewportW * imgHeight / imgWidth)
+  top = (viewportH - height) / 2
   return {
-    width: width,
     height: height,
+    width: viewportW,
     left: 0,
     top: top
   }
 }
-
 /**
  * 从mip-img属性列表里获取属性
  *
@@ -71,7 +89,12 @@ function getAttributeSet (attributes) {
   })
   return attrs
 }
-
+/**
+ * 获取图片的offset
+ *
+ * @param  {HTNMLElement} img img
+ * @return {Object}     一个包含offset信息的对象
+ */
 function getImgOffset (img) {
   let imgOffset = rect.getElementOffset(img)
   return imgOffset
@@ -88,14 +111,22 @@ function getImgsSrc () {
  * @param  {HTMLElement} carouselWrapper carouselWrapper
  * @return {HTMLElement} img
  */
-function getCurrentImg (carouselWrapper) {
+function getCurrentImg (carouselWrapper, mipCarousel) {
   // 例如：'translate3d(-90px,0,0)'
   let str = carouselWrapper.style.webkitTransform
   let result = /translate3d\(-?([0-9]+)/i.exec(str)
-  let number = parseInt(result[1]) / viewport.getWidth()
-  return carouselWrapper.querySelectorAll('mip-img')[number]
+  // 原先宽度是视口宽度，现在需要的是图片本身宽度。最后还是一样的。。。
+  let width = mipCarousel.getAttribute('width')
+  let number = parseInt(result[1], 10) / width
+  return carouselWrapper.querySelectorAll('.div-mip-img')[number]
 }
-// 创建弹层 dom
+/**
+ * 创建图片弹层
+ *
+ * @param  {HTMLElement} element mip-img组件元素
+ * @param  {HTMLElment} img     mip-img元素包裹的img
+ * @return {HTMLElment}         图片弹层的div
+ */
 function createPopup (element, img) {
   // 获取图片数组
   let imgsSrcArray = getImgsSrc()
@@ -111,25 +142,32 @@ function createPopup (element, img) {
   let popUpBg = document.createElement('div')
   // 创建多图预览 wrapper
   let carouselWrapper = document.createElement('div')
-  // 计算 wrapper 窗口大小
-  let imgOffset = getImgOffset(img)
-  let popupImgPos = getPopupImgPos(imgOffset.width, imgOffset.height)
-  popupImgPos.top = 0
+  // 计算 wrapper 窗口大小，变为视口大小
   css(carouselWrapper, {
-    'position': 'absolute'
+    'position': 'absolute',
+    'width': viewport.getWidth(),
+    'height': viewport.getHeight(),
+    'left': 0,
+    'top': 0
   })
-  css(carouselWrapper, popupImgPos)
   // 创建 mip-carousel
   let carousel = document.createElement('mip-carousel')
 
-  carousel.setAttribute('layout', 'height-fixed')
+  carousel.setAttribute('layout', 'responsive')
   carousel.setAttribute('index', index + 1)
-  carousel.setAttribute('width', popupImgPos.width)
-  carousel.setAttribute('height', popupImgPos.height)
+  carousel.setAttribute('width', viewport.getWidth())
+  carousel.setAttribute('height', viewport.getHeight())
 
   for (let i = 0; i < imgsSrcArray.length; i++) {
-    let mipImg = document.createElement('mip-img')
-    mipImg.setAttribute('src', imgsSrcArray[i])
+    let mipImg = document.createElement('div')
+    mipImg.className = 'div-mip-img'
+    mipImg.setAttribute('data-src', imgsSrcArray[i])
+    css(mipImg, {
+      'background-image': `url(${imgsSrcArray[i]})`,
+      'background-repeat': 'no-repeat',
+      'background-size': 'contain',
+      'background-position': 'center'
+    })
     carousel.appendChild(mipImg)
   }
   popUpBg.className = 'mip-img-popUp-bg'
@@ -141,7 +179,13 @@ function createPopup (element, img) {
 
   return popup
 }
-
+/**
+ * 将图片与弹层绑定
+ *
+ * @param  {HTMLElement} element mip-img
+ * @param  {HTMLElement} img     mip-img下的img
+ * @return {void}         无
+ */
 function bindPopup (element, img) {
   // 图片点击时展现图片
   img.addEventListener('click', function (event) {
@@ -175,13 +219,14 @@ function bindPopup (element, img) {
         extraClass: 'black'
       })
       // 找出当前视口下的图片
-      let currentImg = getCurrentImg(popup.querySelector('.mip-carousel-wrapper'))
-      popupImg.setAttribute('src', currentImg.getAttribute('src'))
+      let currentImg = getCurrentImg(popup.querySelector('.mip-carousel-wrapper'), mipCarousel)
+      popupImg.setAttribute('src', currentImg.getAttribute('data-src'))
       let previousPos = getImgOffset(img)
-      // 获取弹出图片滑动的距离，根据前面的设定，top大于0就不是长图，小于0才是滑动的距离
+      // 获取弹出图片滑动的距离，根据前面的设定，top大于0就不是长图，小于0才是滑动的距离。
       let currentImgPos = getImgOffset(currentImg)
       currentImgPos.top < 0 && (previousPos.top -= currentImgPos.top)
       currentImgPos.left < 0 && (previousPos.left -= currentImgPos.left)
+      css(popupImg, getPopupImgPos(popupImg.naturalWidth, popupImg.naturalHeight))
       css(popupImg, 'display', 'block')
       css(mipCarousel, 'display', 'none')
       naboo.animate(popupBg, {
@@ -200,16 +245,15 @@ function bindPopup (element, img) {
     let onResize = function () {
       imgOffset = getImgOffset(img)
       css(popupImg, imgOffset)
-      naboo.animate(popupImg, getPopupImgPos(imgOffset.width, imgOffset.height)).start()
+      naboo.animate(popupImg, getPopupImgPos(img.naturalWidth, img.naturalHeight)).start()
     }
     window.addEventListener('resize', onResize)
 
     css(popupImg, imgOffset)
-    css(mipCarousel, getPopupImgPos(imgOffset.width, imgOffset.height))
     css(mipCarousel, 'display', 'none')
     css(popupBg, 'opacity', 1)
 
-    naboo.animate(popupImg, getPopupImgPos(imgOffset.width, imgOffset.height)).start(() => {
+    naboo.animate(popupImg, getPopupImgPos(img.naturalWidth, img.naturalHeight)).start(() => {
       css(popupImg, 'display', 'none')
       css(mipCarousel, 'display', 'block')
     })

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -57,18 +57,18 @@ function getPopupImgPos (imgWidth, imgHeight) {
     left = (viewportW - width) / 2
     return {
       height: viewportH,
-      width: width,
-      left: left,
+      width,
+      left,
       top: 0
     }
   }
   let height = Math.round(viewportW * imgHeight / imgWidth)
   top = (viewportH - height) / 2
   return {
-    height: height,
+    height,
     width: viewportW,
     left: 0,
-    top: top
+    top
   }
 }
 /**
@@ -109,6 +109,7 @@ function getImgsSrc () {
 /**
  * 找出当前视口下的图片
  * @param  {HTMLElement} carouselWrapper carouselWrapper
+ * @param  {HTMLElement} mipCarousel mipCarousel
  * @return {HTMLElement} img
  */
 function getCurrentImg (carouselWrapper, mipCarousel) {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -53,7 +53,7 @@ let viewer = {
      * @type {Object}
      */
     const messager = clientPrerender.messager
-    this.messager =  messager ? messager : new Messager()
+    this.messager = messager || new Messager()
 
     /**
      * The gesture of document.Used by the event-action of Viewer.
@@ -198,8 +198,8 @@ let viewer = {
     // Jump in top window directly
     // 1. Cross origin and NOT in SF
     // 2. Not MIP page and not only hash change
-    if ((this._isCrossOrigin(to) && window.MIP.standalone)
-      || (!isMipLink && !isHashInCurrentPage)) {
+    if ((this._isCrossOrigin(to) && window.MIP.standalone) ||
+      (!isMipLink && !isHashInCurrentPage)) {
       if (replace) {
         window.top.location.replace(to)
       } else {
@@ -433,7 +433,6 @@ let viewer = {
       this.viewportScroll()
       this.fixSoftKeyboard()
     }
-
   },
 
   /**
@@ -471,15 +470,15 @@ let viewer = {
         let tagName = element.tagName.toLowerCase()
 
         if (element && (tagName === 'input' || tagName === 'textarea')) {
-            setTimeout(() => {
-              if (typeof element.scrollIntoViewIfNeeded === 'function') {
-                element.scrollIntoViewIfNeeded()
-              } else if (typeof element.scrollIntoView === 'function') {
-                element.scrollIntoView()
-                document.body.scrollTop -= 44
-              }
-            }, 250)
-          }
+          setTimeout(() => {
+            if (typeof element.scrollIntoViewIfNeeded === 'function') {
+              element.scrollIntoViewIfNeeded()
+            } else if (typeof element.scrollIntoView === 'function') {
+              element.scrollIntoView()
+              document.body.scrollTop -= 44
+            }
+          }, 250)
+        }
       })
     }
   },

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -270,6 +270,41 @@ describe('mip-img', function () {
     })
   })
 
+  describe('with special image popuping', function () {
+    // 针对长图的大图浏览代码测试，其实只需要设置一张特殊的图即可。
+    let mipImg
+    before(function () {
+      mipImg = document.createElement('mip-img')
+      mipImg.setAttribute('width', '100px')
+      mipImg.setAttribute('height', '100px')
+      mipImg.setAttribute('src', 'https://boscdn.baidu.com/v1/assets/mip/mip2-component-lifecycle.png')
+      mipImg.setAttribute('popup', 'true')
+      mipImg.setAttribute('alt', 'baidu mip img')
+      let theFirst = document.body.firstChild
+      document.body.insertBefore(mipImg, theFirst)
+    })
+
+    it('should popup', function () {
+      let img = mipImg.querySelector('img')
+      let event = document.createEvent('MouseEvents')
+      event.initEvent('click', true, true)
+      img.dispatchEvent(event)
+
+      let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
+      mipPopWrap.dispatchEvent(event)
+
+      expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
+      expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
+      expect(mipPopWrap.tagName).to.equal('DIV')
+      expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
+      expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
+      expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
+    })
+
+    after(function () {
+      document.body.removeChild(mipImg)
+    })
+  })
   after(function () {
     document.body.removeChild(document.querySelector('.mip-img-popUp-wrapper'))
   })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#304 

**1、升级点** （清晰准确的描述升级的功能点）
mip-img 在大图浏览的效果改为 `backgroud-size: contain` ，即高为 100%或 宽100%，二者必然满足一项。

**2、影响范围** （描述该需求上线会影响什么功能）
有使用 mip-img 的 popup 属性的页面

**3、自测 Checklist**
可直接看例子的效果 http://localhost:8080/examples/builtin-components/mip-img.html

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
