### PR TITLE
【免测】mip-component-validator 增加 npm 白名单 fe-siteopen-sdk、nib

### DIFF
--- a/packages/mip-component-validator/src/rules/lib/whitelist.txt
+++ b/packages/mip-component-validator/src/rules/lib/whitelist.txt
@@ -7,3 +7,5 @@ mip-sandbox
 moment
 better-scroll
 xzh-sdk
+nib
+fe-siteopen-sdk


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#331 

**1、升级点** （清晰准确的描述升级的功能点）

增加以下 npm 包白名单：
nib
fe-siteopen-sdk 

**2、影响范围** （描述该需求上线会影响什么功能）

影响线下组件开发

**3、自测 Checklist**

项目使用 nip fe-siteopen-sdk 时控制台不会报错
