### PR TITLE
精简一些重复且不能压缩的代码

### DIFF
--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -213,13 +213,13 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
 
     <script src="../../dist/mip.js"></script>
     <script>
-        document.querySelector('#prerender').addEventListener('click', () => {
-            window.MIP.viewer.page.prerender([
-                'http://localhost:8080/examples/page/tree.html',
-                'http://localhost:8080/examples/page/data.html'
-            ]).then(iframes => {
-                alert('prerender done')
-            })
-        })
+        // document.querySelector('#prerender').addEventListener('click', () => {
+        //     window.MIP.viewer.page.prerender([
+        //         'http://localhost:8080/examples/page/tree.html',
+        //         'http://localhost:8080/examples/page/data.html'
+        //     ]).then(iframes => {
+        //         alert('prerender done')
+        //     })
+        // })
     </script>
 </body>

--- a/packages/mip/src/components/mip-shell/dom.js
+++ b/packages/mip/src/components/mip-shell/dom.js
@@ -7,18 +7,13 @@
 import css from '../../util/dom/css'
 import {
   whenTransitionEnds,
-  nextFrame
+  nextFrame,
+  setHeaderColor,
+  BACK_BUTTON_SVG
 } from '../../page/util/dom'
 import event from '../../util/dom/event'
 import {supportsPassive} from '../../page/util/feature-detect'
 
-const BACK_BUTTON_SVG = [
-  '<svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"',
-    'xmlns:xlink="http://www.w3.org/1999/xlink">',
-    '<path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"',
-      'p-id="3174"></path>',
-  '</svg>'
-].join('')
 const MORE_BUTTON_SVG = [
   '<svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"',
     'xmlns:xlink="http://www.w3.org/1999/xlink">',
@@ -34,7 +29,8 @@ const CLOSE_BUTTON_SVG = [
       'p-id="2954"></path>',
   '</svg>'
 ].join('')
-const MIP_SHELL_HEADER_BUTTON_GROUP = 'mip-shell-header-button-group'
+const MIP_SHELL_HEADER = 'mip-shell-header'
+const MIP_SHELL_HEADER_BUTTON_GROUP = MIP_SHELL_HEADER + '-button-group'
 const MIP_SHELL_HEADER_BUTTON_GROUP_STANDALONE = MIP_SHELL_HEADER_BUTTON_GROUP + '-standalone'
 const MIP_HEADER_BTN = 'mip-header-btn'
 const DATA_BUTTON_NAME = 'data-button-name'
@@ -115,7 +111,7 @@ export function createMoreButtonWrapper (buttonGroup, options = {}) {
  */
 export function createPageMask () {
   let mask = document.createElement('mip-fixed')
-  mask.classList.add('mip-shell-header-mask')
+  mask.classList.add(MIP_SHELL_HEADER + '-mask')
   document.body.appendChild(mask)
 
   return mask
@@ -192,9 +188,9 @@ export function renderHeader (shell, container) {
     ].join('')
   }
   headerHTML += [
-    '<div class="mip-shell-header-logo-title">',
-      `${logo ? `<img class="mip-shell-header-logo" src="${logo}">` : ''}`,
-      `<span class="mip-shell-header-title">${title}</span>`,
+    `<div class="${MIP_SHELL_HEADER}-logo-title">`,
+      `${logo ? `<img class="${MIP_SHELL_HEADER}-logo" src="${logo}">` : ''}`,
+      `<span class="${MIP_SHELL_HEADER}-title">${title}</span>`,
     '</div>'
   ].join('')
 
@@ -221,12 +217,7 @@ export function renderHeader (shell, container) {
   container.innerHTML = headerHTML
 
   // Set color & borderColor & backgroundColor
-  css(container, 'background-color', backgroundColor)
-  css(container.querySelectorAll('svg'), 'fill', color)
-  css(container.querySelector('.mip-shell-header-title'), 'color', color)
-  css(container.querySelector('.mip-shell-header-logo'), 'border-color', borderColor)
-  css(container.querySelector('.mip-shell-header-button-group'), 'border-color', borderColor)
-  css(container.querySelector('.mip-shell-header-button-group .split'), 'background-color', borderColor)
+  setHeaderColor(container, container, color, backgroundColor, borderColor)
 }
 
 export function bindHeaderEvents (shell) {

--- a/packages/mip/src/components/mip-shell/dom.js
+++ b/packages/mip/src/components/mip-shell/dom.js
@@ -12,6 +12,23 @@ import {
 import event from '../../util/dom/event'
 import {supportsPassive} from '../../page/util/feature-detect'
 
+const backButtonSVG = `<svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"
+    p-id="3174"></path>
+</svg>`
+const moreButtonSVG = `<svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path d="M128 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3394" fill="currentColor"></path>
+  <path d="M512 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3395" fill="currentColor"></path>
+  <path d="M896 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3396" fill="currentColor"></path>
+</svg>`
+const closeButtonSVG = `<svg t="1530857971603" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2953"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path  fill="currentColor" d="M586.026667 533.248l208.789333-208.576c9.856-8.874667 15.488-21.248 15.850667-34.858667a53.717333 53.717333 0 0 0-15.829334-39.146666 48.042667 48.042667 0 0 0-36.224-15.872c-14.165333 0-27.584 5.632-37.802666 15.850666L512 459.221333l-208.789333-208.576a48.042667 48.042667 0 0 0-36.245334-15.850666c-14.144 0-27.562667 5.632-37.781333 15.850666A48.085333 48.085333 0 0 0 213.333333 285.504a53.717333 53.717333 0 0 0 15.850667 39.168l208.789333 208.576-208.576 208.853333a48.085333 48.085333 0 0 0-15.850666 34.88 53.717333 53.717333 0 0 0 15.850666 39.146667c9.194667 10.24 22.058667 15.872 36.224 15.872 14.144 0 27.562667-5.632 37.802667-15.850667L512 607.274667l208.597333 208.853333c9.216 10.24 22.08 15.872 36.224 15.872s27.584-5.632 37.802667-15.850667c9.856-8.874667 15.488-21.269333 15.850667-34.88a53.717333 53.717333 0 0 0-15.850667-39.146666l-208.597333-208.853334z"
+    p-id="2954"></path>
+</svg>`
+
 function renderMoreButton ({name, text, link} = {}) {
   if (!name || !text) {
     return
@@ -142,18 +159,13 @@ export function renderHeader (shell, container) {
   let headerHTML = `
     ${showBackIcon ? `<a href="javascript:void(0)" class="back-button" mip-header-btn
       data-button-name="back">
-      <svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"
-        xmlns:xlink="http://www.w3.org/1999/xlink">
-        <path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"
-          p-id="3174"></path>
-      </svg>
+      ${backButtonSVG}
     </a>` : ''}
     <div class="mip-shell-header-logo-title">
       ${logo ? `<img class="mip-shell-header-logo" src="${logo}">` : ''}
       <span class="mip-shell-header-title">${title}</span>
     </div>
   `
-
   let moreFlag = Array.isArray(buttonGroup) && buttonGroup.length > 0
   let closeFlag = !window.MIP.standalone && shell.showHeaderCloseButton()
 
@@ -162,20 +174,11 @@ export function renderHeader (shell, container) {
     headerHTML += `
       <div class="mip-shell-header-button-group">
         <div class="button more" mip-header-btn data-button-name="more">
-          <svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"
-            xmlns:xlink="http://www.w3.org/1999/xlink">
-            <path d="M128 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3394" fill="currentColor"></path>
-            <path d="M512 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3395" fill="currentColor"></path>
-            <path d="M896 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3396" fill="currentColor"></path>
-          </svg>
+          ${moreButtonSVG}
         </div>
         <div class="split"></div>
         <div class="button close" mip-header-btn data-button-name="close">
-          <svg t="1530857971603" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2953"
-            xmlns:xlink="http://www.w3.org/1999/xlink">
-            <path  fill="currentColor" d="M586.026667 533.248l208.789333-208.576c9.856-8.874667 15.488-21.248 15.850667-34.858667a53.717333 53.717333 0 0 0-15.829334-39.146666 48.042667 48.042667 0 0 0-36.224-15.872c-14.165333 0-27.584 5.632-37.802666 15.850666L512 459.221333l-208.789333-208.576a48.042667 48.042667 0 0 0-36.245334-15.850666c-14.144 0-27.562667 5.632-37.781333 15.850666A48.085333 48.085333 0 0 0 213.333333 285.504a53.717333 53.717333 0 0 0 15.850667 39.168l208.789333 208.576-208.576 208.853333a48.085333 48.085333 0 0 0-15.850666 34.88 53.717333 53.717333 0 0 0 15.850666 39.146667c9.194667 10.24 22.058667 15.872 36.224 15.872 14.144 0 27.562667-5.632 37.802667-15.850667L512 607.274667l208.597333 208.853333c9.216 10.24 22.08 15.872 36.224 15.872s27.584-5.632 37.802667-15.850667c9.856-8.874667 15.488-21.269333 15.850667-34.88a53.717333 53.717333 0 0 0-15.850667-39.146666l-208.597333-208.853334z"
-              p-id="2954"></path>
-          </svg>
+          ${closeButtonSVG}
         </div>
       </div>
    `
@@ -183,12 +186,7 @@ export function renderHeader (shell, container) {
     // only more
     headerHTML += `
       <div class="mip-shell-header-button-group-standalone more" mip-header-btn data-button-name="more">
-        <svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"
-          xmlns:xlink="http://www.w3.org/1999/xlink">
-          <path d="M128 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3394" fill="currentColor"></path>
-          <path d="M512 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3395" fill="currentColor"></path>
-          <path d="M896 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3396" fill="currentColor"></path>
-        </svg>
+        ${moreButtonSVG}
       </div>
    `
   } else if (!moreFlag && closeFlag) {
@@ -196,11 +194,7 @@ export function renderHeader (shell, container) {
     headerHTML += `
       <div class="mip-shell-header-button-group-standalone">
         <div class="button close" mip-header-btn data-button-name="close">
-          <svg t="1530857971603" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2953"
-            xmlns:xlink="http://www.w3.org/1999/xlink">
-            <path  fill="currentColor" d="M586.026667 533.248l208.789333-208.576c9.856-8.874667 15.488-21.248 15.850667-34.858667a53.717333 53.717333 0 0 0-15.829334-39.146666 48.042667 48.042667 0 0 0-36.224-15.872c-14.165333 0-27.584 5.632-37.802666 15.850666L512 459.221333l-208.789333-208.576a48.042667 48.042667 0 0 0-36.245334-15.850666c-14.144 0-27.562667 5.632-37.781333 15.850666A48.085333 48.085333 0 0 0 213.333333 285.504a53.717333 53.717333 0 0 0 15.850667 39.168l208.789333 208.576-208.576 208.853333a48.085333 48.085333 0 0 0-15.850666 34.88 53.717333 53.717333 0 0 0 15.850666 39.146667c9.194667 10.24 22.058667 15.872 36.224 15.872 14.144 0 27.562667-5.632 37.802667-15.850667L512 607.274667l208.597333 208.853333c9.216 10.24 22.08 15.872 36.224 15.872s27.584-5.632 37.802667-15.850667c9.856-8.874667 15.488-21.269333 15.850667-34.88a53.717333 53.717333 0 0 0-15.850667-39.146666l-208.597333-208.853334z"
-              p-id="2954"></path>
-          </svg>
+          ${closeButtonSVG}
         </div>
       </div>
     `

--- a/packages/mip/src/components/mip-shell/dom.js
+++ b/packages/mip/src/components/mip-shell/dom.js
@@ -12,33 +12,59 @@ import {
 import event from '../../util/dom/event'
 import {supportsPassive} from '../../page/util/feature-detect'
 
-const backButtonSVG = `<svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"
-    p-id="3174"></path>
-</svg>`
-const moreButtonSVG = `<svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <path d="M128 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3394" fill="currentColor"></path>
-  <path d="M512 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3395" fill="currentColor"></path>
-  <path d="M896 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3396" fill="currentColor"></path>
-</svg>`
-const closeButtonSVG = `<svg t="1530857971603" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2953"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <path  fill="currentColor" d="M586.026667 533.248l208.789333-208.576c9.856-8.874667 15.488-21.248 15.850667-34.858667a53.717333 53.717333 0 0 0-15.829334-39.146666 48.042667 48.042667 0 0 0-36.224-15.872c-14.165333 0-27.584 5.632-37.802666 15.850666L512 459.221333l-208.789333-208.576a48.042667 48.042667 0 0 0-36.245334-15.850666c-14.144 0-27.562667 5.632-37.781333 15.850666A48.085333 48.085333 0 0 0 213.333333 285.504a53.717333 53.717333 0 0 0 15.850667 39.168l208.789333 208.576-208.576 208.853333a48.085333 48.085333 0 0 0-15.850666 34.88 53.717333 53.717333 0 0 0 15.850666 39.146667c9.194667 10.24 22.058667 15.872 36.224 15.872 14.144 0 27.562667-5.632 37.802667-15.850667L512 607.274667l208.597333 208.853333c9.216 10.24 22.08 15.872 36.224 15.872s27.584-5.632 37.802667-15.850667c9.856-8.874667 15.488-21.269333 15.850667-34.88a53.717333 53.717333 0 0 0-15.850667-39.146666l-208.597333-208.853334z"
-    p-id="2954"></path>
-</svg>`
+const BACK_BUTTON_SVG = [
+  '<svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"',
+    'xmlns:xlink="http://www.w3.org/1999/xlink">',
+    '<path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"',
+      'p-id="3174"></path>',
+  '</svg>'
+].join('')
+const MORE_BUTTON_SVG = [
+  '<svg t="1530857985972" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3393"',
+    'xmlns:xlink="http://www.w3.org/1999/xlink">',
+    '<path d="M128 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3394" fill="currentColor"></path>',
+    '<path d="M512 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3395" fill="currentColor"></path>',
+    '<path d="M896 512m-128 0a128 128 0 1 0 256 0 128 128 0 1 0-256 0Z" p-id="3396" fill="currentColor"></path>',
+  '</svg>'
+].join('')
+const CLOSE_BUTTON_SVG = [
+  '<svg t="1530857971603" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2953"',
+    'xmlns:xlink="http://www.w3.org/1999/xlink">',
+    '<path  fill="currentColor" d="M586.026667 533.248l208.789333-208.576c9.856-8.874667 15.488-21.248 15.850667-34.858667a53.717333 53.717333 0 0 0-15.829334-39.146666 48.042667 48.042667 0 0 0-36.224-15.872c-14.165333 0-27.584 5.632-37.802666 15.850666L512 459.221333l-208.789333-208.576a48.042667 48.042667 0 0 0-36.245334-15.850666c-14.144 0-27.562667 5.632-37.781333 15.850666A48.085333 48.085333 0 0 0 213.333333 285.504a53.717333 53.717333 0 0 0 15.850667 39.168l208.789333 208.576-208.576 208.853333a48.085333 48.085333 0 0 0-15.850666 34.88 53.717333 53.717333 0 0 0 15.850666 39.146667c9.194667 10.24 22.058667 15.872 36.224 15.872 14.144 0 27.562667-5.632 37.802667-15.850667L512 607.274667l208.597333 208.853333c9.216 10.24 22.08 15.872 36.224 15.872s27.584-5.632 37.802667-15.850667c9.856-8.874667 15.488-21.269333 15.850667-34.88a53.717333 53.717333 0 0 0-15.850667-39.146666l-208.597333-208.853334z"',
+      'p-id="2954"></path>',
+  '</svg>'
+].join('')
+const MIP_SHELL_HEADER_BUTTON_GROUP = 'mip-shell-header-button-group'
+const MIP_SHELL_HEADER_BUTTON_GROUP_STANDALONE = MIP_SHELL_HEADER_BUTTON_GROUP + '-standalone'
+const MIP_HEADER_BTN = 'mip-header-btn'
+const DATA_BUTTON_NAME = 'data-button-name'
+
+function getSVGWrapper(type, standalone) {
+  if (standalone) {
+    return [
+      `<div class="${MIP_SHELL_HEADER_BUTTON_GROUP_STANDALONE}" ${MIP_HEADER_BTN} ${DATA_BUTTON_NAME}="${type}">`,
+        type === 'more' ? MORE_BUTTON_SVG : CLOSE_BUTTON_SVG,
+      '</div>'
+    ].join('')
+  }
+
+  return [
+    `<div class="button ${type}" ${MIP_HEADER_BTN} ${DATA_BUTTON_NAME}="${type}">`,
+      type === 'more' ? MORE_BUTTON_SVG : CLOSE_BUTTON_SVG,
+    '</div>'
+  ].join('')
+}
 
 function renderMoreButton ({name, text, link} = {}) {
   if (!name || !text) {
     return
   }
 
-  return `
-    <div class="mip-shell-button" mip-header-btn data-button-name="${name}">
-      ${link ? `<a mip-link href="${link}">${text}</a>` : text}
-    </div>
-  `
+  return [
+    `<div class="mip-shell-button" mip-header-btn data-button-name="${name}">`,
+      `${link ? `<a mip-link href="${link}">${text}</a>` : text}`,
+    '</div>'
+  ].join('')
 }
 
 /**
@@ -156,48 +182,40 @@ export function renderHeader (shell, container) {
   }
   let showBackIcon = !pageMeta.view.isIndex
 
-  let headerHTML = `
-    ${showBackIcon ? `<a href="javascript:void(0)" class="back-button" mip-header-btn
-      data-button-name="back">
-      ${backButtonSVG}
-    </a>` : ''}
-    <div class="mip-shell-header-logo-title">
-      ${logo ? `<img class="mip-shell-header-logo" src="${logo}">` : ''}
-      <span class="mip-shell-header-title">${title}</span>
-    </div>
-  `
+  // 为了代码体积考虑，拼接 HTML 代码看起来比较复杂
+  let headerHTML = ''
+  if (showBackIcon) {
+    headerHTML += [
+      `<a href="javascript:void(0)" class="back-button" ${MIP_HEADER_BTN} ${DATA_BUTTON_NAME}="back">`,
+        BACK_BUTTON_SVG,
+      '</a>'
+    ].join('')
+  }
+  headerHTML += [
+    '<div class="mip-shell-header-logo-title">',
+      `${logo ? `<img class="mip-shell-header-logo" src="${logo}">` : ''}`,
+      `<span class="mip-shell-header-title">${title}</span>`,
+    '</div>'
+  ].join('')
+
   let moreFlag = Array.isArray(buttonGroup) && buttonGroup.length > 0
   let closeFlag = !window.MIP.standalone && shell.showHeaderCloseButton()
 
   if (moreFlag && closeFlag) {
     // more & close
-    headerHTML += `
-      <div class="mip-shell-header-button-group">
-        <div class="button more" mip-header-btn data-button-name="more">
-          ${moreButtonSVG}
-        </div>
-        <div class="split"></div>
-        <div class="button close" mip-header-btn data-button-name="close">
-          ${closeButtonSVG}
-        </div>
-      </div>
-   `
+    headerHTML += [
+      `<div class="${MIP_SHELL_HEADER_BUTTON_GROUP}">`,
+        getSVGWrapper('more'),
+        '<div class="split"></div>',
+        getSVGWrapper('close'),
+      '</div>'
+    ].join('')
   } else if (moreFlag && !closeFlag) {
     // only more
-    headerHTML += `
-      <div class="mip-shell-header-button-group-standalone more" mip-header-btn data-button-name="more">
-        ${moreButtonSVG}
-      </div>
-   `
+    headerHTML += getSVGWrapper('more', true)
   } else if (!moreFlag && closeFlag) {
     // only close
-    headerHTML += `
-      <div class="mip-shell-header-button-group-standalone">
-        <div class="button close" mip-header-btn data-button-name="close">
-          ${closeButtonSVG}
-        </div>
-      </div>
-    `
+    headerHTML += getSVGWrapper('close', true)
   }
 
   container.innerHTML = headerHTML

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -81,15 +81,13 @@ class MipShell extends CustomElement {
     if (ele) {
       try {
         tmpShellConfig = JSON.parse(ele.textContent.toString()) || {}
-        if (tmpShellConfig.alwaysReadConfigOnLoad !== undefined) {
-          this.alwaysReadConfigOnLoad = tmpShellConfig.alwaysReadConfigOnLoad
-        }
-        if (tmpShellConfig.transitionContainsHeader !== undefined) {
-          this.transitionContainsHeader = tmpShellConfig.transitionContainsHeader
-        }
-        if (tmpShellConfig.ignoreWarning !== undefined) {
-          this.ignoreWarning = tmpShellConfig.ignoreWarning
-        }
+        // 开头的分号是为了应对 rollup 的 BUG，否则会导致方括号和上一句的 || {} 连接在一起从而不执行
+        ;['alwaysReadConfigOnLoad', 'transitionContainsHeader', 'ignoreWarning'].forEach(key => {
+          if (tmpShellConfig[key] !== undefined) {
+            this[key] = tmpShellConfig[key]
+          }
+        })
+
         if (!tmpShellConfig.routes) {
           !this.ignoreWarning && console.warn('检测到 MIP Shell 配置没有包含 `routes` 数组，MIP 将自动生成一条默认的路由配置。')
           tmpShellConfig.routes = [{

--- a/packages/mip/src/components/mip-shell/util.js
+++ b/packages/mip/src/components/mip-shell/util.js
@@ -34,6 +34,5 @@ export /* istanbul ignore next */ function checkRouteConfig (route) {
 }
 
 function routeConfigWarning (configName, replaceName, route) {
-  console.warn(`检测到一条路由配置中没有设置 ${configName} 选项，MIP 将使用 ${replaceName} 代替。`)
-  console.warn(route)
+  console.warn(`检测到一条路由配置中没有设置 ${configName} 选项，MIP 将使用 ${replaceName} 代替。\n`, route)
 }

--- a/packages/mip/src/components/mip-shell/util.js
+++ b/packages/mip/src/components/mip-shell/util.js
@@ -33,6 +33,7 @@ export /* istanbul ignore next */ function checkRouteConfig (route) {
   }
 }
 
+/* istanbul ignore next */
 function routeConfigWarning (configName, replaceName, route) {
   console.warn(`检测到一条路由配置中没有设置 ${configName} 选项，MIP 将使用 ${replaceName} 代替。\n`, route)
 }

--- a/packages/mip/src/components/mip-shell/util.js
+++ b/packages/mip/src/components/mip-shell/util.js
@@ -23,16 +23,17 @@ export /* istanbul ignore next */ function checkRouteConfig (route) {
   if (!route) {
     console.warn('检测到空的路由配置，MIP 将跳过这条配置')
   } else if (!route.pattern) {
-    console.warn('检测到一条路由配置中没有设置 `pattern` 选项，MIP 将使用 * 代替。')
-    console.warn(route)
+    routeConfigWarning('pattern', '*', route)
   } else if (!route.meta) {
-    console.warn('检测到一条路由配置中没有设置 `meta` 选项，MIP 将使用默认的 `meta` 配置代替。')
-    console.warn(route)
+    routeConfigWarning('meta', 'meta', route)
   } else if (!route.meta.header) {
-    console.warn('检测到一条路由配置中没有设置 `meta.header` 选项，MIP 将使用默认的 `meta.header` 配置代替。')
-    console.warn(route)
+    routeConfigWarning('meta.header', 'meta.header', route)
   } else if (!route.meta.view) {
-    console.warn('检测到一条路由配置中没有设置 `meta.view` 选项，MIP 将使用默认的 `meta.view` 配置代替。')
-    console.warn(route)
+    routeConfigWarning('meta.view', 'meta.view', route)
   }
+}
+
+function routeConfigWarning (configName, replaceName, route) {
+  console.warn(`检测到一条路由配置中没有设置 ${configName} 选项，MIP 将使用 ${replaceName} 代替。`)
+  console.warn(route)
 }

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -415,10 +415,9 @@ class Page {
             // 预加载前已经存在，直接返回即可
             resolve(iframe)
             return
-          } else {
-            // 如果在断网情况下，内部的 window.MIP 会是一个数组。这样实际上这个 iframe 也不可复用，应当删除
-            iframe.parentNode.removeChild(iframe)
           }
+          // 如果在断网情况下，内部的 window.MIP 会是一个数组。这样实际上这个 iframe 也不可复用，应当删除
+          iframe.parentNode.removeChild(iframe)
         }
 
         createIFrame({fullpath: fullpath + '#prerender=1', pageId}, {

--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -12,6 +12,18 @@ import {raf, transitionEndEvent, animationEndEvent} from './feature-detect'
 import {normalizeLocation} from './route'
 import viewport from '../../viewport'
 
+const MIP_SHELL_HEADER = 'mip-shell-header'
+const MIP_PAGE_LOADING_WRAPPER = 'mip-page-loading-wrapper'
+const MIP_PAGE_FADE_HEADER_WRAPPER = 'mip-page-fade-header-wrapper'
+
+export const BACK_BUTTON_SVG = [
+  '<svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"',
+    'xmlns:xlink="http://www.w3.org/1999/xlink">',
+    '<path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"',
+      'p-id="3174"></path>',
+  '</svg>'
+].join('')
+
 export function createIFrame ({fullpath, pageId}, {onLoad, onError} = {}) {
   let container = document.querySelector(`.${MIP_IFRAME_CONTAINER}[data-page-id="${pageId}"]`)
 
@@ -82,38 +94,48 @@ export function hideAllIFrames () {
   }
 }
 
+function getHeaderHTML (logo, isFake) {
+  return [
+    `<div class="${MIP_SHELL_HEADER}">`,
+      `<span ${isFake ? '' : 'mip-header-btn'} class="back-button">`,
+        BACK_BUTTON_SVG,
+      '</span>',
+      `<div class="${MIP_SHELL_HEADER}-logo-title">`,
+        `<img class="${MIP_SHELL_HEADER}-logo" src="${logo}">`,
+        `<span class="${MIP_SHELL_HEADER}-title"></span>`,
+      '</div>',
+    '</div>'
+  ].join('')
+}
+
 /**
  * Create loading div
  *
  * @param {Object} pageMeta Page meta info
  */
 export function createLoading (pageMeta) {
-  let loading = document.querySelector('#mip-page-loading-wrapper')
+  let loading = document.querySelector('#' + MIP_PAGE_LOADING_WRAPPER)
   if (loading) {
     return loading
   }
 
   let logo = pageMeta ? (pageMeta.header.logo || '') : ''
   loading = document.createElement('mip-fixed')
-  loading.id = 'mip-page-loading-wrapper'
-  loading.setAttribute('class', 'mip-page-loading-wrapper')
-  loading.innerHTML = `
-    <div class="mip-shell-header">
-      <span mip-header-btn class="back-button">
-        <svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"
-          xmlns:xlink="http://www.w3.org/1999/xlink">
-          <path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"
-            p-id="3174"></path>
-        </svg>
-      </span>
-      <div class="mip-shell-header-logo-title">
-        <img class="mip-shell-header-logo" src="${logo}">
-        <span class="mip-shell-header-title"></span>
-      </div>
-    </div>
-  `
+  loading.id = MIP_PAGE_LOADING_WRAPPER
+  loading.setAttribute('class', MIP_PAGE_LOADING_WRAPPER)
+  loading.innerHTML = getHeaderHTML(logo, false)
   document.body.appendChild(loading)
   return loading
+}
+
+// 可能已经没人用，之后考虑删除吧
+export function setHeaderColor(container, dom, color, backgroundColor, borderColor) {
+  css(container, 'background-color', backgroundColor)
+  css(dom.querySelectorAll('svg'), 'fill', color)
+  css(dom.querySelector(`.${MIP_SHELL_HEADER}-title`), 'color', color)
+  css(dom.querySelector(`.${MIP_SHELL_HEADER}-logo`), 'border-color', borderColor)
+  css(dom.querySelector(`.${MIP_SHELL_HEADER}-button-group`), 'border-color', borderColor)
+  css(dom.querySelector(`.${MIP_SHELL_HEADER}-button-group .split`), 'background-color', borderColor)
 }
 
 /**
@@ -127,10 +149,11 @@ export function createLoading (pageMeta) {
  * @returns {HTMLElement}
  */
 export function getLoading (targetMeta, {onlyHeader, transitionContainsHeader} = {}) {
-  let loading = document.querySelector('#mip-page-loading-wrapper')
+  let loadingSelector = '#' + MIP_PAGE_LOADING_WRAPPER
+  let loading = document.querySelector(loadingSelector)
   if (!loading) {
     createLoading()
-    loading = document.querySelector('#mip-page-loading-wrapper')
+    loading = document.querySelector(loadingSelector)
   }
 
   if (!targetMeta) {
@@ -149,13 +172,14 @@ export function getLoading (targetMeta, {onlyHeader, transitionContainsHeader} =
     loading.classList.toggle('only-header', !!onlyHeader)
   }
 
+  let mipShellHeader = loading.querySelector('.' + MIP_SHELL_HEADER)
   if (!transitionContainsHeader || !targetMeta.header.show) {
-    css(loading.querySelector('.mip-shell-header'), 'display', 'none')
+    css(mipShellHeader, 'display', 'none')
   } else {
-    css(loading.querySelector('.mip-shell-header'), 'display', 'flex')
+    css(mipShellHeader, 'display', 'flex')
   }
 
-  let $logo = loading.querySelector('.mip-shell-header-logo')
+  let $logo = loading.querySelector(`.${MIP_SHELL_HEADER}-logo`)
   if (targetMeta.header.logo) {
     $logo.setAttribute('src', targetMeta.header.logo)
     css($logo, 'display', 'block')
@@ -164,7 +188,7 @@ export function getLoading (targetMeta, {onlyHeader, transitionContainsHeader} =
   }
 
   if (targetMeta.header.title) {
-    loading.querySelector('.mip-shell-header-title').innerHTML = targetMeta.header.title
+    loading.querySelector(`.${MIP_SHELL_HEADER}-title`).innerHTML = targetMeta.header.title
   }
 
   css(loading.querySelector('.back-button'), 'display', targetMeta.view.isIndex ? 'none' : 'flex')
@@ -176,44 +200,25 @@ export function getLoading (targetMeta, {onlyHeader, transitionContainsHeader} =
       borderColor,
       backgroundColor = '#ffffff'
     } = targetMeta.header
-    let loadingContainer = loading.querySelector('.mip-shell-header')
+    let loadingContainer = loading.querySelector('.' + MIP_SHELL_HEADER)
 
-    css(loadingContainer, 'background-color', backgroundColor)
-    css(loading.querySelectorAll('svg'), 'fill', color)
-    css(loading.querySelector('.mip-shell-header-title'), 'color', color)
-    css(loading.querySelector('.mip-shell-header-logo'), 'border-color', borderColor)
-    css(loading.querySelector('.mip-shell-header-button-group'), 'border-color', borderColor)
-    css(loading.querySelector('.mip-shell-header-button-group .split'), 'background-color', borderColor)
+    setHeaderColor(loadingContainer, loading, color, backgroundColor, borderColor)
   }
 
   return loading
 }
 
 export function createFadeHeader (pageMeta) {
-  let fadeHeader = document.querySelector('#mip-page-fade-header-wrapper')
+  let fadeHeader = document.querySelector('#' + MIP_PAGE_FADE_HEADER_WRAPPER)
   if (fadeHeader) {
     return fadeHeader
   }
 
   let logo = pageMeta ? (pageMeta.header.logo || '') : ''
   fadeHeader = document.createElement('mip-fixed')
-  fadeHeader.id = 'mip-page-fade-header-wrapper'
-  fadeHeader.setAttribute('class', 'mip-page-fade-header-wrapper')
-  fadeHeader.innerHTML = `
-    <div class="mip-shell-header">
-      <span class="back-button">
-        <svg t="1530857979993" class="icon" style="" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="3173"
-          xmlns:xlink="http://www.w3.org/1999/xlink">
-          <path  fill="currentColor" d="M348.949333 511.829333L774.250667 105.728C783.978667 96 789.333333 83.712 789.333333 71.104c0-12.629333-5.354667-24.917333-15.082666-34.645333-9.728-9.728-22.037333-15.082667-34.645334-15.082667-12.586667 0-24.917333 5.333333-34.624 15.082667L249.557333 471.616A62.570667 62.570667 0 0 0 234.666667 512c0 10.410667 1.130667 25.408 14.890666 40.042667l455.424 435.605333c9.706667 9.728 22.016 15.082667 34.624 15.082667s24.917333-5.354667 34.645334-15.082667c9.728-9.728 15.082667-22.037333 15.082666-34.645333 0-12.608-5.354667-24.917333-15.082666-34.645334L348.949333 511.829333z"
-            p-id="3174"></path>
-        </svg>
-      </span>
-      <div class="mip-shell-header-logo-title">
-        <img class="mip-shell-header-logo" src="${logo}">
-        <span class="mip-shell-header-title"></span>
-      </div>
-    </div>
-  `
+  fadeHeader.id = MIP_PAGE_FADE_HEADER_WRAPPER
+  fadeHeader.setAttribute('class', MIP_PAGE_FADE_HEADER_WRAPPER)
+  fadeHeader.innerHTML = getHeaderHTML(logo, true)
   document.body.appendChild(fadeHeader)
   return fadeHeader
 }
@@ -227,17 +232,18 @@ export function createFadeHeader (pageMeta) {
  * @returns {HTMLElement}
  */
 export function getFadeHeader (targetMeta, sourceMeta) {
-  let fadeHeader = document.querySelector('#mip-page-fade-header-wrapper')
+  let fadeHeaderSelector = '#' + MIP_PAGE_FADE_HEADER_WRAPPER
+  let fadeHeader = document.querySelector(fadeHeaderSelector)
   if (!fadeHeader) {
     createFadeHeader()
-    fadeHeader = document.querySelector('#mip-page-fade-header-wrapper')
+    fadeHeader = document.querySelector(fadeHeaderSelector)
   }
 
   if (!targetMeta) {
     return fadeHeader
   }
 
-  let $logo = fadeHeader.querySelector('.mip-shell-header-logo')
+  let $logo = fadeHeader.querySelector(`.${MIP_SHELL_HEADER}-logo`)
   if (targetMeta.header.logo) {
     $logo.setAttribute('src', targetMeta.header.logo)
     css($logo, 'display', 'block')
@@ -246,7 +252,7 @@ export function getFadeHeader (targetMeta, sourceMeta) {
   }
 
   if (targetMeta.header.title) {
-    fadeHeader.querySelector('.mip-shell-header-title').innerHTML = targetMeta.header.title
+    fadeHeader.querySelector(`.${MIP_SHELL_HEADER}-title`).innerHTML = targetMeta.header.title
   }
 
   css(fadeHeader.querySelector('.back-button'), 'display', targetMeta.view.isIndex ? 'none' : 'flex')
@@ -258,14 +264,9 @@ export function getFadeHeader (targetMeta, sourceMeta) {
     borderColor = '#e1e1e1',
     backgroundColor = '#ffffff'
   } = colorConfig
-  let fadeHeaderContainer = fadeHeader.querySelector('.mip-shell-header')
+  let fadeHeaderContainer = fadeHeader.querySelector('.' + MIP_SHELL_HEADER)
 
-  css(fadeHeaderContainer, 'background-color', backgroundColor)
-  css(fadeHeader.querySelectorAll('svg'), 'fill', color)
-  css(fadeHeader.querySelector('.mip-shell-header-title'), 'color', color)
-  css(fadeHeader.querySelector('.mip-shell-header-logo'), 'border-color', borderColor)
-  css(fadeHeader.querySelector('.mip-shell-header-button-group'), 'border-color', borderColor)
-  css(fadeHeader.querySelector('.mip-shell-header-button-group .split'), 'background-color', borderColor)
+  setHeaderColor(fadeHeaderContainer, fadeHeader, color, backgroundColor, borderColor)
 
   return fadeHeader
 }

--- a/packages/mip/src/styles/mip-shell.less
+++ b/packages/mip/src/styles/mip-shell.less
@@ -133,7 +133,7 @@ mip-shell * {
     right: 0;
     height: 30px;
     width: 40px;
-    &>svg {
+    svg {
       width: 16px;
       height: 16px;
     }


### PR DESCRIPTION
本次改动主要针对相似度大但不能压缩的代码（例如报错信息的字符串，SVG内容等），对功能上没有任何改变，目的还是为了缩小 mip.js 的体积