### PR TITLE
每一条给 SF 的消息都带上name

### DIFF
--- a/packages/mip/src/client-prerender.js
+++ b/packages/mip/src/client-prerender.js
@@ -41,7 +41,9 @@ class ClientPrerender {
     // 延迟执行的的函数队列
     this.queue = []
 
-    this.messager = new Messager()
+    this.messager = new Messager({
+      name: util.fn.getRootName(window.name)
+    })
 
     if (util.hash.get('prerender') === '1') {
       this.prerender = true

--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -32,7 +32,8 @@ export function createIFrame ({fullpath, pageId}, {onLoad, onError} = {}) {
   let pageMeta = JSON.stringify({
     standalone: window.MIP.standalone,
     isRootPage: false,
-    isCrossOrigin: targetOrigin !== window.location.origin
+    isCrossOrigin: targetOrigin !== window.location.origin,
+    rootName: window.MIP.viewer.rootName
   })
   container.setAttribute('name', pageMeta)
 

--- a/packages/mip/src/util/fn.js
+++ b/packages/mip/src/util/fn.js
@@ -181,6 +181,28 @@ function isCacheUrl (pageUrl) {
     /^(\/\/|http:\/\/|https:\/\/)[^.]+.mipcdn.com\/(stati)?c\//.test(pageUrl)
 }
 
+/**
+ * 获取 SF 创建的第一个 iframe 的 name，在实例化 messager 时会使用到。
+ * 如果是 MIP2 的子页面，通过 window.name 由父页面传递下来。
+ * 格式如 iframe-shell-xxxxxx
+ */
+function getRootName (name) {
+  if (!name) {
+    return ''
+  }
+
+  if (/^iframe-shell/.test(name)) {
+    return name
+  }
+
+  try {
+    let info = JSON.parse(name)
+    return info.rootName
+  } catch (e) {
+    return name
+  }
+}
+
 export default {
   throttle,
   values,
@@ -190,5 +212,6 @@ export default {
   isString,
   del,
   hasTouch,
-  isCacheUrl
+  isCacheUrl,
+  getRootName
 }

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -46,6 +46,12 @@ let viewer = {
      * The initialise method of viewer
      */
   init () {
+
+    /**
+     * SF 创建的第一个页面的 window.name
+     */
+    this.rootName = fn.getRootName(window.name)
+
     /**
      * Send Message, keep messager only one if prerender have created
      *
@@ -53,7 +59,7 @@ let viewer = {
      * @type {Object}
      */
     const messager = clientPrerender.messager
-    this.messager = messager || new Messager()
+    this.messager = messager || new Messager({name: this.rootName})
 
     /**
      * The gesture of document.Used by the event-action of Viewer.

--- a/packages/mip/test/specs/util.spec.js
+++ b/packages/mip/test/specs/util.spec.js
@@ -25,7 +25,8 @@ describe('util', function () {
       'Gesture',
       'customStorage',
       'naboo',
-      'jsonParse'
+      'jsonParse',
+      'getRootName'
     ].forEach(function (key) {
       it('.' + key, function () {
         expect(util[key]).to.be.not.undefined
@@ -223,6 +224,26 @@ describe('util', function () {
     expect(util.isCacheUrl('https://c.mipcdn.com/static/v2/internal/instantService-mip-duliangheng/font/wendu-bda6817d452d4a204e4371b3c6c06715.svg')).to.be.true
     expect(util.isCacheUrl('https://yjmtpt-xx--motor-com.mipcdn.com/c/s/yjmtpt.xx-motor.com/xmdcwbaidu.com/example/mip-xmd-illegal-index.html')).to.be.true
     expect(util.isCacheUrl('http://ab.c.mipcdn.com/c/www.mipengine.com/docs/index.html')).to.be.false
+  })
+
+  describe('.getRootName', function () {
+    it('.getRootName in root page', function () {
+      expect(util.getRootName('iframe-shell-vhn7s9y6hu9')).to.be.equal('iframe-shell-vhn7s9y6hu9')
+    })
+
+    it('.getRootName in sub page', function () {
+      expect(util.getRootName('{"standalone":false,"isRootPage":false,"isCrossOrigin":false, "rootName":"iframe-shell-vhn7s9y6hu9"}'))
+        .to.be.equal('iframe-shell-vhn7s9y6hu9')
+    })
+
+    it('.getRootName with undefined params', function () {
+      expect(util.getRootName()).to.be.equal('')
+    })
+
+    it('.getRootName in other cases', function () {
+      expect(util.getRootName('some other name'))
+        .to.be.equal('some other name')
+    })
   })
 })
 

--- a/packages/mip/test/specs/util.spec.js
+++ b/packages/mip/test/specs/util.spec.js
@@ -25,8 +25,7 @@ describe('util', function () {
       'Gesture',
       'customStorage',
       'naboo',
-      'jsonParse',
-      'getRootName'
+      'jsonParse'
     ].forEach(function (key) {
       it('.' + key, function () {
         expect(util[key]).to.be.not.undefined
@@ -224,26 +223,6 @@ describe('util', function () {
     expect(util.isCacheUrl('https://c.mipcdn.com/static/v2/internal/instantService-mip-duliangheng/font/wendu-bda6817d452d4a204e4371b3c6c06715.svg')).to.be.true
     expect(util.isCacheUrl('https://yjmtpt-xx--motor-com.mipcdn.com/c/s/yjmtpt.xx-motor.com/xmdcwbaidu.com/example/mip-xmd-illegal-index.html')).to.be.true
     expect(util.isCacheUrl('http://ab.c.mipcdn.com/c/www.mipengine.com/docs/index.html')).to.be.false
-  })
-
-  describe('.getRootName', function () {
-    it('.getRootName in root page', function () {
-      expect(util.getRootName('iframe-shell-vhn7s9y6hu9')).to.be.equal('iframe-shell-vhn7s9y6hu9')
-    })
-
-    it('.getRootName in sub page', function () {
-      expect(util.getRootName('{"standalone":false,"isRootPage":false,"isCrossOrigin":false, "rootName":"iframe-shell-vhn7s9y6hu9"}'))
-        .to.be.equal('iframe-shell-vhn7s9y6hu9')
-    })
-
-    it('.getRootName with undefined params', function () {
-      expect(util.getRootName()).to.be.equal('')
-    })
-
-    it('.getRootName in other cases', function () {
-      expect(util.getRootName('some other name'))
-        .to.be.equal('some other name')
-    })
   })
 })
 

--- a/packages/mip/test/specs/util/fn.spec.js
+++ b/packages/mip/test/specs/util/fn.spec.js
@@ -104,13 +104,24 @@ describe('fn', function () {
     } catch (e) {}
   })
 
-  it('isCacheUrl', function () {
-    expect(util.isCacheUrl('http://www-mipengine-com.mipcdn.com/c/www.mipengine.com/docs/index.html')).to.be.true
-    expect(util.isCacheUrl('https://www.badiu.com/c/www.mipengine.com/docs/index.html')).to.be.false
-    expect(util.isCacheUrl('//mipcache.bdstatic.com/c/')).to.be.true
-    expect(util.isCacheUrl('https://c.mipcdn.com/static/v2/internal/instantService-mip-duliangheng/font/wendu-bda6817d452d4a204e4371b3c6c06715.svg')).to.be.true
-    expect(util.isCacheUrl('https://yjmtpt-xx--motor-com.mipcdn.com/c/s/yjmtpt.xx-motor.com/xmdcwbaidu.com/example/mip-xmd-illegal-index.html')).to.be.true
+  describe('.getRootName', function () {
+    it('.getRootName in root page', function () {
+      expect(fn.getRootName('iframe-shell-vhn7s9y6hu9')).to.be.equal('iframe-shell-vhn7s9y6hu9')
+    })
+
+    it('.getRootName in sub page', function () {
+      expect(fn.getRootName('{"standalone":false,"isRootPage":false,"isCrossOrigin":false, "rootName":"iframe-shell-vhn7s9y6hu9"}'))
+        .to.be.equal('iframe-shell-vhn7s9y6hu9')
+    })
+
+    it('.getRootName with undefined params', function () {
+      expect(fn.getRootName()).to.be.equal('')
+    })
+
+    it('.getRootName in other cases', function () {
+      expect(fn.getRootName('some other name'))
+        .to.be.equal('some other name')
+    })
   })
-    expect(util.isCacheUrl('http://ab.c.mipcdn.com/c/www.mipengine.com/docs/index.html')).to.be.false
 })
 /* eslint-enable no-unused-expressions */


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#328 
**1、升级点** （清晰准确的描述升级的功能点）
每一条和 SF 的通讯信息都设置 name，格式如 `iframe-shell-xxxx`
**2、影响范围** （描述该需求上线会影响什么功能）
对代码正常运行没有影响，但能修复 328 提到的问题，让 SF 能够区分正常页面和预渲染页面（需配合 SF 的修改一起）
**3、自测 Checklist**
联合 @oott123 进行过线下测试，效果正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
