### PR TITLE
【免测】注册外部 service 时直接实例化

### DIFF
--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -345,7 +345,7 @@ export class Extensions {
 
     holder.extension.services[name] = {implementation}
 
-    Services.registerService(this.win, name, implementation)
+    Services.registerService(this.win, name, implementation, true)
   }
 
   /**

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -336,6 +336,7 @@ export class Extensions {
    * Registers a service in extension currently being registered (by calling `MIP.push`).
    * A service in extension is still a class contains some useful functions,
    * it's no conceptual difference with other internal services.
+   * However, external services will be instantiated immediately.
    *
    * @param {string} name
    * @param {!Function} implementation

--- a/packages/mip/src/services/services.js
+++ b/packages/mip/src/services/services.js
@@ -81,9 +81,10 @@ class ServicesInternal {
    * @param {string} id
    * @param {!Object} context
    * @param {!Function} Constructor
+   * @param {?boolean} instantiate
    * @returns {!Object}
    */
-  static registerService (holder, id, context, Constructor) {
+  static registerService (holder, id, context, Constructor, instantiate) {
     const services = this.getServices(holder)
     let service = services[id]
 
@@ -113,7 +114,7 @@ class ServicesInternal {
     /**
      * Service may have been requested already, in which case we need to fulfill the pending promise.
      */
-    if (service.resolve) {
+    if (service.resolve || instantiate) {
       this.instantiateService(service)
     }
 
@@ -227,9 +228,10 @@ class Services extends ServicesFactory {
    * @param {!Window} holder currently represents `Window`.
    * @param {string} id of the service.
    * @param {!Function} Constructor of the service.
+   * @param {?boolean} instantiate service immediately.
    */
-  static registerService (holder, id, Constructor) {
-    ServicesInternal.registerService(holder, id, holder, Constructor)
+  static registerService (holder, id, Constructor, instantiate) {
+    ServicesInternal.registerService(holder, id, holder, Constructor, instantiate)
   }
 
   /**

--- a/packages/mip/test/specs/services/services.spec.js
+++ b/packages/mip/test/specs/services/services.spec.js
@@ -57,6 +57,14 @@ describe('services', () => {
       expect(Constructor).to.be.calledOnce
     })
 
+    it('should instantiate service immediately', () => {
+      Services.registerService(window, 'a', Constructor, true)
+      const a = window.services.a
+      expect(a.instance).instanceOf(Constructor)
+      expect(a.context).to.be.null
+      expect(a.Constructor).to.be.null
+    })
+
     it('should return the service when it exists', () => {
       const a0 = Services.getServiceOrNull(window, 'a')
       expect(a0).to.be.null


### PR DESCRIPTION
**相关 ISSUE:** 

**1、升级点**
 - mip2-extensions 中的 service 为外部 service，注册时应直接实例化

**2、影响范围** （描述该需求上线会影响什么功能）
 - 线上无任何影响，因为根本没有外部 service
 - 不影响原注册流程

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
