### PR TITLE
【免测】增加 mip-sandbox 白名单

### DIFF
--- a/packages/mip-cli/CHANGELOG.md
+++ b/packages/mip-cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- 1.4.3
+    1. 更新 mip-sandbox 和 mip-component-validator 依赖版本，新增 `atob` `TextEncoder` `TextDecoder` 白名单
+
 - 1.4.2
     1. 更新 mip-sandbox 依赖版本，添加 `DataView` 白名单
 

--- a/packages/mip-cli/package-lock.json
+++ b/packages/mip-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5950,18 +5950,18 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mip-component-validator": {
-      "version": "1.1.5",
-      "resolved": "http://registry.npm.taobao.org/mip-component-validator/download/mip-component-validator-1.1.5.tgz",
-      "integrity": "sha1-XTjtQw59+KmRlqa3zQugqNO/Fz4=",
+      "version": "1.1.6",
+      "resolved": "http://registry.npm.taobao.org/mip-component-validator/download/mip-component-validator-1.1.6.tgz",
+      "integrity": "sha1-9RAYV3KSdFuOJxYM/mOQ6z8z5AY=",
       "requires": {
         "babel-core": "6.26.3",
         "babel-preset-stage-3": "6.24.1",
         "fs-extra": "7.0.1",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "mip-sandbox": "1.0.25",
+        "mip-sandbox": "1.0.26",
         "mip-validator": "1.5.15",
-        "node-fetch": "2.2.1",
+        "node-fetch": "2.3.0",
         "vue": "2.5.16",
         "vue-template-compiler": "2.5.16"
       },
@@ -5990,9 +5990,9 @@
       }
     },
     "mip-sandbox": {
-      "version": "1.0.25",
-      "resolved": "http://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.0.25.tgz",
-      "integrity": "sha1-xAWarIlGOpjcU+gpApFszjLsT8c=",
+      "version": "1.0.26",
+      "resolved": "http://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.0.26.tgz",
+      "integrity": "sha1-Un++eZ87gvNRySAh2MVEUYcpIVs=",
       "requires": {
         "acorn": "5.7.1",
         "acorn-dynamic-import": "3.0.0",
@@ -6165,9 +6165,9 @@
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "node-fetch": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npm.taobao.org/node-fetch/download/node-fetch-2.2.1.tgz",
-      "integrity": "sha1-H+VR4N7WxFs7O5N9D7Rvdt9xjR4="
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.taobao.org/node-fetch/download/node-fetch-2.3.0.tgz",
+      "integrity": "sha1-Gh2UC7+5FqHT4CGfA36J5x+MX6U="
     },
     "node-libs-browser": {
       "version": "2.1.0",

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {
@@ -62,9 +62,9 @@
     "livereload": "^0.7.0",
     "metalsmith": "^2.3.0",
     "minimatch": "^3.0.4",
-    "mip-component-validator": "^1.1.5",
+    "mip-component-validator": "^1.1.6",
     "mip-components-webpack-helpers": "^1.0.7",
-    "mip-sandbox": "^1.0.25",
+    "mip-sandbox": "^1.0.26",
     "mip-validator": "^1.5.15",
     "opn": "^5.3.0",
     "ora": "^2.1.0",

--- a/packages/mip-component-validator/package-lock.json
+++ b/packages/mip-component-validator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-component-validator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -817,9 +817,9 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mip-sandbox": {
-      "version": "1.0.25",
-      "resolved": "http://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.0.25.tgz",
-      "integrity": "sha1-xAWarIlGOpjcU+gpApFszjLsT8c=",
+      "version": "1.0.26",
+      "resolved": "http://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.0.26.tgz",
+      "integrity": "sha1-Un++eZ87gvNRySAh2MVEUYcpIVs=",
       "requires": {
         "acorn": "5.7.3",
         "acorn-dynamic-import": "3.0.0",

--- a/packages/mip-component-validator/package.json
+++ b/packages/mip-component-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-component-validator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "MIP component validate",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "fs-extra": "^7.0.0",
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",
-    "mip-sandbox": "^1.0.25",
+    "mip-sandbox": "^1.0.26",
     "mip-validator": "^1.5.15",
     "node-fetch": "^2.2.0",
     "vue": "2.5.16",

--- a/packages/mip-sandbox/README.md
+++ b/packages/mip-sandbox/README.md
@@ -277,6 +277,9 @@ var ORIGINAL = [
   'String',
   'Symbol',
   'SyntaxError',
+  // https://github.com/mipengine/mip2/issues/347
+  'TextDecoder',
+  'TextEncoder',
   'TypeError',
   'URIError',
   'URL',
@@ -288,6 +291,8 @@ var ORIGINAL = [
   // 1.0.17 新增 WebSocket
   'WebSocket',
   'WritableStream',
+  // https://github.com/mipengine/mip2/issues/347
+  'atob',
   // issue https://github.com/mipengine/mip2/issues/62
   'crypto',
   'clearInterval',

--- a/packages/mip-sandbox/lib/keywords.js
+++ b/packages/mip-sandbox/lib/keywords.js
@@ -41,6 +41,9 @@ var ORIGINAL = [
   'String',
   'Symbol',
   'SyntaxError',
+  // https://github.com/mipengine/mip2/issues/347
+  'TextDecoder',
+  'TextEncoder',
   'TypeError',
   'URIError',
   'URL',
@@ -52,6 +55,8 @@ var ORIGINAL = [
   // 1.0.17 新增 WebSocket
   'WebSocket',
   'WritableStream',
+  // https://github.com/mipengine/mip2/issues/347
+  'atob',
   // issue https://github.com/mipengine/mip2/issues/62
   'crypto',
   'clearInterval',

--- a/packages/mip-sandbox/package-lock.json
+++ b/packages/mip-sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mip-sandbox/package.json
+++ b/packages/mip-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "sandbox tools for MIP project",
   "main": "lib/sandbox.js",
   "scripts": {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#347 
**1、升级点** （清晰准确的描述升级的功能点）
1. 新增 mip-sandbox 白名单 atob TextEncoder TextDecoder，并发布新版本
2. 升级 mip-component-validator 的 mip-sandbox 版本依赖，并发布新版本
3. 升级 mip-cli 的 mip-component-validator 和 mip-sandbox 的版本依赖，并发布新版本

**2、影响范围** （描述该需求上线会影响什么功能）
1. 仅影响第三方站长组件开发时的 mip-sandbox 白名单校验

**3、自测 Checklist**
无

