### PR TITLE
再次尝试异步操作提升性能

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -215,11 +215,15 @@ class MipShell extends CustomElement {
       page.pageMeta = this.currentPageMeta
       this.initShell()
       this.initRouter()
-      // 绑定事件改为异步，不阻塞发送 mippageload 事件，下同
-      setTimeout(() => this.bindRootEvents(), 0)
     }
 
-    setTimeout(() => this.bindAllEvents(), 0)
+    // 绑定事件改为异步，不阻塞发送 mippageload 事件，下同
+    setTimeout(() => {
+      if (page.isRootPage) {
+        this.bindRootEvents()
+      }
+      this.bindAllEvents()
+    }, 0)
   }
 
   disconnectedCallback () {

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -215,10 +215,11 @@ class MipShell extends CustomElement {
       page.pageMeta = this.currentPageMeta
       this.initShell()
       this.initRouter()
-      this.bindRootEvents()
+      // 绑定事件改为异步，不阻塞发送 mippageload 事件，下同
+      setTimeout(() => this.bindRootEvents(), 0)
     }
 
-    this.bindAllEvents()
+    setTimeout(() => this.bindAllEvents(), 0)
   }
 
   disconnectedCallback () {
@@ -237,15 +238,45 @@ class MipShell extends CustomElement {
    * 4. Page mask (mainly used to cover header)
    */
   initShell () {
+    if (this.currentPageMeta.header && this.currentPageMeta.header.show) {
+      isHeaderShown = true
+      this.createHeader(true)
+    } else {
+      isHeaderShown = false
+    }
+
+    // Other sync parts
+    this.renderOtherParts()
+
+    setTimeout(() => {
+      if (!isHeaderShown) {
+        this.createHeader(false)
+      }
+
+      // Button wrapper & mask
+      let buttonGroup = this.currentPageMeta.header.buttonGroup
+      let {mask, buttonWrapper} = createMoreButtonWrapper(buttonGroup)
+      this.$buttonMask = mask
+      this.$buttonWrapper = buttonWrapper
+
+      // Page mask
+      this.$pageMask = createPageMask()
+
+      // Loading
+      this.$loading = createLoading(this.currentPageMeta)
+
+      // Other async parts
+      this.renderOtherPartsAsync()
+    }, 0)
+  }
+
+  createHeader (showHeader) {
     // Shell wrapper
     this.$wrapper = document.createElement('mip-fixed')
     this.$wrapper.setAttribute('type', 'top')
     this.$wrapper.classList.add('mip-shell-header-wrapper')
-    if (this.currentPageMeta.header && this.currentPageMeta.header.show) {
-      isHeaderShown = true
-    } else {
+    if (!showHeader) {
       this.$wrapper.classList.add('hide')
-      isHeaderShown = false
     }
 
     // Header
@@ -255,26 +286,6 @@ class MipShell extends CustomElement {
     this.$wrapper.insertBefore(this.$el, this.$wrapper.firstChild)
 
     document.body.insertBefore(this.$wrapper, document.body.firstChild)
-
-    // Other sync parts
-    this.renderOtherParts()
-
-    // Button wrapper & mask
-    let buttonGroup = this.currentPageMeta.header.buttonGroup
-    let {mask, buttonWrapper} = createMoreButtonWrapper(buttonGroup)
-    this.$buttonMask = mask
-    this.$buttonWrapper = buttonWrapper
-
-    // Page mask
-    this.$pageMask = createPageMask()
-
-    // Loading
-    this.$loading = createLoading(this.currentPageMeta)
-
-    setTimeout(() => {
-      // Other async parts
-      this.renderOtherPartsAsync()
-    }, 0)
   }
 
   initRouter () {

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -91,7 +91,8 @@ let viewer = {
     fixedElement.init()
 
     // proxy <a mip-link>
-    this._proxyLink(this.page)
+    setTimeout(() => this._proxyLink(this.page), 0)
+
   },
 
   /**


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#280 
**1、升级点** （清晰准确的描述升级的功能点）
还是把一些无需立刻执行的操作异步进行，避免阻塞发送消息
**2、影响范围** （描述该需求上线会影响什么功能）
首屏shell（例如头部）的渲染以及所有 a 链接的事件绑定现在都变成了异步
另外小说广告之前有依赖顺序的问题，需要确认修改后是否还有这个问题（当时就是因为这个而回滚的）
**3、自测 Checklist**
采用线下代理的方式测试过极速服务&小说，基本功能正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
