### PR TITLE
去除 index.js export mip

### DIFF
--- a/packages/mip/build/config.js
+++ b/packages/mip/build/config.js
@@ -66,7 +66,7 @@ function genConfig (name) {
       format: opts.format,
       banner: opts.banner,
       intro: opts.intro,
-      name: opts.moduleName || 'MIP'
+      // name: opts.moduleName || 'MIP'
     }
   }
 

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -142,5 +142,3 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
     storage.delExceedCookie()
   })
 }
-
-export default mip

--- a/packages/mip/test/specs/index.spec.js
+++ b/packages/mip/test/specs/index.spec.js
@@ -5,10 +5,11 @@
 
 /* globals describe, it, expect, sinon */
 
-import MIP from 'src/index'
+import 'src/index'
 
 describe('MIP', function () {
   let prefix = 'mip-index-'
+  let MIP = window.MIP
 
   it('should expose MIP.registerVueCustomElement', function () {
     let name = prefix + 'vue-element'

--- a/packages/mip/test/specs/resources.spec.js
+++ b/packages/mip/test/specs/resources.spec.js
@@ -8,13 +8,14 @@
 import sinon from 'sinon'
 import resources from 'src/resources'
 import viewport from 'src/viewport'
-import MIP from 'src/index'
+import 'src/index'
 import rect from 'src/util/dom/rect'
 import MIPTestCustomElement from '../util/custom-element'
 
 describe('resources', function () {
   let Resources = resources.constructor
   let app
+  let MIP = window.MIP
 
   beforeEach(function () {
     app = new Resources()


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
 #312

**1、升级点** （清晰准确的描述升级的功能点）
去除 export MIP，避免在 waitDocumentReady 之前 MIP 直接挂载到window下

**2、影响范围** （描述该需求上线会影响什么功能）
影响 js 提到head 使用 async 属性

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
