### PR TITLE
【WIP】删除基础样式中的 100px

### DIFF
--- a/packages/mip/src/styles/mip-base.less
+++ b/packages/mip/src/styles/mip-base.less
@@ -4,16 +4,6 @@
   padding: 0
 }
 
-html {
-  font-size: 100px;
-}
-
-@media screen and (max-width: 360px) {
-  html {
-    font-size: 90px !important;
-  }
-}
-
 body {
   font-size-adjust: none;
   text-size-adjust: none;


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#182 

**1、升级点** （清晰准确的描述升级的功能点）
删除基础样式中的 100px，请使用mip-rem

**2、影响范围** （描述该需求上线会影响什么功能）
有用到基础样式中的 100px 和 rem 的站点

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
