### PR TITLE
SF情况下首屏不展现 loading

### DIFF
--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -47,6 +47,9 @@
             z-index: 100000;
             animation: loading-rotate 1s linear infinite
         }
+        body::after {
+            display: none;
+        }
 
         @keyframes loading-rotate {
             from {

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -101,16 +101,6 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
   mip1PolyfillInstall(mip)
 
   util.dom.waitDocumentReady(() => {
-    try {
-      // SF 环境下首次打开页面不需要展现 Loading，否则会和 SF 的 Loading 重叠（且样式不同）
-      // 因此单独打开或者后续页面，均需要展现 Loading
-      if (!viewer.isIframed || typeof window.parent.MIP !== 'undefined') {
-        document.body.classList.add('show-loading')
-      }
-    } catch (e) {
-      // 跨域表示外层是 SF，且默认是隐藏，所以什么都不做。
-    }
-
     // Initialize sleepWakeModule
     sleepWakeModule.init()
 

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -38,7 +38,7 @@ let mip = {}
 if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefined') {
   monitorInstall()
 
-  // pass meta through `window.name` in cross-origin scene
+  // 通过 window.name 传递信息，可用于跨域情况
   let pageMeta
   let pageMetaConfirmed = false
   try {
@@ -101,6 +101,16 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
   mip1PolyfillInstall(mip)
 
   util.dom.waitDocumentReady(() => {
+    try {
+      // SF 环境下首次打开页面不需要展现 Loading，否则会和 SF 的 Loading 重叠（且样式不同）
+      // 因此单独打开或者后续页面，均需要展现 Loading
+      if (!viewer.isIframed || typeof window.parent.MIP !== 'undefined') {
+        document.body.classList.add('show-loading')
+      }
+    } catch (e) {
+      // 跨域表示外层是 SF，且默认是隐藏，所以什么都不做。
+    }
+
     // Initialize sleepWakeModule
     sleepWakeModule.init()
 

--- a/packages/mip/src/styles/mip-page.less
+++ b/packages/mip/src/styles/mip-page.less
@@ -29,10 +29,6 @@ body::after,
 
 body::after {
   display: none;
-
-  .show-loading {
-    display: block;
-  }
 }
 
 @keyframes loading-rotate {
@@ -49,7 +45,7 @@ body.mip-fixedlayer::after,
 body[mip-ready]::before,
 body[mip-ready]::after,
 .mip-page-loading-wrapper.only-header::after {
-  display: none!important;
+  display: none;
 }
 
 body.with-header {

--- a/packages/mip/src/styles/mip-page.less
+++ b/packages/mip/src/styles/mip-page.less
@@ -24,7 +24,15 @@ body::after,
   left: 50%;
   margin: -17px 0 0 -17px;
   z-index: 100000;
-  animation: loading-rotate 1s linear infinite
+  animation: loading-rotate 1s linear infinite;
+}
+
+body::after {
+  display: none;
+
+  .show-loading {
+    display: block;
+  }
 }
 
 @keyframes loading-rotate {
@@ -41,7 +49,7 @@ body.mip-fixedlayer::after,
 body[mip-ready]::before,
 body[mip-ready]::after,
 .mip-page-loading-wrapper.only-header::after {
-  display: none;
+  display: none!important;
 }
 
 body.with-header {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#344 
**1、升级点** （清晰准确的描述升级的功能点）
在 SF 情况下，MIP 首个页面不展现自己的 Loading
在 MIP1 的页面尤其有效，MIP2因为 SF 的 Loading 是全覆盖页面的样式，所以看不出差别。
**2、影响范围** （描述该需求上线会影响什么功能）
[https://m.baidu.com/mip/c/s/m.meishichina.com/recipe/176377/](https://m.baidu.com/mip/c/s/m.meishichina.com/recipe/176377/)
主要影响 MIP1 的页面直接迁移成 MIP2 的 JS 之后，两层 Loading 问题的修复
**3、自测 Checklist**
使用代理线上JS和CSS的方式测试过上面的红烧肉页面，没有两层 Loading
另外回归过极速服务搬家，小说阅读器，翻页等 Loading 正常展现。
单独打开 MIP 页面（不在SF里）也正常展现 Loading
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
