### PR TITLE
mip-cli dev模式添加目录浏览功能并对静态资源访问作限制

### DIFF
--- a/packages/mip-cli/CHANGELOG.md
+++ b/packages/mip-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- 1.4.4
+    1. dev模式添加目录浏览功能
+    2. 禁止example和mock文件夹外的静态资源访问
+
 - 1.4.3
     1. 更新 mip-sandbox 和 mip-component-validator 依赖版本，新增 `atob` `TextEncoder` `TextDecoder` 白名单
 

--- a/packages/mip-cli/lib/dev.js
+++ b/packages/mip-cli/lib/dev.js
@@ -30,7 +30,7 @@ module.exports = function (options) {
 
     console.log()
     console.log()
-    cli.info(`服务启动成功，正在监听 http://127.0.0.1:${server.port}`)
+    cli.info(`服务启动成功，正在监听 http://127.0.0.1:${server.port}，直接访问可显示项目目录`)
     console.log()
     console.log(chalk.yellow('预览页面:'))
     console.log(`/example 目录下的 html 可以通过 http://127.0.0.1:${server.port}/example/{页面名}.html 进行预览。`)

--- a/packages/mip-cli/lib/server/index.js
+++ b/packages/mip-cli/lib/server/index.js
@@ -11,6 +11,7 @@ const html = require('./middleware/html')
 const livereload = require('livereload')
 const cli = require('../cli')
 const koaStatic = require('koa-static')
+const directory = require('./middleware/directory')
 
 module.exports = class Server {
   constructor (options) {
@@ -34,10 +35,13 @@ module.exports = class Server {
 
     let scriptMiddlewares = script(options)
     let htmlMiddlewares = html(options)
+    let dirMiddlewares = directory(options)
 
     this.router
-      .get(['/:id([^\\.]*)', '/:id([^\\.]+\\.html)'], ...htmlMiddlewares)
-      .get('*', ...scriptMiddlewares, koaStatic(this.dir))
+      .get('/:id([^\\.]+\\.html)', ...htmlMiddlewares)
+      .get('/:id([^\\.]*)', ...dirMiddlewares)
+      .get(['/**/example/*.*', '/**/mock/*.*'], koaStatic(this.dir))
+      .get('*', ...scriptMiddlewares)
 
     this.app
       .use(record)

--- a/packages/mip-cli/lib/server/middleware/directory/dir-template.etpl
+++ b/packages/mip-cli/lib/server/middleware/directory/dir-template.etpl
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="format-detection" content="telephone=no">
+    <meta name="screen-orientation" content="portrait">
+    <meta name="x5-orientation" content="portrait">
+    <style>
+      *,
+      *:before,
+      *:after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        font-size: 120%;
+        font-family: Consolas, Tahoma;
+      }
+      a, p {
+        text-decoration: none;
+        color: #333;
+      }
+      a:hover {
+        background: #eaeaea;
+      }
+      ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
+      .crumb {
+        margin-bottom: 1em;
+        padding: 1em;
+        background: #333;
+      }
+      .crumb li {
+        display: inline;
+        margin-right: 5px;
+        color: #ccc;
+      }
+      .crumb li a {
+        color: #ccc;
+      }
+      .crumb li a:hover {
+        text-decoration: underline;
+        background: inherit;
+      }
+      .list li {
+        min-height: .5em;
+        display: inline-block;
+        width: 33.33%;
+      }
+      .list li a, p {
+        display: block;
+        padding: 0 1em;
+        line-height: 2;
+      }
+      .list li p {
+        opacity: 0.5;
+        margin: 0;
+      }
+      @media only screen and (max-width : 768px) {
+      .list li {
+        display: block;
+        width: 100%;
+      }
+      .list li a, p {
+        line-height: 3;
+        border-bottom: 1px dotted #ccc;
+      }
+    }
+    </style>
+  </head>
+  <body>
+    {% var: url = {{url}} %}
+    {% var: dirUrl = '/' %}
+
+    <ul class="crumb">
+      <li><a href="/">/</a></li>
+      {% for: {{urlArr}} as {{u}} %}
+      {% var: dirUrl = {{dirUrl}} + {{u}} + '/' %}
+        <li><a href={{dirUrl}}>{{u}}/</a></li>
+      {% /for %}
+    </ul>
+    
+    <ul class="list">
+      {% for: {{dirList}} as {{item}} %}
+        <li><a href={{url}}{{item}}/>{{item}}/</a></li>
+      {% /for %}
+    </ul>
+
+    <ul class="list">
+      {% for: {{fileList}} as {{item}} %}
+        <li>
+          {% if: {{canAccess}} == true %}
+            <a href={{url}}{{item}}>{{item}}</a>
+          {% else %}
+            <p>{{item}}</p>
+          {% /if %}
+        </li>
+      {% /for %}
+    </ul>
+  </body>
+</html>

--- a/packages/mip-cli/lib/server/middleware/directory/index.js
+++ b/packages/mip-cli/lib/server/middleware/directory/index.js
@@ -1,0 +1,65 @@
+const fs = require('fs-extra')
+const path = require('path')
+const render = require('../../../utils/render').render
+
+module.exports = function (config) {
+  return [
+    async (ctx, next) => {
+      let pagePath = path.join(config.dir, ctx.url)
+
+      let content = ''
+      let stat = await fs.stat(pagePath)
+      if (stat.isDirectory()) {
+        content = await dir(ctx.url, pagePath)
+        ctx.body = content
+      } else {
+        await next()
+      }
+    }
+  ]
+}
+
+async function dir (url, reqPath) {
+  let {fileList, dirList, canAccess} = await walk(reqPath)
+  url = url.endsWith('/') ? url : url + '/'
+  let urlArr = []
+  if (url !== '/') {
+    urlArr = url.slice(1, -1).split('/')
+  }
+  let template = await fs.readFile(path.join(__dirname, 'dir-template.etpl'), 'utf8')
+  let data = {
+    canAccess: canAccess,
+    fileList: fileList,
+    dirList: dirList,
+    urlArr: urlArr,
+    url: url
+  }
+  return render(template, data)
+}
+
+async function walk (reqPath) {
+  let items = await fs.readdir(reqPath)
+  let pathArr = reqPath.split(path.sep)
+  let canAccess = false
+  // 仅可访问example和mock目录及子目录下的文件
+  if (pathArr.indexOf('example') !== -1 || pathArr.indexOf('mock') !== -1) {
+    canAccess = true
+  }
+
+  let dirList = []
+  let fileList = []
+  for (let item of items) {
+    let stats = await fs.stat(path.join(reqPath, item))
+    if (stats.isDirectory()) {
+      dirList.push(item)
+    }
+    if (stats.isFile()) {
+      fileList.push(item)
+    }
+  }
+  return {
+    fileList: fileList,
+    dirList: dirList,
+    canAccess: canAccess
+  }
+}

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#350 
#351 

**1、升级点** （清晰准确的描述升级的功能点）
dev server 增加目录浏览功能
禁止直接通过url访问example和mock目录外的静态资源

**2、影响范围** （描述该需求上线会影响什么功能）
影响在mip-cli dev模式下调试代码

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
