### PR TITLE
feat: mip iframe 增加 https 检查、ascii 转码、src 和 srcdoc 属性监听

### DIFF
--- a/docs/extensions/builtin/mip-iframe.md
+++ b/docs/extensions/builtin/mip-iframe.md
@@ -7,7 +7,7 @@
 标题|内容
 ----|----
 类型|通用
-支持布局|responsive, fixed-height, fixed
+支持布局|responsive, fixed-height, fixed, fill, container
 所需脚本|无
 
 ## 示例
@@ -59,63 +59,88 @@
 </mip-iframe>
 ```
 
+### 加 `encode` 转码中文字符
+
+```html
+<mip-iframe
+    allowfullscreen
+    srcdoc="
+        <div>你好</div>
+        "
+    encode
+    width="400"
+    height="300"
+    sandbox=""
+    allowtransparency="true">
+</mip-iframe>
+```
+
 ## 属性
 
 ### src
 
-说明：与原生 `<iframe>` 的 `src` 属性作用一致  
-必选项：是  
-类型：URL  
-单位：无  
-取值：必须要使用 HTTPS 地址  
+说明：与原生 `<iframe>` 的 `src` 属性作用一致
+必选项：是
+类型：URL
+单位：无
+取值：必须要使用 HTTPS 地址
 默认值：无
 
 ### width
 
 说明：宽度，不是实际宽度，与高度属性配合来设置图片比例，详见[组件布局](../../guide/component/layout.md)
-必选项：是  
-类型：数字  
-单位：无  
+必选项：是
+类型：数字
+单位：无
 默认值：无
 
 ### height
 
 说明：高度，不是实际高度，与宽度属性配合来设置图片比例，详见[组件布局](../../guide/component/layout.md)
-必选项：是  
-类型：数字  
-单位：无  
+必选项：是
+类型：数字
+单位：无
 默认值：无
 
 ### allowfullscreen
 
-说明：与原生 `<iframe>` 的 `allowfullscreen` 属性作用一致  
-必选项：否  
-取值：空  
+说明：与原生 `<iframe>` 的 `allowfullscreen` 属性作用一致
+必选项：否
+取值：空
 默认值：无
 
 ### srcdoc
 
-说明：与原生 `<iframe>` 的 `srcdoc` 属性作用一致	  
-必选项：否  
-类型：HTML_code  
-单位：无  
-取值：要显示在 `<iframe>` 中的 HTML 内容。必需是有效的 HTML 语法  
+说明：与原生 `<iframe>` 的 `srcdoc` 属性作用一致
+必选项：否
+类型：HTML_code
+单位：无
+取值：要显示在 `<iframe>` 中的 HTML 内容。必需是有效的 HTML 语法
 默认值：无
+
+### encode
+
+说明：是否对 `srcdoc` 的内容做 unicode 转 ascii，如果 srcdoc 存在中文等未做 ascii 转码的字符，需要设置该属性
+必选项：否
+类型：字符串
+单位：无
+取值："", true, false
+默认值：false
 
 ### sandbox
 
-说明：与原生 `<iframe>` 的 `sandbox` 属性作用一致  
-必选项：否  
-类型：字符串  	
-单位：无  
-取值："", `allow-same-origin`, `allow-top-navigation`, `allow-forms`, `allow-script`  
+说明：与原生 `<iframe>` 的 `sandbox` 属性作用一致
+必选项：否
+类型：字符串
+单位：无
+取值："", `allow-same-origin`, `allow-top-navigation`, `allow-forms`, `allow-script`
 默认值：无
 
 ### allowtransparency
 
-说明：与原生 `<iframe>` 的 `allowtransparency` 属性作用一致  
-必选项：否  
-类型：字符串  	
-单位：无  
-取值："", true, false  
+说明：与原生 `<iframe>` 的 `allowtransparency` 属性作用一致
+必选项：否
+类型：字符串
+单位：无
+取值："", true, false
 默认值：无

--- a/packages/mip/examples/builtin-components/mip-iframe.html
+++ b/packages/mip/examples/builtin-components/mip-iframe.html
@@ -97,6 +97,32 @@
   allowtransparency="true">
 </mip-iframe>
 
+<h2>加带中文的 srcdoc</h2>
+
+<pre class="code">&lt;mip-iframe
+  allowfullscreen
+  srcdoc="
+    &lt;div&gt;你好&lt;/div&gt;
+    "
+  encode="true"
+  width="400"
+  height="300"
+  sandbox=""
+  allowtransparency="true"&gt;
+&lt;/mip-iframe&gt;</pre>
+
+<mip-iframe
+  allowfullscreen
+  srcdoc="
+    <div>你好</div>
+    "
+  encode
+  width="400"
+  height="300"
+  sandbox=""
+  allowtransparency="true">
+</mip-iframe>
+
 
 
 </body>

--- a/packages/mip/src/components/mip-iframe.js
+++ b/packages/mip/src/components/mip-iframe.js
@@ -16,13 +16,20 @@ let attrList = ['allowfullscreen', 'allowtransparency', 'sandbox']
 
 class MipIframe extends CustomElement {
   build () {
-    this.handlePageResize = this.handlePageResize.bind(this)
-    this.notifyRootPage = this.notifyRootPage.bind(this)
+    this.bindedHandlePageResize = this.handlePageResize.bind(this)
+    this.bindedHnotifyRootPage = this.notifyRootPage.bind(this)
+
     let element = this.element
-    let src = element.getAttribute('src')
+
+    let src
     let srcdoc = element.getAttribute('srcdoc')
     if (srcdoc) {
       src = 'data:text/html;charset=utf-8;base64,' + window.btoa(srcdoc)
+    } else {
+      src = element.getAttribute('src') || ''
+      if ('https://' !== src.slice(0, 8)) {
+        return
+      }
     }
 
     let height = element.getAttribute('height')

--- a/packages/mip/src/components/mip-iframe.js
+++ b/packages/mip/src/components/mip-iframe.js
@@ -23,8 +23,8 @@ const ATTR_LIST = [
 
 function encode (str) {
   let arr
-  if (typeof TextEncoder !== 'undefined') {
-    arr = new TextEncoder('utf-8').encode(str)
+  if (typeof window.TextEncoder !== 'undefined') {
+    arr = new window.TextEncoder('utf-8').encode(str)
   } else {
     arr = new Uint8Array(str.length)
     str = unescape(encodeURIComponent(str))
@@ -79,7 +79,8 @@ class MipIframe extends CustomElement {
     } else if (this._srcdoc !== value) {
       this._srcdoc = value
       // 兼容 mip1
-      if (this.element.getAttribute('encode')) {
+      let needEncode = this.element.getAttribute('encode')
+      if (needEncode === 'true' || needEncode === '') {
         value = encode(value)
       }
       this._src = 'data:text/html;charset=utf-8;base64,' + window.btoa(value)

--- a/packages/mip/test/specs/components/mip-iframe.spec.js
+++ b/packages/mip/test/specs/components/mip-iframe.spec.js
@@ -13,11 +13,11 @@ import {
 
 import viewport from 'src/viewport'
 
-describe('mip-iframe', function () {
-  let mipIframe
-  let iframe
-
+describe.only('mip-iframe', function () {
   describe('iframe with default width and attrs', function () {
+    let mipIframe
+    let iframe
+
     this.timeout(1200)
     before(function () {
       mipIframe = document.createElement('mip-iframe')
@@ -50,6 +50,9 @@ describe('mip-iframe', function () {
   })
 
   describe('iframe with set width and height', function () {
+    let mipIframe
+    let iframe
+
     before(function () {
       mipIframe = document.createElement('mip-iframe')
       mipIframe.setAttribute('srcdoc', '<p>Hello MIP!</p>')
@@ -107,6 +110,9 @@ describe('mip-iframe', function () {
   })
 
   describe('iframe with no src and height', function () {
+    let mipIframe
+    let iframe
+
     before(function () {
       mipIframe = document.createElement('mip-iframe')
       document.body.appendChild(mipIframe)
@@ -115,6 +121,55 @@ describe('mip-iframe', function () {
     it('should not produce iframe', function () {
       iframe = mipIframe.querySelector('iframe')
       expect(iframe).to.be.null
+    })
+
+    after(function () {
+      document.body.removeChild(mipIframe)
+    })
+  })
+
+  describe('iframe src is HTTP', function () {
+    let mipIframe
+    let iframe
+
+    before(function () {
+      mipIframe = document.createElement('mip-iframe')
+      mipIframe.setAttribute('width', '300px')
+      mipIframe.setAttribute('height', '400px')
+      mipIframe.setAttribute('layout', 'fixed')
+      mipIframe.setAttribute('src', 'http://www.baidu.com')
+      document.body.appendChild(mipIframe)
+    })
+
+    it('should alert HTTPS request', function () {
+      iframe = mipIframe.querySelector('iframe')
+      expect(iframe.src).to.equal('data:text/html;charset=utf-8;base64,' + window.btoa('Invalid &lt;mip-iframe&gt; src. Must start with https://'))
+    })
+
+    after(function () {
+      document.body.removeChild(mipIframe)
+    })
+  })
+
+
+  describe('iframe srcdoc with Chinese', function () {
+    this.timeout(1200)
+    let mipIframe
+
+    it('should show chinese words', function (done) {
+      expect(
+        function () {
+          mipIframe = document.createElement('mip-iframe')
+          mipIframe.setAttribute('width', '300px')
+          mipIframe.setAttribute('height', '400px')
+          mipIframe.setAttribute('layout', 'fixed')
+          mipIframe.setAttribute('srcdoc', '<p>你好</p>')
+          mipIframe.setAttribute('encode', 'true')
+          document.body.appendChild(mipIframe)
+
+          setTimeout(done, 1000)
+        }
+      ).to.not.throw()
     })
 
     after(function () {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#303 

**1、升级点** （清晰准确的描述升级的功能点）
1. src 增加 https 检查
2. 增加 ‘‘encode’’ 属性增加对 srcdoc 内容的 ascii 转码
3. 增加对 src 和 srcdoc 的属性监听

**2、影响范围** （描述该需求上线会影响什么功能）
1. 对现有 mip-iframe 的使用方法不变
2. 新增功能

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
