### PR TITLE
Remove build asynchronous and performance optimization

### DIFF
--- a/packages/mip/package-lock.json
+++ b/packages/mip/package-lock.json
@@ -3182,11 +3182,11 @@
       }
     },
     "document-register-element": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.1.tgz",
-      "integrity": "sha512-BYZMAyT6Jryi0hYeZI7JrjHEpl53252IUxeXlyBvRvnxALWW4RXj4trSxewAj3OLFjS05Zncb6lvjft7lu0tNg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.13.1.tgz",
+      "integrity": "sha512-92ZyLDKg9j4rOll//NNXj25f+8rAzOkYsGJonhugKwXfeqH7bzs8Ucpvey0WzZ2ZzKdrvW9RnUw3UyOZ/uhBFw==",
       "requires": {
-        "lightercollective": "^0.0.0"
+        "lightercollective": "^0.1.0"
       }
     },
     "dom-serialize": {
@@ -6120,9 +6120,9 @@
       "dev": true
     },
     "lightercollective": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
-      "integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.1.0.tgz",
+      "integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ=="
     },
     "load-json-file": {
       "version": "1.1.0",

--- a/packages/mip/package-lock.json
+++ b/packages/mip/package-lock.json
@@ -34,15 +34,15 @@
       "resolved": "http://registry.npm.taobao.org/@vue/component-compiler-utils/download/@vue/component-compiler-utils-1.3.1.tgz",
       "integrity": "sha1-aG8LkT1ZWQrjJ7Khy0ttm5Mbvg4=",
       "requires": {
-        "consolidate": "0.15.1",
-        "hash-sum": "1.0.2",
-        "lru-cache": "4.1.3",
-        "merge-source-map": "1.1.0",
-        "postcss": "6.0.22",
-        "postcss-selector-parser": "3.1.1",
-        "prettier": "1.13.5",
-        "source-map": "0.5.7",
-        "vue-template-es2015-compiler": "1.6.0"
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^6.0.20",
+        "postcss-selector-parser": "^3.1.1",
+        "prettier": "^1.13.0",
+        "source-map": "^0.5.6",
+        "vue-template-es2015-compiler": "^1.6.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -50,9 +50,9 @@
           "resolved": "http://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         },
         "source-map": {
@@ -71,8 +71,8 @@
         "@webassemblyjs/helper-module-context": "1.5.12",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
         "@webassemblyjs/wast-parser": "1.5.12",
-        "debug": "3.1.0",
-        "mamacro": "0.0.3"
+        "debug": "^3.1.0",
+        "mamacro": "^0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -104,7 +104,7 @@
       "integrity": "sha1-Hw3lqqvv74muwxT3+XAAnNFZxz0=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -139,8 +139,8 @@
       "integrity": "sha1-tViMp4szuKDadfmrjHaaNwe6qGE=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "mamacro": "0.0.3"
+        "debug": "^3.1.0",
+        "mamacro": "^0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -170,7 +170,7 @@
         "@webassemblyjs/helper-buffer": "1.5.12",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
         "@webassemblyjs/wasm-gen": "1.5.12",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -190,7 +190,7 @@
       "integrity": "sha1-7pV0vFWIiPEwl84+eQDf8jTqGaQ=",
       "dev": true,
       "requires": {
-        "ieee754": "1.1.12"
+        "ieee754": "^1.1.11"
       }
     },
     "@webassemblyjs/leb128": {
@@ -199,7 +199,7 @@
       "integrity": "sha1-AwjuxlJ2XuVn2KX6EItPCyW0WOE=",
       "dev": true,
       "requires": {
-        "leb": "0.3.0"
+        "leb": "^0.3.0"
       }
     },
     "@webassemblyjs/utf8": {
@@ -222,7 +222,7 @@
         "@webassemblyjs/wasm-opt": "1.5.12",
         "@webassemblyjs/wasm-parser": "1.5.12",
         "@webassemblyjs/wast-printer": "1.5.12",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -259,7 +259,7 @@
         "@webassemblyjs/helper-buffer": "1.5.12",
         "@webassemblyjs/wasm-gen": "1.5.12",
         "@webassemblyjs/wasm-parser": "1.5.12",
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -298,8 +298,8 @@
         "@webassemblyjs/helper-api-error": "1.5.12",
         "@webassemblyjs/helper-code-frame": "1.5.12",
         "@webassemblyjs/helper-fsm": "1.5.12",
-        "long": "3.2.0",
-        "mamacro": "0.0.3"
+        "long": "^3.2.0",
+        "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/wast-printer": {
@@ -310,7 +310,7 @@
       "requires": {
         "@webassemblyjs/ast": "1.5.12",
         "@webassemblyjs/wast-parser": "1.5.12",
-        "long": "3.2.0"
+        "long": "^3.2.0"
       }
     },
     "abbrev": {
@@ -325,7 +325,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -339,7 +339,7 @@
       "resolved": "http://registry.npm.taobao.org/acorn-dynamic-import/download/acorn-dynamic-import-3.0.0.tgz",
       "integrity": "sha1-kBzu5Mf6rvfgetKkfokGddpQong=",
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.0"
       }
     },
     "addressparser": {
@@ -361,7 +361,7 @@
       "integrity": "sha1-mDi1wzkrliutAx5qTF4QJKvsRc4=",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -370,10 +370,10 @@
       "integrity": "sha1-iOvBJjxxM5N9EIuAxVcuZOHZMi0=",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
       }
     },
     "ajv-keywords": {
@@ -388,9 +388,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -399,7 +399,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -422,11 +422,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bitsyntax": "0.0.4",
-        "bluebird": "3.5.1",
+        "bitsyntax": "~0.0.4",
+        "bluebird": "^3.4.6",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.1.14",
-        "safe-buffer": "5.1.1"
+        "readable-stream": "1.x >=1.1.9",
+        "safe-buffer": "^5.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -436,10 +436,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -461,7 +461,7 @@
       "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
-        "color-convert": "1.9.2"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -470,8 +470,8 @@
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "aproba": {
@@ -485,7 +485,7 @@
       "resolved": "http://registry.npm.taobao.org/argparse/download/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -527,7 +527,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -569,9 +569,9 @@
       "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -628,7 +628,7 @@
       "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "async-each": {
@@ -658,12 +658,12 @@
       "resolved": "http://registry.npm.taobao.org/autoprefixer/download/autoprefixer-8.6.4.tgz",
       "integrity": "sha1-a/UB3kJqO5WXP10jfbzJGB6ZBNI=",
       "requires": {
-        "browserslist": "3.2.8",
-        "caniuse-lite": "1.0.30000859",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.23",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^3.2.8",
+        "caniuse-lite": "^1.0.30000859",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.23",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "caniuse-lite": {
@@ -676,9 +676,9 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.4.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         }
       }
@@ -710,7 +710,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9"
+            "debug": "^2.2.0"
           }
         }
       }
@@ -720,9 +720,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-code-frame/download/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -735,11 +735,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -754,25 +754,25 @@
       "resolved": "http://registry.npm.taobao.org/babel-core/download/babel-core-6.26.3.tgz",
       "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -787,14 +787,14 @@
       "resolved": "http://registry.npm.taobao.org/babel-generator/download/babel-generator-6.26.1.tgz",
       "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -809,9 +809,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-builder-binary-assignment-operator-visitor/download/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -819,10 +819,10 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-call-delegate/download/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -830,10 +830,10 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-define-map/download/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -841,9 +841,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-explode-assignable-expression/download/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -851,11 +851,11 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-function-name/download/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -863,8 +863,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-get-function-arity/download/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -872,8 +872,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-hoist-variables/download/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -881,8 +881,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-optimise-call-expression/download/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -890,9 +890,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-regex/download/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -900,11 +900,11 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-remap-async-to-generator/download/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -912,12 +912,12 @@
       "resolved": "http://registry.npm.taobao.org/babel-helper-replace-supers/download/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-vue-jsx-merge-props": {
@@ -930,8 +930,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-helpers/download/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-loader": {
@@ -940,9 +940,9 @@
       "integrity": "sha1-40Y5OL1ObVXRwXTFSF1AahiO0BU=",
       "dev": true,
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -950,7 +950,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -958,7 +958,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-check-es2015-constants/download/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -966,7 +966,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-external-helpers/download/babel-plugin-external-helpers-6.22.0.tgz",
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -974,10 +974,10 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-istanbul/download/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha1-NsWbIZLvzoHFs3gyG3QXWt0cmkU=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
       }
     },
     "babel-plugin-jsx-event-modifiers": {
@@ -990,9 +990,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-jsx-v-model/download/babel-plugin-jsx-v-model-2.0.3.tgz",
       "integrity": "sha1-w5ZBa5nLGveCCHMVrh0+YuBw9H0=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "html-tags": "2.0.0",
-        "svg-tags": "1.0.0"
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "html-tags": "^2.0.0",
+        "svg-tags": "^1.0.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1030,9 +1030,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-to-generator/download/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-builtin-classes": {
@@ -1040,9 +1040,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-builtin-classes/download/babel-plugin-transform-builtin-classes-0.6.1.tgz",
       "integrity": "sha1-CShvV1Jn8B0J0nmn2OAtWHOfFsI=",
       "requires": {
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-runtime": "^6.23.0",
+        "babel-template": "^6.25.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1050,7 +1050,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-arrow-functions/download/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1058,7 +1058,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-block-scoped-functions/download/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1066,11 +1066,11 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-block-scoping/download/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1078,15 +1078,15 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-classes/download/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1094,8 +1094,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-computed-properties/download/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1103,7 +1103,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-destructuring/download/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1111,8 +1111,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-duplicate-keys/download/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1120,7 +1120,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-for-of/download/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1128,9 +1128,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-function-name/download/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1138,7 +1138,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-literals/download/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1146,9 +1146,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-amd/download/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1156,10 +1156,10 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-commonjs/download/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1167,9 +1167,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-systemjs/download/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1177,9 +1177,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-umd/download/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1187,8 +1187,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-object-super/download/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1196,12 +1196,12 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-parameters/download/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1209,8 +1209,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-shorthand-properties/download/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1218,7 +1218,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-spread/download/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1226,9 +1226,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-sticky-regex/download/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1236,7 +1236,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-template-literals/download/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1244,7 +1244,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-typeof-symbol/download/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1252,9 +1252,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-unicode-regex/download/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1262,9 +1262,9 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-exponentiation-operator/download/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1272,8 +1272,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1281,7 +1281,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-regenerator/download/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -1289,7 +1289,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-runtime/download/babel-plugin-transform-runtime-6.23.0.tgz",
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1297,8 +1297,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-strict-mode/download/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-vue-jsx": {
@@ -1306,7 +1306,7 @@
       "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-vue-jsx/download/babel-plugin-transform-vue-jsx-3.7.0.tgz",
       "integrity": "sha1-1ASS5mkqNrWU9+mhko9D6Wl0CWA=",
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "babel-preset-env": {
@@ -1314,36 +1314,36 @@
       "resolved": "http://registry.npm.taobao.org/babel-preset-env/download/babel-preset-env-1.7.0.tgz",
       "integrity": "sha1-3qefpOvriDzTXasH4mDBycBN93o=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.8",
-        "invariant": "2.2.4",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-vue": {
@@ -1351,11 +1351,11 @@
       "resolved": "http://registry.npm.taobao.org/babel-preset-vue/download/babel-preset-vue-2.0.2.tgz",
       "integrity": "sha1-z63xvXNhJTl0gbX4UlztAEmgxx8=",
       "requires": {
-        "babel-helper-vue-jsx-merge-props": "2.0.3",
-        "babel-plugin-jsx-event-modifiers": "2.0.5",
-        "babel-plugin-jsx-v-model": "2.0.3",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-vue-jsx": "3.7.0"
+        "babel-helper-vue-jsx-merge-props": "^2.0.2",
+        "babel-plugin-jsx-event-modifiers": "^2.0.2",
+        "babel-plugin-jsx-v-model": "^2.0.1",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "babel-plugin-transform-vue-jsx": "^3.5.0"
       }
     },
     "babel-register": {
@@ -1363,13 +1363,13 @@
       "resolved": "http://registry.npm.taobao.org/babel-register/download/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1377,8 +1377,8 @@
       "resolved": "http://registry.npm.taobao.org/babel-runtime/download/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1386,11 +1386,11 @@
       "resolved": "http://registry.npm.taobao.org/babel-template/download/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1398,15 +1398,15 @@
       "resolved": "http://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1414,10 +1414,10 @@
       "resolved": "http://registry.npm.taobao.org/babel-types/download/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1441,13 +1441,13 @@
       "resolved": "http://registry.npm.taobao.org/base/download/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1455,7 +1455,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1463,7 +1463,7 @@
           "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1471,7 +1471,7 @@
           "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1479,9 +1479,9 @@
           "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1516,7 +1516,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -1534,9 +1534,9 @@
       "integrity": "sha1-4j2LJwV/HQIU/FYRQq2duZjyaDA=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "check-types": "7.4.0",
-        "tryer": "1.0.0"
+        "bluebird": "^3.5.1",
+        "check-types": "^7.3.0",
+        "tryer": "^1.0.0"
       }
     },
     "big.js": {
@@ -1567,7 +1567,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "~2.0.5"
       },
       "dependencies": {
         "isarray": {
@@ -1591,12 +1591,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1632,15 +1632,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       }
     },
     "boom": {
@@ -1649,7 +1649,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -1657,7 +1657,7 @@
       "resolved": "http://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1666,16 +1666,16 @@
       "resolved": "http://registry.npm.taobao.org/braces/download/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1683,7 +1683,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1706,12 +1706,12 @@
       "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1720,9 +1720,9 @@
       "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1731,9 +1731,9 @@
       "integrity": "sha1-M0MSTbbXrVPiaogmMYcSvchFD5w=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -1742,8 +1742,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -1752,13 +1752,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1767,7 +1767,7 @@
       "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -1775,8 +1775,8 @@
       "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-3.2.8.tgz",
       "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
       "requires": {
-        "caniuse-lite": "1.0.30000856",
-        "electron-to-chromium": "1.3.49"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       }
     },
     "buffer": {
@@ -1785,9 +1785,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1864,19 +1864,19 @@
       "integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.3",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.3.0",
-        "unique-filename": "1.1.0",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
       }
     },
     "cache-base": {
@@ -1884,15 +1884,15 @@
       "resolved": "http://registry.npm.taobao.org/cache-base/download/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "callsite": {
@@ -1913,8 +1913,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-api": {
@@ -1922,10 +1922,10 @@
       "resolved": "http://registry.npm.taobao.org/caniuse-api/download/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000856",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -1933,8 +1933,8 @@
           "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000856",
-            "electron-to-chromium": "1.3.49"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         }
       }
@@ -1961,8 +1961,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -1971,12 +1971,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-nightwatch": {
@@ -2017,9 +2017,9 @@
       "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.1.tgz",
       "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "check-error": {
@@ -2040,19 +2040,19 @@
       "integrity": "sha1-NW/04rDo5D4yLRijckYLvPOszSY=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       }
     },
     "chownr": {
@@ -2067,7 +2067,7 @@
       "integrity": "sha1-Rakb0sIMlBHwljtarrmhuV4JzEg=",
       "dev": true,
       "requires": {
-        "tslib": "1.9.2"
+        "tslib": "^1.9.0"
       }
     },
     "chromedriver": {
@@ -2076,11 +2076,11 @@
       "integrity": "sha1-KpTMaKvjs0o8Q7KHYbNFvRk4fvY=",
       "dev": true,
       "requires": {
-        "del": "3.0.0",
-        "extract-zip": "1.6.7",
-        "kew": "0.7.0",
-        "mkdirp": "0.5.1",
-        "request": "2.87.0"
+        "del": "^3.0.0",
+        "extract-zip": "^1.6.7",
+        "kew": "^0.7.0",
+        "mkdirp": "^0.5.1",
+        "request": "^2.87.0"
       }
     },
     "cipher-base": {
@@ -2089,8 +2089,8 @@
       "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -2104,7 +2104,7 @@
       "resolved": "http://registry.npm.taobao.org/clap/download/clap-1.2.3.tgz",
       "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2117,11 +2117,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2136,10 +2136,10 @@
       "resolved": "http://registry.npm.taobao.org/class-utils/download/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2147,7 +2147,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -2157,7 +2157,7 @@
       "resolved": "http://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -2172,8 +2172,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -2201,7 +2201,7 @@
       "resolved": "http://registry.npm.taobao.org/coa/download/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "collection-visit": {
@@ -2209,8 +2209,8 @@
       "resolved": "http://registry.npm.taobao.org/collection-visit/download/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -2218,9 +2218,9 @@
       "resolved": "http://registry.npm.taobao.org/color/download/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
-        "clone": "1.0.4",
-        "color-convert": "1.9.2",
-        "color-string": "0.3.0"
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
@@ -2241,7 +2241,7 @@
       "resolved": "http://registry.npm.taobao.org/color-string/download/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "^1.0.0"
       }
     },
     "colormin": {
@@ -2249,9 +2249,9 @@
       "resolved": "http://registry.npm.taobao.org/colormin/download/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
-        "color": "0.11.4",
+        "color": "^0.11.0",
         "css-color-names": "0.0.4",
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "colors": {
@@ -2265,7 +2265,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.5.0"
       }
     },
     "combined-stream": {
@@ -2273,7 +2273,7 @@
       "resolved": "http://registry.npm.taobao.org/combined-stream/download/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2315,10 +2315,10 @@
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "concat-with-sourcemaps": {
@@ -2326,7 +2326,7 @@
       "resolved": "http://registry.npm.taobao.org/concat-with-sourcemaps/download/concat-with-sourcemaps-1.1.0.tgz",
       "integrity": "sha1-1OqT8FriV5CVG5nns7CeOQikCC4=",
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       }
     },
     "connect": {
@@ -2337,7 +2337,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -2348,12 +2348,12 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "statuses": {
@@ -2370,7 +2370,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "consolidate": {
@@ -2378,7 +2378,7 @@
       "resolved": "http://registry.npm.taobao.org/consolidate/download/consolidate-0.15.1.tgz",
       "integrity": "sha1-IasEMjXHGgfUXZqtmFk7DbpWurc=",
       "requires": {
-        "bluebird": "3.5.1"
+        "bluebird": "^3.1.1"
       }
     },
     "constants-browserify": {
@@ -2422,12 +2422,12 @@
       "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -2450,13 +2450,13 @@
       "resolved": "http://registry.npm.taobao.org/cosmiconfig/download/cosmiconfig-2.2.2.tgz",
       "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.7.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.1.0",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "require-from-string": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -2472,12 +2472,12 @@
       "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
-        "js-yaml": "3.12.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.87.0"
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.85.0"
       },
       "dependencies": {
         "js-yaml": {
@@ -2486,8 +2486,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.1"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "minimist": {
@@ -2504,8 +2504,8 @@
       "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2514,11 +2514,11 @@
       "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2527,12 +2527,12 @@
       "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-env": {
@@ -2541,8 +2541,8 @@
       "integrity": "sha1-bs1MAV1Xc+YUA57lKQdmabnRJvI=",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "is-windows": "1.0.2"
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -2551,11 +2551,11 @@
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -2565,7 +2565,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "crypto-browserify": {
@@ -2574,17 +2574,17 @@
       "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css-color-names": {
@@ -2598,20 +2598,20 @@
       "integrity": "sha1-w/mGSnAL4nEbtaJGKyOJsaOS2rc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-modules-extract-imports": "1.2.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "2.0.0"
+        "babel-code-frame": "^6.26.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssnano": "^3.10.0",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "object-assign": "^4.1.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.2.0",
+        "postcss-modules-local-by-default": "^1.2.0",
+        "postcss-modules-scope": "^1.1.0",
+        "postcss-modules-values": "^1.3.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2626,11 +2626,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2653,10 +2653,10 @@
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -2671,7 +2671,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2699,11 +2699,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2723,9 +2723,9 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.1.tgz",
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
           "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "postcss-modules-extract-imports": {
@@ -2733,7 +2733,7 @@
           "resolved": "http://registry.npm.taobao.org/postcss-modules-extract-imports/download/postcss-modules-extract-imports-1.1.0.tgz",
           "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
           "requires": {
-            "postcss": "6.0.1"
+            "postcss": "^6.0.1"
           }
         },
         "source-map": {
@@ -2746,7 +2746,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2756,9 +2756,9 @@
       "resolved": "http://registry.npm.taobao.org/css-selector-tokenizer/download/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -2766,9 +2766,9 @@
           "resolved": "http://registry.npm.taobao.org/regexpu-core/download/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "1.4.0",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         }
       }
@@ -2778,8 +2778,8 @@
       "resolved": "http://registry.npm.taobao.org/css-tree/download/css-tree-1.0.0-alpha25.tgz",
       "integrity": "sha1-G7+r+/bu708B2RCP8u3Qvi/jVZc=",
       "requires": {
-        "mdn-data": "1.1.4",
-        "source-map": "0.5.7"
+        "mdn-data": "^1.0.0",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -2799,38 +2799,38 @@
       "resolved": "http://registry.npm.taobao.org/cssnano/download/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.3",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.3",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2843,12 +2843,12 @@
           "resolved": "http://registry.npm.taobao.org/autoprefixer/download/autoprefixer-6.7.7.tgz",
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000856",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "browserslist": {
@@ -2856,8 +2856,8 @@
           "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000856",
-            "electron-to-chromium": "1.3.49"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -2865,11 +2865,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2889,10 +2889,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -2905,7 +2905,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2915,8 +2915,8 @@
       "resolved": "http://registry.npm.taobao.org/csso/download/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.7"
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -2932,7 +2932,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "custom-event": {
@@ -2953,7 +2953,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.45"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -2961,7 +2961,7 @@
       "resolved": "http://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -2988,8 +2988,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "de-indent": {
@@ -3021,7 +3021,7 @@
       "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -3035,7 +3035,7 @@
       "resolved": "http://registry.npm.taobao.org/defaults/download/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -3044,8 +3044,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -3053,8 +3053,8 @@
       "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3062,7 +3062,7 @@
           "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3070,7 +3070,7 @@
           "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3078,9 +3078,9 @@
           "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3096,9 +3096,9 @@
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "dev": true,
       "requires": {
-        "ast-types": "0.11.5",
-        "escodegen": "1.10.0",
-        "esprima": "3.1.3"
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
       },
       "dependencies": {
         "esprima": {
@@ -3115,12 +3115,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -3140,8 +3140,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3155,7 +3155,7 @@
       "resolved": "http://registry.npm.taobao.org/detect-indent/download/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "di": {
@@ -3176,17 +3176,17 @@
       "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "document-register-element": {
-      "version": "1.9.1",
-      "resolved": "http://registry.npm.taobao.org/document-register-element/download/document-register-element-1.9.1.tgz",
-      "integrity": "sha1-FJulXhWQ4WKep2RKJh74uV5UPQk=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.1.tgz",
+      "integrity": "sha512-BYZMAyT6Jryi0hYeZI7JrjHEpl53252IUxeXlyBvRvnxALWW4RXj4trSxewAj3OLFjS05Zncb6lvjft7lu0tNg==",
       "requires": {
-        "lightercollective": "0.0.0"
+        "lightercollective": "^0.0.0"
       }
     },
     "dom-serialize": {
@@ -3195,10 +3195,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "void-elements": "2.0.1"
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -3212,7 +3212,7 @@
       "resolved": "http://registry.npm.taobao.org/dot-prop/download/dot-prop-4.2.0.tgz",
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "double-ended-queue": {
@@ -3234,10 +3234,10 @@
       "integrity": "sha1-WSkD9dgLONA3IgVBJk1poZj7NBA=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -3246,7 +3246,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -3272,13 +3272,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.4",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -3298,7 +3298,7 @@
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -3307,13 +3307,13 @@
       "integrity": "sha1-Dn751pDrCzVZfx1K0Comyi26OEU=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "uws": "9.14.0",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "uws": "~9.14.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -3335,14 +3335,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3364,10 +3364,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -3376,9 +3376,9 @@
       "integrity": "sha1-40puqnkPYvzNcdk5WfVrK0MtsQo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.0.0"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "ent": {
@@ -3392,7 +3392,7 @@
       "resolved": "http://registry.npm.taobao.org/errno/download/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3400,7 +3400,7 @@
       "resolved": "http://registry.npm.taobao.org/error-ex/download/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -3409,9 +3409,9 @@
       "integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
@@ -3420,9 +3420,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-promise": {
@@ -3437,7 +3437,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-symbol": {
@@ -3446,8 +3446,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -3467,11 +3467,11 @@
       "integrity": "sha1-9kc5XeIlGfvQ2Sj/zx0X4N7CYD4=",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -3488,8 +3488,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "esprima": {
@@ -3504,7 +3504,7 @@
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -3546,8 +3546,8 @@
       "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "expand-braces": {
@@ -3556,9 +3556,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "0.2.3",
-        "array-unique": "0.2.1",
-        "braces": "0.1.5"
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
       },
       "dependencies": {
         "array-unique": {
@@ -3573,7 +3573,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "0.1.1"
+            "expand-range": "^0.1.0"
           }
         }
       }
@@ -3583,13 +3583,13 @@
       "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3597,7 +3597,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -3605,7 +3605,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3616,8 +3616,8 @@
       "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "dev": true,
       "requires": {
-        "is-number": "0.1.1",
-        "repeat-string": "0.2.2"
+        "is-number": "^0.1.1",
+        "repeat-string": "^0.2.2"
       },
       "dependencies": {
         "is-number": {
@@ -3640,36 +3640,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "path-to-regexp": {
@@ -3690,8 +3690,8 @@
       "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3699,7 +3699,7 @@
           "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3709,14 +3709,14 @@
       "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3724,7 +3724,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -3732,7 +3732,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -3740,7 +3740,7 @@
           "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3748,7 +3748,7 @@
           "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3756,9 +3756,9 @@
           "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3808,7 +3808,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "file-uri-to-path": {
@@ -3833,10 +3833,10 @@
       "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3844,7 +3844,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3856,12 +3856,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -3870,9 +3870,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.3.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-up": {
@@ -3880,7 +3880,7 @@
       "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flatten": {
@@ -3894,8 +3894,8 @@
       "integrity": "sha1-xdWG7zivYJdlC0m8QbVfq7GfNb0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "follow-redirects": {
@@ -3904,7 +3904,7 @@
       "integrity": "sha1-I09Jz3cLfzW0DnkPY2zroMOgq3c=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -3928,7 +3928,7 @@
       "resolved": "http://registry.npm.taobao.org/for-own/download/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -3947,9 +3947,9 @@
       "resolved": "http://registry.npm.taobao.org/form-data/download/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -3963,7 +3963,7 @@
       "resolved": "http://registry.npm.taobao.org/fragment-cache/download/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -3978,8 +3978,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-access": {
@@ -3988,7 +3988,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -3997,10 +3997,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -4015,8 +4015,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4042,8 +4042,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -4056,7 +4056,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4120,7 +4120,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -4135,14 +4135,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -4151,12 +4151,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -4171,7 +4171,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -4180,7 +4180,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -4189,8 +4189,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4209,7 +4209,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -4223,7 +4223,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -4236,8 +4236,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -4246,7 +4246,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -4269,9 +4269,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4280,16 +4280,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -4298,8 +4298,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -4314,8 +4314,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -4324,10 +4324,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -4346,7 +4346,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -4367,8 +4367,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -4389,10 +4389,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4409,13 +4409,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -4424,7 +4424,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -4462,23 +4462,23 @@
           "dev": true,
           "optional": true
         },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -4486,7 +4486,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -4501,13 +4501,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -4522,7 +4522,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -4543,7 +4543,7 @@
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
       },
       "dependencies": {
@@ -4553,10 +4553,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4586,7 +4586,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "generic-names": {
@@ -4594,7 +4594,7 @@
       "resolved": "http://registry.npm.taobao.org/generic-names/download/generic-names-1.0.3.tgz",
       "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
       "requires": {
-        "loader-utils": "0.2.17"
+        "loader-utils": "^0.2.16"
       },
       "dependencies": {
         "loader-utils": {
@@ -4602,10 +4602,10 @@
           "resolved": "http://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -4628,12 +4628,12 @@
       "integrity": "sha1-XHlecTJvbKEoby/IJXXNK6sq9Xg=",
       "dev": true,
       "requires": {
-        "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "file-uri-to-path": "1.0.0",
-        "ftp": "0.3.10",
-        "readable-stream": "2.3.6"
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "3",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
       }
     },
     "get-value": {
@@ -4646,7 +4646,7 @@
       "resolved": "http://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -4654,12 +4654,12 @@
       "resolved": "http://registry.npm.taobao.org/glob/download/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -4667,8 +4667,8 @@
       "resolved": "http://registry.npm.taobao.org/glob-base/download/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -4676,7 +4676,7 @@
           "resolved": "http://registry.npm.taobao.org/glob-parent/download/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -4689,7 +4689,7 @@
           "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -4700,8 +4700,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -4710,7 +4710,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -4726,11 +4726,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4764,8 +4764,8 @@
       "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "3.0.0"
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
       }
     },
     "handlebars": {
@@ -4774,10 +4774,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -4792,7 +4792,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -4802,9 +4802,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -4828,8 +4828,8 @@
       "resolved": "http://registry.npm.taobao.org/har-validator/download/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -4837,10 +4837,10 @@
           "resolved": "http://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "fast-deep-equal": {
@@ -4860,7 +4860,7 @@
       "resolved": "http://registry.npm.taobao.org/has/download/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -4868,7 +4868,7 @@
       "resolved": "http://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -4910,9 +4910,9 @@
       "resolved": "http://registry.npm.taobao.org/has-value/download/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -4920,8 +4920,8 @@
       "resolved": "http://registry.npm.taobao.org/has-values/download/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4929,7 +4929,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4940,8 +4940,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash-sum": {
@@ -4955,8 +4955,8 @@
       "integrity": "sha1-i1Dh811RvQHl7Z7OTb41Scz6Cjw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -4966,10 +4966,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "he": {
@@ -4984,8 +4984,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.10",
-        "request": "2.87.0"
+        "lodash": "^4.0.0",
+        "request": "^2.0.0"
       }
     },
     "hmac-drbg": {
@@ -4994,9 +4994,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.4",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -5010,8 +5010,8 @@
       "resolved": "http://registry.npm.taobao.org/home-or-tmp/download/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -5035,10 +5035,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy": {
@@ -5047,9 +5047,9 @@
       "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
       "dev": true,
       "requires": {
-        "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-agent": {
@@ -5058,7 +5058,7 @@
       "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -5079,10 +5079,10 @@
       "integrity": "sha1-CYfmu1pWBuWmkWjY+WeofxXdiqs=",
       "dev": true,
       "requires": {
-        "http-proxy": "1.17.0",
-        "is-glob": "4.0.0",
-        "lodash": "4.17.10",
-        "micromatch": "3.1.10"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9"
       }
     },
     "http-signature": {
@@ -5090,9 +5090,9 @@
       "resolved": "http://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "httpntlm": {
@@ -5101,8 +5101,8 @@
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
       "requires": {
-        "httpreq": "0.4.24",
-        "underscore": "1.7.0"
+        "httpreq": ">=0.4.22",
+        "underscore": "~1.7.0"
       }
     },
     "httpreq": {
@@ -5123,8 +5123,8 @@
       "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5155,7 +5155,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.1"
       }
     },
     "ieee754": {
@@ -5181,7 +5181,7 @@
       "resolved": "http://registry.npm.taobao.org/import-cwd/download/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-from": {
@@ -5189,7 +5189,7 @@
       "resolved": "http://registry.npm.taobao.org/import-from/download/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "imurmurhash": {
@@ -5204,7 +5204,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
@@ -5230,8 +5230,8 @@
       "resolved": "http://registry.npm.taobao.org/inflight/download/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -5244,7 +5244,7 @@
       "resolved": "http://registry.npm.taobao.org/invariant/download/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "ip": {
@@ -5269,7 +5269,7 @@
       "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5277,7 +5277,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5293,7 +5293,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -5306,7 +5306,7 @@
       "resolved": "http://registry.npm.taobao.org/is-builtin-module/download/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -5314,7 +5314,7 @@
       "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5322,7 +5322,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5332,9 +5332,9 @@
       "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5359,7 +5359,7 @@
       "resolved": "http://registry.npm.taobao.org/is-equal-shallow/download/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -5378,7 +5378,7 @@
       "resolved": "http://registry.npm.taobao.org/is-finite/download/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -5387,7 +5387,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-module": {
@@ -5409,11 +5409,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -5421,7 +5421,7 @@
       "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5429,7 +5429,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5444,7 +5444,7 @@
       "resolved": "http://registry.npm.taobao.org/is-odd/download/is-odd-2.0.0.tgz",
       "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5466,7 +5466,7 @@
       "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -5475,7 +5475,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -5488,7 +5488,7 @@
       "resolved": "http://registry.npm.taobao.org/is-plain-object/download/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -5520,7 +5520,7 @@
       "resolved": "http://registry.npm.taobao.org/is-svg/download/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-typedarray": {
@@ -5572,20 +5572,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -5600,11 +5600,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
           }
         },
         "esprima": {
@@ -5625,11 +5625,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -5645,7 +5645,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "supports-color": {
@@ -5654,7 +5654,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -5665,10 +5665,10 @@
       "integrity": "sha1-mVe9WSUrNz+uXFK3tRiOb94qCUk=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.1",
-        "istanbul-lib-instrument": "1.10.1",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "convert-source-map": "^1.5.0",
+        "istanbul-lib-instrument": "^1.7.3",
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.3.0"
       },
       "dependencies": {
         "ajv": {
@@ -5677,10 +5677,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "fast-deep-equal": {
@@ -5701,7 +5701,7 @@
           "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2"
+            "ajv": "^5.0.0"
           }
         }
       }
@@ -5716,13 +5716,13 @@
       "resolved": "http://registry.npm.taobao.org/istanbul-lib-instrument/download/istanbul-lib-instrument-1.10.1.tgz",
       "integrity": "sha1-cktLbKzrqGktPx+dByfiecQBr3s=",
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "semver": "^5.3.0"
       }
     },
     "jasmine-core": {
@@ -5746,8 +5746,8 @@
       "resolved": "http://registry.npm.taobao.org/js-yaml/download/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       },
       "dependencies": {
         "esprima": {
@@ -5806,7 +5806,7 @@
       "resolved": "http://registry.npm.taobao.org/jsonfile/download/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonpointer": {
@@ -5839,31 +5839,31 @@
       "integrity": "sha1-TV4T0l9aUTMcU3iyTEmEcJwBEgs=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "body-parser": "1.18.2",
-        "chokidar": "2.0.4",
-        "colors": "1.1.2",
-        "combine-lists": "1.0.1",
-        "connect": "3.6.6",
-        "core-js": "2.5.7",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "expand-braces": "0.1.2",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "http-proxy": "1.17.0",
-        "isbinaryfile": "3.0.2",
-        "lodash": "4.17.10",
-        "log4js": "2.9.0",
-        "mime": "1.4.1",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.2.0",
-        "range-parser": "1.2.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.16.1",
+        "chokidar": "^2.0.3",
+        "colors": "^1.1.0",
+        "combine-lists": "^1.0.0",
+        "connect": "^3.6.0",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^4.17.4",
+        "log4js": "^2.5.3",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.2",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "range-parser": "^1.2.0",
+        "rimraf": "^2.6.0",
+        "safe-buffer": "^5.0.1",
         "socket.io": "2.0.4",
-        "source-map": "0.6.1",
+        "source-map": "^0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.2.1"
       }
@@ -5886,8 +5886,8 @@
       "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
       "dev": true,
       "requires": {
-        "fs-access": "1.0.1",
-        "which": "1.3.1"
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
       }
     },
     "karma-coverage": {
@@ -5896,11 +5896,11 @@
       "integrity": "sha1-zAnc61iagxAayl/nDCh2Re84dok=",
       "dev": true,
       "requires": {
-        "dateformat": "1.0.12",
-        "istanbul": "0.4.5",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "source-map": "0.5.7"
+        "dateformat": "^1.0.6",
+        "istanbul": "^0.4.0",
+        "lodash": "^4.17.0",
+        "minimatch": "^3.0.0",
+        "source-map": "^0.5.1"
       },
       "dependencies": {
         "source-map": {
@@ -5940,9 +5940,9 @@
       "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "log-symbols": "2.2.0",
-        "strip-ansi": "4.0.0"
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5957,7 +5957,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -5968,7 +5968,7 @@
       "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.2"
       }
     },
     "karma-webpack": {
@@ -5977,12 +5977,12 @@
       "integrity": "sha1-vwCcW3PGZ8EcAVcX6eUg9YExfEQ=",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "babel-runtime": "6.26.0",
-        "loader-utils": "1.1.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "webpack-dev-middleware": "2.0.6"
+        "async": "^2.0.0",
+        "babel-runtime": "^6.0.0",
+        "loader-utils": "^1.0.0",
+        "lodash": "^4.0.0",
+        "source-map": "^0.5.6",
+        "webpack-dev-middleware": "^2.0.6"
       },
       "dependencies": {
         "mime": {
@@ -6003,13 +6003,13 @@
           "integrity": "sha1-pRaSgB6DEIRO8+N5Dh6s/lIyb9Q=",
           "dev": true,
           "requires": {
-            "loud-rejection": "1.6.0",
-            "memory-fs": "0.4.1",
-            "mime": "2.3.1",
-            "path-is-absolute": "1.0.1",
-            "range-parser": "1.2.0",
-            "url-join": "2.0.5",
-            "webpack-log": "1.2.0"
+            "loud-rejection": "^1.6.0",
+            "memory-fs": "~0.4.1",
+            "mime": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3",
+            "url-join": "^2.0.2",
+            "webpack-log": "^1.0.1"
           }
         }
       }
@@ -6049,14 +6049,14 @@
       "resolved": "http://registry.npm.taobao.org/less/download/less-3.0.4.tgz",
       "integrity": "sha1-0n3O26yWAxyee3bx2h5LfYN2CBQ=",
       "requires": {
-        "errno": "0.1.7",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.5.5",
-        "mime": "1.4.1",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.87.0",
-        "source-map": "0.6.1"
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.83.0",
+        "source-map": "~0.6.0"
       }
     },
     "less-loader": {
@@ -6065,9 +6065,9 @@
       "integrity": "sha1-LBNSxbCaT4QQFJAnT9UWdN5BNj4=",
       "dev": true,
       "requires": {
-        "clone": "2.1.1",
-        "loader-utils": "1.1.0",
-        "pify": "3.0.0"
+        "clone": "^2.1.1",
+        "loader-utils": "^1.1.0",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "clone": {
@@ -6084,8 +6084,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "libbase64": {
@@ -6121,19 +6121,19 @@
     },
     "lightercollective": {
       "version": "0.0.0",
-      "resolved": "http://registry.npm.taobao.org/lightercollective/download/lightercollective-0.0.0.tgz",
-      "integrity": "sha1-W4X2dVt4wflNtZDkeflUy/7rBAk="
+      "resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+      "integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/load-json-file/download/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6155,9 +6155,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -6165,8 +6165,8 @@
       "resolved": "http://registry.npm.taobao.org/locate-path/download/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -6192,8 +6192,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._baseclone": {
@@ -6202,12 +6202,12 @@
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseassign": "3.2.0",
-        "lodash._basefor": "3.0.3",
-        "lodash.isarray": "3.0.4",
-        "lodash.keys": "3.1.2"
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -6264,9 +6264,9 @@
       "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "3.3.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.create": {
@@ -6275,9 +6275,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.debounce": {
@@ -6292,12 +6292,12 @@
       "integrity": "sha1-bBpYbmxWR7DmTi15gUG4g2FYvoo=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "4.5.7",
-        "lodash._stack": "4.1.3",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.keysin": "4.2.0",
-        "lodash.mergewith": "4.6.1",
-        "lodash.rest": "4.0.5"
+        "lodash._baseclone": "^4.0.0",
+        "lodash._stack": "^4.0.0",
+        "lodash.isplainobject": "^4.0.0",
+        "lodash.keysin": "^4.0.0",
+        "lodash.mergewith": "^4.0.0",
+        "lodash.rest": "^4.0.0"
       },
       "dependencies": {
         "lodash._baseclone": {
@@ -6338,9 +6338,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.keysin": {
@@ -6382,7 +6382,7 @@
       "resolved": "http://registry.npm.taobao.org/log-symbols/download/log-symbols-2.2.0.tgz",
       "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "log4js": {
@@ -6391,18 +6391,18 @@
       "integrity": "sha1-QdmawvFAt9pUABoho7ymGhZHRqc=",
       "dev": true,
       "requires": {
-        "amqplib": "0.5.2",
-        "axios": "0.15.3",
-        "circular-json": "0.5.4",
-        "date-format": "1.2.0",
-        "debug": "3.1.0",
-        "hipchat-notifier": "1.1.0",
-        "loggly": "1.1.1",
-        "mailgun-js": "0.18.1",
-        "nodemailer": "2.7.2",
-        "redis": "2.8.0",
-        "semver": "5.5.0",
-        "slack-node": "0.2.0",
+        "amqplib": "^0.5.2",
+        "axios": "^0.15.3",
+        "circular-json": "^0.5.4",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "hipchat-notifier": "^1.1.0",
+        "loggly": "^1.1.0",
+        "mailgun-js": "^0.18.0",
+        "nodemailer": "^2.5.0",
+        "redis": "^2.7.1",
+        "semver": "^5.5.0",
+        "slack-node": "~0.2.0",
         "streamroller": "0.7.0"
       },
       "dependencies": {
@@ -6424,9 +6424,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "json-stringify-safe": "5.0.1",
-        "request": "2.75.0",
-        "timespan": "2.3.0"
+        "json-stringify-safe": "5.0.x",
+        "request": "2.75.x",
+        "timespan": "2.3.x"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6464,11 +6464,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "form-data": {
@@ -6478,9 +6478,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "har-validator": {
@@ -6490,10 +6490,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "http-signature": {
@@ -6503,9 +6503,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "node-uuid": {
@@ -6529,27 +6529,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.0.0",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.3",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.0.0",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "supports-color": {
@@ -6574,8 +6574,8 @@
       "integrity": "sha1-NvxPWZbWZA9Tn/IDuoGWQWgNdaI=",
       "dev": true,
       "requires": {
-        "es6-symbol": "3.1.1",
-        "object.assign": "4.1.0"
+        "es6-symbol": "^3.1.1",
+        "object.assign": "^4.1.0"
       }
     },
     "lolex": {
@@ -6601,7 +6601,7 @@
       "resolved": "http://registry.npm.taobao.org/loose-envify/download/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -6610,8 +6610,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -6619,8 +6619,8 @@
       "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.3.tgz",
       "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "magic-string": {
@@ -6628,7 +6628,7 @@
       "resolved": "http://registry.npm.taobao.org/magic-string/download/magic-string-0.22.5.tgz",
       "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "^0.2.2"
       },
       "dependencies": {
         "vlq": {
@@ -6656,15 +6656,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "2.6.1",
-        "debug": "3.1.0",
-        "form-data": "2.3.2",
-        "inflection": "1.12.0",
-        "is-stream": "1.1.0",
-        "path-proxy": "1.0.0",
-        "promisify-call": "2.0.4",
-        "proxy-agent": "3.0.0",
-        "tsscmp": "1.0.5"
+        "async": "~2.6.0",
+        "debug": "~3.1.0",
+        "form-data": "~2.3.0",
+        "inflection": "~1.12.0",
+        "is-stream": "^1.1.0",
+        "path-proxy": "~1.0.0",
+        "promisify-call": "^2.0.2",
+        "proxy-agent": "~3.0.0",
+        "tsscmp": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6685,7 +6685,7 @@
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "mamacro": {
@@ -6710,7 +6710,7 @@
       "resolved": "http://registry.npm.taobao.org/map-visit/download/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "math-expression-evaluator": {
@@ -6729,8 +6729,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mdn-data": {
@@ -6750,8 +6750,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.6"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -6760,16 +6760,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -6791,7 +6791,7 @@
       "resolved": "http://registry.npm.taobao.org/merge-source-map/download/merge-source-map-1.1.0.tgz",
       "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       }
     },
     "methods": {
@@ -6805,19 +6805,19 @@
       "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -6826,8 +6826,8 @@
       "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -6845,7 +6845,7 @@
       "resolved": "http://registry.npm.taobao.org/mime-types/download/mime-types-2.1.18.tgz",
       "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -6859,8 +6859,8 @@
       "integrity": "sha1-/zvwi+6W5hjhd8FsphMb/s73B/k=",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "webpack-sources": "1.1.0"
+        "loader-utils": "^1.1.0",
+        "webpack-sources": "^1.1.0"
       }
     },
     "minimalistic-assert": {
@@ -6880,7 +6880,7 @@
       "resolved": "http://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -6893,11 +6893,11 @@
       "resolved": "http://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.1.0-alpha-1.tgz",
       "integrity": "sha1-RIsRQOuTKF0fFr5igKYP16SQEH8=",
       "requires": {
-        "acorn": "5.7.1",
-        "acorn-dynamic-import": "3.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "source-map": "0.6.1"
+        "acorn": "^5.7.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
       }
     },
     "mississippi": {
@@ -6906,16 +6906,16 @@
       "integrity": "sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.6.0",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.3",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "2.0.1",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -6923,8 +6923,8 @@
       "resolved": "http://registry.npm.taobao.org/mixin-deep/download/mixin-deep-1.3.1.tgz",
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6932,7 +6932,7 @@
           "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -7012,7 +7012,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -7036,12 +7036,12 @@
           "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "growl": {
@@ -7068,7 +7068,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -7079,12 +7079,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -7104,18 +7104,18 @@
       "resolved": "http://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.9.tgz",
       "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "negotiator": {
@@ -7154,7 +7154,7 @@
       "integrity": "sha1-nnlKdRS0/V9GYC02jlBRUjKrnpA=",
       "dev": true,
       "requires": {
-        "chai-nightwatch": "0.1.1",
+        "chai-nightwatch": "~0.1.x",
         "ejs": "2.5.7",
         "lodash.clone": "3.0.3",
         "lodash.defaultsdeep": "4.3.2",
@@ -7172,8 +7172,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "3.0.1",
-            "semver": "5.0.3"
+            "extend": "~3.0.0",
+            "semver": "~5.0.1"
           }
         },
         "co": {
@@ -7194,9 +7194,9 @@
           "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
           }
         },
         "https-proxy-agent": {
@@ -7205,9 +7205,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
           }
         },
         "ip": {
@@ -7228,7 +7228,7 @@
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         },
         "pac-proxy-agent": {
@@ -7237,15 +7237,15 @@
           "integrity": "sha1-NKOF399h0vDsrOCIWMdF0+eR/U0=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1",
-            "get-uri": "2.0.2",
-            "http-proxy-agent": "1.0.0",
-            "https-proxy-agent": "1.0.0",
-            "pac-resolver": "2.0.0",
-            "raw-body": "2.3.2",
-            "socks-proxy-agent": "2.1.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3",
+            "get-uri": "2",
+            "http-proxy-agent": "1",
+            "https-proxy-agent": "1",
+            "pac-resolver": "~2.0.0",
+            "raw-body": "2",
+            "socks-proxy-agent": "2"
           }
         },
         "pac-resolver": {
@@ -7254,11 +7254,11 @@
           "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
           "dev": true,
           "requires": {
-            "co": "3.0.6",
-            "degenerator": "1.0.4",
+            "co": "~3.0.6",
+            "degenerator": "~1.0.2",
             "ip": "1.0.1",
-            "netmask": "1.0.6",
-            "thunkify": "2.1.2"
+            "netmask": "~1.0.4",
+            "thunkify": "~2.1.1"
           }
         },
         "proxy-agent": {
@@ -7267,14 +7267,14 @@
           "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1",
-            "http-proxy-agent": "1.0.0",
-            "https-proxy-agent": "1.0.0",
-            "lru-cache": "2.6.5",
-            "pac-proxy-agent": "1.1.0",
-            "socks-proxy-agent": "2.1.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3",
+            "http-proxy-agent": "1",
+            "https-proxy-agent": "1",
+            "lru-cache": "~2.6.5",
+            "pac-proxy-agent": "1",
+            "socks-proxy-agent": "2"
           }
         },
         "q": {
@@ -7295,9 +7295,9 @@
           "integrity": "sha1-huuwcZMlhjeHDhO3vZnybGY989M=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "extend": "3.0.1",
-            "socks": "1.1.10"
+            "agent-base": "2",
+            "extend": "3",
+            "socks": "~1.1.5"
           }
         }
       }
@@ -7308,11 +7308,11 @@
       "integrity": "sha1-qaOADjmUmUr55FIzPVSdYPcrjow=",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.7.1",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "node-libs-browser": {
@@ -7321,28 +7321,28 @@
       "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.6",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.4",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -7377,8 +7377,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
+            "ip": "^1.1.2",
+            "smart-buffer": "^1.0.4"
           }
         }
       }
@@ -7445,7 +7445,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -7453,10 +7453,10 @@
       "resolved": "http://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -7464,7 +7464,7 @@
       "resolved": "http://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -7477,10 +7477,10 @@
       "resolved": "http://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
       }
     },
     "null-check": {
@@ -7520,9 +7520,9 @@
       "resolved": "http://registry.npm.taobao.org/object-copy/download/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -7530,7 +7530,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -7538,7 +7538,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7554,7 +7554,7 @@
       "resolved": "http://registry.npm.taobao.org/object-visit/download/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -7563,10 +7563,10 @@
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.12"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.omit": {
@@ -7574,8 +7574,8 @@
       "resolved": "http://registry.npm.taobao.org/object.omit/download/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -7583,7 +7583,7 @@
       "resolved": "http://registry.npm.taobao.org/object.pick/download/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -7600,7 +7600,7 @@
       "resolved": "http://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -7608,7 +7608,7 @@
       "resolved": "http://registry.npm.taobao.org/onetime/download/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opener": {
@@ -7623,8 +7623,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -7641,12 +7641,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "ora": {
@@ -7654,12 +7654,12 @@
       "resolved": "http://registry.npm.taobao.org/ora/download/ora-2.1.0.tgz",
       "integrity": "sha1-bK8oMOuSSUGGHsU6FzeZ4Ai1Hls=",
       "requires": {
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.3.1",
-        "log-symbols": "2.2.0",
-        "strip-ansi": "4.0.0",
-        "wcwidth": "1.0.1"
+        "chalk": "^2.3.1",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.1.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^4.0.0",
+        "wcwidth": "^1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7672,7 +7672,7 @@
           "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7698,7 +7698,7 @@
       "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -7706,7 +7706,7 @@
       "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -7732,14 +7732,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "get-uri": "2.0.2",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "pac-resolver": "3.0.0",
-        "raw-body": "2.3.2",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7761,11 +7761,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "4.6.0",
-        "degenerator": "1.0.4",
-        "ip": "1.1.5",
-        "netmask": "1.0.6",
-        "thunkify": "2.1.2"
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
       }
     },
     "pako": {
@@ -7780,9 +7780,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "parse-asn1": {
@@ -7791,11 +7791,11 @@
       "integrity": "sha1-9r8pOBgzK9DatU77Fgh3JHRebKg=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -7803,10 +7803,10 @@
       "resolved": "http://registry.npm.taobao.org/parse-glob/download/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -7819,7 +7819,7 @@
           "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -7829,7 +7829,7 @@
       "resolved": "http://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parseqs": {
@@ -7838,7 +7838,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -7847,7 +7847,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -7907,7 +7907,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inflection": "1.3.8"
+        "inflection": "~1.3.0"
       },
       "dependencies": {
         "inflection": {
@@ -7933,9 +7933,9 @@
       "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7957,11 +7957,11 @@
       "integrity": "sha1-dAQgjsawG2LYW/g4U6gGT42cKlw=",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -7990,7 +7990,7 @@
       "resolved": "http://registry.npm.taobao.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -7999,7 +7999,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "posix-character-classes": {
@@ -8012,9 +8012,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.22.tgz",
       "integrity": "sha1-4jt4MUkFw7kMvWFwISHnp4hI8qM=",
       "requires": {
-        "chalk": "2.4.1",
-        "source-map": "0.6.1",
-        "supports-color": "5.4.0"
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
       }
     },
     "postcss-calc": {
@@ -8022,9 +8022,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-calc/download/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8037,11 +8037,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8061,10 +8061,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8077,7 +8077,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8087,9 +8087,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-colormin/download/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8102,11 +8102,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8126,10 +8126,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8142,7 +8142,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8152,8 +8152,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-convert-values/download/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8166,11 +8166,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8190,10 +8190,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8206,7 +8206,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8216,8 +8216,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-csso/download/postcss-csso-3.0.0.tgz",
       "integrity": "sha1-dHPnLx7JoJhUXjbMk2WBU3BNaIE=",
       "requires": {
-        "csso": "3.3.1",
-        "postcss": "6.0.22"
+        "csso": "~3.3.0",
+        "postcss": "^6.0.0"
       },
       "dependencies": {
         "csso": {
@@ -8235,7 +8235,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-discard-comments/download/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8248,11 +8248,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8272,10 +8272,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8288,7 +8288,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8298,7 +8298,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-discard-duplicates/download/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8311,11 +8311,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8335,10 +8335,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8351,7 +8351,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8361,7 +8361,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-discard-empty/download/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8374,11 +8374,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8398,10 +8398,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8414,7 +8414,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8424,7 +8424,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-discard-overridden/download/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8437,11 +8437,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8461,10 +8461,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8477,7 +8477,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8487,8 +8487,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-discard-unused/download/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8501,11 +8501,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8525,10 +8525,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8541,7 +8541,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8551,7 +8551,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-filter-plugins/download/postcss-filter-plugins-2.0.3.tgz",
       "integrity": "sha1-giRf34IzcEFkXkdxFNjlk6oYuOw=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8564,11 +8564,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8588,10 +8588,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8604,7 +8604,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8614,10 +8614,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       }
     },
     "postcss-load-options": {
@@ -8625,8 +8625,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-load-options/download/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-load-plugins": {
@@ -8634,8 +8634,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-load-plugins/download/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-loader": {
@@ -8644,10 +8644,10 @@
       "integrity": "sha1-PGM27mQcj5UTgXJTOuRhqDWV54g=",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "6.0.22",
-        "postcss-load-config": "1.2.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "postcss": "^6.0.0",
+        "postcss-load-config": "^1.2.0",
+        "schema-utils": "^0.4.0"
       }
     },
     "postcss-merge-idents": {
@@ -8655,9 +8655,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-merge-idents/download/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8670,11 +8670,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8694,10 +8694,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8710,7 +8710,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8720,7 +8720,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-merge-longhand/download/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8733,11 +8733,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8757,10 +8757,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8773,7 +8773,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8783,11 +8783,11 @@
       "resolved": "http://registry.npm.taobao.org/postcss-merge-rules/download/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.2"
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8800,8 +8800,8 @@
           "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000856",
-            "electron-to-chromium": "1.3.49"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -8809,11 +8809,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8833,10 +8833,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8849,7 +8849,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8864,9 +8864,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-minify-font-values/download/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8879,11 +8879,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8903,10 +8903,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8919,7 +8919,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8929,8 +8929,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-minify-gradients/download/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8943,11 +8943,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8967,10 +8967,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -8983,7 +8983,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8993,10 +8993,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-minify-params/download/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9009,11 +9009,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9033,10 +9033,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9049,7 +9049,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9059,10 +9059,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-minify-selectors/download/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3"
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9075,11 +9075,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9099,10 +9099,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9115,7 +9115,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9125,10 +9125,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-modules/download/postcss-modules-1.1.0.tgz",
       "integrity": "sha1-yflPdv9q3ffDW4Quae1EIRgVa7A=",
       "requires": {
-        "css-modules-loader-core": "1.1.0",
-        "generic-names": "1.0.3",
-        "postcss": "6.0.22",
-        "string-hash": "1.1.3"
+        "css-modules-loader-core": "^1.1.0",
+        "generic-names": "^1.0.2",
+        "postcss": "^6.0.1",
+        "string-hash": "^1.1.1"
       }
     },
     "postcss-modules-extract-imports": {
@@ -9137,7 +9137,7 @@
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-local-by-default": {
@@ -9145,8 +9145,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-modules-local-by-default/download/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.22"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-scope": {
@@ -9154,8 +9154,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-modules-scope/download/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.22"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-values": {
@@ -9163,8 +9163,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-modules-values/download/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.22"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-normalize-charset": {
@@ -9172,7 +9172,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-normalize-charset/download/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9185,11 +9185,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9209,10 +9209,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9225,7 +9225,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9235,10 +9235,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-normalize-url/download/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9251,11 +9251,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9275,10 +9275,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9291,7 +9291,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9301,8 +9301,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-ordered-values/download/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9315,11 +9315,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9339,10 +9339,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9355,7 +9355,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9365,8 +9365,8 @@
       "resolved": "http://registry.npm.taobao.org/postcss-reduce-idents/download/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9379,11 +9379,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9403,10 +9403,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9419,7 +9419,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9429,7 +9429,7 @@
       "resolved": "http://registry.npm.taobao.org/postcss-reduce-initial/download/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9442,11 +9442,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9466,10 +9466,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9482,7 +9482,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9492,9 +9492,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-reduce-transforms/download/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9507,11 +9507,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9531,10 +9531,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9547,7 +9547,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9557,9 +9557,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -9567,10 +9567,10 @@
       "resolved": "http://registry.npm.taobao.org/postcss-svgo/download/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9583,11 +9583,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9607,10 +9607,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9623,7 +9623,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9633,9 +9633,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-unique-selectors/download/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9648,11 +9648,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9672,10 +9672,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9688,7 +9688,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9703,9 +9703,9 @@
       "resolved": "http://registry.npm.taobao.org/postcss-zindex/download/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9718,11 +9718,11 @@
           "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9742,10 +9742,10 @@
           "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
           "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.5",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -9758,7 +9758,7 @@
           "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -9807,7 +9807,7 @@
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "optional": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promise-inflight": {
@@ -9828,7 +9828,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "with-callback": "1.0.2"
+        "with-callback": "^1.0.2"
       }
     },
     "proxy-addr": {
@@ -9837,7 +9837,7 @@
       "integrity": "sha1-NV8mJQWmIWRrMTCnKOtkfiIFU0E=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -9848,14 +9848,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lru-cache": "4.1.3",
-        "pac-proxy-agent": "2.0.2",
-        "proxy-from-env": "1.0.0",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "pac-proxy-agent": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -9893,11 +9893,11 @@
       "integrity": "sha1-RuuRByBr9zSJ+LhbadkTNMZhCZQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -9906,8 +9906,8 @@
       "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -9916,9 +9916,9 @@
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -9948,8 +9948,8 @@
       "resolved": "http://registry.npm.taobao.org/query-string/download/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -9969,9 +9969,9 @@
       "resolved": "http://registry.npm.taobao.org/randomatic/download/randomatic-3.0.0.tgz",
       "integrity": "sha1-01SQAw6091eN4pLObfsEqRoSiSM=",
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -9987,7 +9987,7 @@
       "integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -9996,8 +9996,8 @@
       "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -10033,7 +10033,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -10054,9 +10054,9 @@
       "resolved": "http://registry.npm.taobao.org/read-pkg/download/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -10064,8 +10064,8 @@
       "resolved": "http://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -10073,8 +10073,8 @@
           "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -10082,7 +10082,7 @@
           "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -10093,13 +10093,13 @@
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -10116,10 +10116,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "redent": {
@@ -10128,8 +10128,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "redis": {
@@ -10139,9 +10139,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -10163,9 +10163,9 @@
       "resolved": "http://registry.npm.taobao.org/reduce-css-calc/download/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -10180,7 +10180,7 @@
       "resolved": "http://registry.npm.taobao.org/reduce-function-call/download/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "^0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -10205,9 +10205,9 @@
       "resolved": "http://registry.npm.taobao.org/regenerator-transform/download/regenerator-transform-0.10.1.tgz",
       "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -10215,7 +10215,7 @@
       "resolved": "http://registry.npm.taobao.org/regex-cache/download/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -10223,8 +10223,8 @@
       "resolved": "http://registry.npm.taobao.org/regex-not/download/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpu-core": {
@@ -10232,9 +10232,9 @@
       "resolved": "http://registry.npm.taobao.org/regexpu-core/download/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -10247,7 +10247,7 @@
       "resolved": "http://registry.npm.taobao.org/regjsparser/download/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -10277,7 +10277,7 @@
       "resolved": "http://registry.npm.taobao.org/repeating/download/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -10285,26 +10285,26 @@
       "resolved": "http://registry.npm.taobao.org/request/download/request-2.87.0.tgz",
       "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "requestretry": {
@@ -10314,10 +10314,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "3.0.1",
-        "lodash": "4.17.10",
-        "request": "2.87.0",
-        "when": "3.7.8"
+        "extend": "^3.0.0",
+        "lodash": "^4.15.0",
+        "request": "^2.74.0",
+        "when": "^3.7.7"
       }
     },
     "require-from-string": {
@@ -10361,8 +10361,8 @@
       "resolved": "http://registry.npm.taobao.org/restore-cursor/download/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -10377,7 +10377,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -10385,7 +10385,7 @@
       "resolved": "http://registry.npm.taobao.org/rimraf/download/rimraf-2.6.2.tgz",
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -10394,8 +10394,8 @@
       "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rollup": {
@@ -10404,7 +10404,7 @@
       "integrity": "sha1-K2Lvkwb3GbGrhaeBSz5llqxR+ug=",
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "10.3.4"
+        "@types/node": "*"
       }
     },
     "rollup-plugin-alias": {
@@ -10412,7 +10412,7 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-alias/download/rollup-plugin-alias-1.4.0.tgz",
       "integrity": "sha1-Egy6fEZiHAMTjwym/V3SremHLbk=",
       "requires": {
-        "slash": "1.0.0"
+        "slash": "^1.0.0"
       }
     },
     "rollup-plugin-babel": {
@@ -10420,7 +10420,7 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-babel/download/rollup-plugin-babel-3.0.7.tgz",
       "integrity": "sha1-WxNhHxq4kiSX6dFRl65diiP+Ox4=",
       "requires": {
-        "rollup-pluginutils": "1.5.2"
+        "rollup-pluginutils": "^1.5.0"
       }
     },
     "rollup-plugin-commonjs": {
@@ -10428,10 +10428,10 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-commonjs/download/rollup-plugin-commonjs-9.1.3.tgz",
       "integrity": "sha1-N7+/NBKS6hT1EkOKVt+PnKO6TWc=",
       "requires": {
-        "estree-walker": "0.5.2",
-        "magic-string": "0.22.5",
-        "resolve": "1.8.1",
-        "rollup-pluginutils": "2.3.0"
+        "estree-walker": "^0.5.1",
+        "magic-string": "^0.22.4",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -10439,7 +10439,7 @@
           "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -10452,9 +10452,9 @@
           "resolved": "http://registry.npm.taobao.org/braces/download/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "estree-walker": {
@@ -10467,7 +10467,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -10475,7 +10475,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-range/download/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "requires": {
-            "fill-range": "2.2.4"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -10483,7 +10483,7 @@
           "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "fill-range": {
@@ -10491,11 +10491,11 @@
           "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-extglob": {
@@ -10508,7 +10508,7 @@
           "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -10516,7 +10516,7 @@
           "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isarray": {
@@ -10537,7 +10537,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -10545,19 +10545,19 @@
           "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "resolve": {
@@ -10565,7 +10565,7 @@
           "resolved": "http://registry.npm.taobao.org/resolve/download/resolve-1.8.1.tgz",
           "integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "rollup-pluginutils": {
@@ -10573,8 +10573,8 @@
           "resolved": "http://registry.npm.taobao.org/rollup-pluginutils/download/rollup-pluginutils-2.3.0.tgz",
           "integrity": "sha1-R4rOBL1/baLnJDVsp5ghSIRzj8Q=",
           "requires": {
-            "estree-walker": "0.5.2",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
           }
         }
       }
@@ -10584,9 +10584,9 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-node-resolve/download/rollup-plugin-node-resolve-3.3.0.tgz",
       "integrity": "sha1-wm0RCjaBLL76fOEXytzTQ5qhxxM=",
       "requires": {
-        "builtin-modules": "2.0.0",
-        "is-module": "1.0.0",
-        "resolve": "1.1.7"
+        "builtin-modules": "^2.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.1.6"
       },
       "dependencies": {
         "builtin-modules": {
@@ -10601,22 +10601,22 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-postcss2/download/rollup-plugin-postcss2-1.0.0.tgz",
       "integrity": "sha1-JdOo/Fur3XjMkDXPS3GW66it0e8=",
       "requires": {
-        "@vue/component-compiler-utils": "1.3.1",
-        "chalk": "2.4.1",
-        "concat-with-sourcemaps": "1.1.0",
-        "cssnano": "3.10.0",
-        "fs-extra": "5.0.0",
-        "import-cwd": "2.1.0",
-        "p-queue": "2.4.2",
-        "pify": "3.0.0",
-        "postcss": "6.0.22",
-        "postcss-load-config": "1.2.0",
-        "postcss-modules": "1.1.0",
-        "promise.series": "0.2.0",
-        "reserved-words": "0.1.2",
-        "resolve": "1.8.1",
-        "rollup-pluginutils": "2.3.0",
-        "style-inject": "0.3.0"
+        "@vue/component-compiler-utils": "^1.0.0",
+        "chalk": "^2.0.0",
+        "concat-with-sourcemaps": "^1.0.5",
+        "cssnano": "^3.10.0",
+        "fs-extra": "^5.0.0",
+        "import-cwd": "^2.1.0",
+        "p-queue": "^2.4.2",
+        "pify": "^3.0.0",
+        "postcss": "^6.0.21",
+        "postcss-load-config": "^1.2.0",
+        "postcss-modules": "^1.1.0",
+        "promise.series": "^0.2.0",
+        "reserved-words": "^0.1.2",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1",
+        "style-inject": "^0.3.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -10624,7 +10624,7 @@
           "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -10637,9 +10637,9 @@
           "resolved": "http://registry.npm.taobao.org/braces/download/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "estree-walker": {
@@ -10652,7 +10652,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -10660,7 +10660,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-range/download/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "requires": {
-            "fill-range": "2.2.4"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -10668,7 +10668,7 @@
           "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "fill-range": {
@@ -10676,11 +10676,11 @@
           "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "fs-extra": {
@@ -10688,9 +10688,9 @@
           "resolved": "http://registry.npm.taobao.org/fs-extra/download/fs-extra-5.0.0.tgz",
           "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "is-extglob": {
@@ -10703,7 +10703,7 @@
           "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -10711,7 +10711,7 @@
           "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isarray": {
@@ -10732,7 +10732,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -10740,19 +10740,19 @@
           "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "resolve": {
@@ -10760,7 +10760,7 @@
           "resolved": "http://registry.npm.taobao.org/resolve/download/resolve-1.8.1.tgz",
           "integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "rollup-pluginutils": {
@@ -10768,8 +10768,8 @@
           "resolved": "http://registry.npm.taobao.org/rollup-pluginutils/download/rollup-pluginutils-2.3.0.tgz",
           "integrity": "sha1-R4rOBL1/baLnJDVsp5ghSIRzj8Q=",
           "requires": {
-            "estree-walker": "0.5.2",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
           }
         }
       }
@@ -10779,9 +10779,9 @@
       "resolved": "http://registry.npm.taobao.org/rollup-plugin-replace/download/rollup-plugin-replace-2.0.0.tgz",
       "integrity": "sha1-GQdAicjtVxhLjMZOlnoD0JURknc=",
       "requires": {
-        "magic-string": "0.22.5",
-        "minimatch": "3.0.4",
-        "rollup-pluginutils": "2.3.0"
+        "magic-string": "^0.22.4",
+        "minimatch": "^3.0.2",
+        "rollup-pluginutils": "^2.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -10789,7 +10789,7 @@
           "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -10802,9 +10802,9 @@
           "resolved": "http://registry.npm.taobao.org/braces/download/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "estree-walker": {
@@ -10817,7 +10817,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -10825,7 +10825,7 @@
           "resolved": "http://registry.npm.taobao.org/expand-range/download/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "requires": {
-            "fill-range": "2.2.4"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -10833,7 +10833,7 @@
           "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "fill-range": {
@@ -10841,11 +10841,11 @@
           "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-extglob": {
@@ -10858,7 +10858,7 @@
           "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -10866,7 +10866,7 @@
           "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isarray": {
@@ -10887,7 +10887,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -10895,19 +10895,19 @@
           "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "rollup-pluginutils": {
@@ -10915,8 +10915,8 @@
           "resolved": "http://registry.npm.taobao.org/rollup-pluginutils/download/rollup-pluginutils-2.3.0.tgz",
           "integrity": "sha1-R4rOBL1/baLnJDVsp5ghSIRzj8Q=",
           "requires": {
-            "estree-walker": "0.5.2",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
           }
         }
       }
@@ -10926,8 +10926,8 @@
       "resolved": "http://registry.npm.taobao.org/rollup-pluginutils/download/rollup-pluginutils-1.5.2.tgz",
       "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
       "requires": {
-        "estree-walker": "0.2.1",
-        "minimatch": "3.0.4"
+        "estree-walker": "^0.2.1",
+        "minimatch": "^3.0.2"
       }
     },
     "run-queue": {
@@ -10936,7 +10936,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "safe-buffer": {
@@ -10949,7 +10949,7 @@
       "resolved": "http://registry.npm.taobao.org/safe-regex/download/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -10974,8 +10974,8 @@
       "integrity": "sha1-IYNvBgiqwXt4+ePiTa/xSlyhOj4=",
       "dev": true,
       "requires": {
-        "ajv": "6.5.1",
-        "ajv-keywords": "3.2.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       }
     },
     "script-loader": {
@@ -10983,7 +10983,7 @@
       "resolved": "http://registry.npm.taobao.org/script-loader/download/script-loader-0.7.2.tgz",
       "integrity": "sha1-IBbbb4byX1z1baOJFdgzeLsWa6c=",
       "requires": {
-        "raw-loader": "0.5.1"
+        "raw-loader": "~0.5.1"
       }
     },
     "selenium-server": {
@@ -11004,18 +11004,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       }
     },
     "serialize-javascript": {
@@ -11030,13 +11030,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.18",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       }
     },
     "serve-static": {
@@ -11045,9 +11045,9 @@
       "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -11062,10 +11062,10 @@
       "resolved": "http://registry.npm.taobao.org/set-value/download/set-value-2.0.0.tgz",
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11073,7 +11073,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -11096,8 +11096,8 @@
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -11106,7 +11106,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -11126,14 +11126,14 @@
       "integrity": "sha1-mOfXFrexH38SAOnJl+dPUK4JRmA=",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "@sinonjs/samsam": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.7.1",
-        "nise": "1.4.2",
-        "supports-color": "5.4.0",
-        "type-detect": "4.0.8"
+        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/samsam": "^2.0.0",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.4.2",
+        "nise": "^1.3.3",
+        "supports-color": "^5.4.0",
+        "type-detect": "^4.0.8"
       }
     },
     "sinon-chai": {
@@ -11149,7 +11149,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "requestretry": "1.13.0"
+        "requestretry": "^1.2.2"
       }
     },
     "slash": {
@@ -11178,14 +11178,14 @@
       "resolved": "http://registry.npm.taobao.org/snapdragon/download/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -11193,7 +11193,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -11201,7 +11201,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -11216,9 +11216,9 @@
       "resolved": "http://registry.npm.taobao.org/snapdragon-node/download/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -11226,7 +11226,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11234,7 +11234,7 @@
           "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -11242,7 +11242,7 @@
           "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -11250,9 +11250,9 @@
           "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -11262,7 +11262,7 @@
       "resolved": "http://registry.npm.taobao.org/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -11270,7 +11270,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11282,7 +11282,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "socket.io": {
@@ -11291,11 +11291,11 @@
       "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "engine.io": "3.1.5",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~2.6.6",
+        "engine.io": "~3.1.0",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.0.4",
-        "socket.io-parser": "3.1.3"
+        "socket.io-parser": "~3.1.1"
       }
     },
     "socket.io-adapter": {
@@ -11314,14 +11314,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.6",
+        "debug": "~2.6.4",
+        "engine.io-client": "~3.1.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.3",
+        "socket.io-parser": "~3.1.1",
         "to-array": "0.1.4"
       }
     },
@@ -11332,8 +11332,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "has-binary2": "1.0.3",
+        "debug": "~3.1.0",
+        "has-binary2": "~1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -11360,8 +11360,8 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.4",
+        "smart-buffer": "^1.0.13"
       }
     },
     "socks-proxy-agent": {
@@ -11370,8 +11370,8 @@
       "integrity": "sha1-Lq58+OKoLTRWV2FTmn+XGMVhdlk=",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "socks": "1.1.10"
+        "agent-base": "^4.1.0",
+        "socks": "^1.1.10"
       }
     },
     "sort-keys": {
@@ -11379,7 +11379,7 @@
       "resolved": "http://registry.npm.taobao.org/sort-keys/download/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -11398,11 +11398,11 @@
       "resolved": "http://registry.npm.taobao.org/source-map-resolve/download/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -11410,7 +11410,7 @@
       "resolved": "http://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz",
       "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -11430,8 +11430,8 @@
       "resolved": "http://registry.npm.taobao.org/spdx-correct/download/spdx-correct-3.0.0.tgz",
       "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -11444,8 +11444,8 @@
       "resolved": "http://registry.npm.taobao.org/spdx-expression-parse/download/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -11458,7 +11458,7 @@
       "resolved": "http://registry.npm.taobao.org/split-string/download/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -11471,15 +11471,15 @@
       "resolved": "http://registry.npm.taobao.org/sshpk/download/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -11488,7 +11488,7 @@
       "integrity": "sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "static-extend": {
@@ -11496,8 +11496,8 @@
       "resolved": "http://registry.npm.taobao.org/static-extend/download/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -11505,7 +11505,7 @@
           "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -11522,8 +11522,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -11532,8 +11532,8 @@
       "integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -11542,11 +11542,11 @@
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -11561,10 +11561,10 @@
       "integrity": "sha1-odG3z4PTmvsNYwSaWsv5NJO99ks=",
       "dev": true,
       "requires": {
-        "date-format": "1.2.0",
-        "debug": "3.1.0",
-        "mkdirp": "0.5.1",
-        "readable-stream": "2.3.6"
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
       },
       "dependencies": {
         "debug": {
@@ -11583,19 +11583,19 @@
       "resolved": "http://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/string-hash/download/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npm.taobao.org/string-hash/download/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "stringstream": {
       "version": "0.0.6",
@@ -11609,7 +11609,7 @@
       "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -11617,7 +11617,7 @@
       "resolved": "http://registry.npm.taobao.org/strip-bom/download/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -11626,7 +11626,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "style-inject": {
@@ -11640,8 +11640,8 @@
       "integrity": "sha1-aMUuXrKvycqStidL4nfuWa6jqFI=",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.4.5"
       }
     },
     "supports-color": {
@@ -11649,7 +11649,7 @@
       "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.4.0.tgz",
       "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "svg-tags": {
@@ -11662,13 +11662,13 @@
       "resolved": "http://registry.npm.taobao.org/svgo/download/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
       }
     },
     "tapable": {
@@ -11682,11 +11682,11 @@
       "resolved": "http://registry.npm.taobao.org/test-exclude/download/test-exclude-4.2.1.tgz",
       "integrity": "sha1-36Ii8DSAvKaSB8pyizfXS0X3JPo=",
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^3.1.8",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-encoding": {
@@ -11701,8 +11701,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "thunkify": {
@@ -11717,7 +11717,7 @@
       "integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "timespan": {
@@ -11733,7 +11733,7 @@
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-array": {
@@ -11758,7 +11758,7 @@
       "resolved": "http://registry.npm.taobao.org/to-object-path/download/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -11766,7 +11766,7 @@
           "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11776,10 +11776,10 @@
       "resolved": "http://registry.npm.taobao.org/to-regex/download/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -11787,8 +11787,8 @@
       "resolved": "http://registry.npm.taobao.org/to-regex-range/download/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -11796,7 +11796,7 @@
       "resolved": "http://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.3.4.tgz",
       "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -11847,7 +11847,7 @@
       "resolved": "http://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -11862,7 +11862,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -11878,7 +11878,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -11892,8 +11892,8 @@
       "resolved": "http://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.1.tgz",
       "integrity": "sha1-AG2lQNwl6TGdEGqZpe8dJK4EzmA=",
       "requires": {
-        "commander": "2.15.1",
-        "source-map": "0.6.1"
+        "commander": "~2.15.0",
+        "source-map": "~0.6.1"
       }
     },
     "uglify-to-browserify": {
@@ -11909,14 +11909,14 @@
       "integrity": "sha1-9LtE8CQx6CswHY1GJDMKajVyk4E=",
       "dev": true,
       "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.5",
-        "serialize-javascript": "1.5.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.6.0"
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.4.5",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "uglify-es": "^3.3.4",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "commander": {
@@ -11931,8 +11931,8 @@
           "integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -11954,10 +11954,10 @@
       "resolved": "http://registry.npm.taobao.org/union-value/download/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11965,7 +11965,7 @@
           "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -11973,10 +11973,10 @@
           "resolved": "http://registry.npm.taobao.org/set-value/download/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -11997,7 +11997,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -12006,7 +12006,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -12025,8 +12025,8 @@
       "resolved": "http://registry.npm.taobao.org/unset-value/download/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -12034,9 +12034,9 @@
           "resolved": "http://registry.npm.taobao.org/has-value/download/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -12073,7 +12073,7 @@
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -12111,9 +12111,9 @@
       "integrity": "sha1-YbxT8fGE1zQ9onKKEonvhyLqRe4=",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "2.3.1",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "mime": "^2.0.3",
+        "schema-utils": "^0.4.3"
       },
       "dependencies": {
         "mime": {
@@ -12129,7 +12129,7 @@
       "resolved": "http://registry.npm.taobao.org/use/download/use-3.1.0.tgz",
       "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "useragent": {
@@ -12138,8 +12138,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.33"
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
       },
       "dependencies": {
         "lru-cache": {
@@ -12188,8 +12188,8 @@
       "resolved": "http://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -12208,9 +12208,9 @@
       "resolved": "http://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -12240,11 +12240,11 @@
       "integrity": "sha1-p7kjEj08+HIwqP9UocFtMabF27Q=",
       "dev": true,
       "requires": {
-        "@vue/component-compiler-utils": "1.3.1",
-        "hash-sum": "1.0.2",
-        "loader-utils": "1.1.0",
-        "vue-hot-reload-api": "2.3.0",
-        "vue-style-loader": "4.1.0"
+        "@vue/component-compiler-utils": "^1.2.1",
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.1.0",
+        "vue-hot-reload-api": "^2.3.0",
+        "vue-style-loader": "^4.1.0"
       }
     },
     "vue-style-loader": {
@@ -12253,8 +12253,8 @@
       "integrity": "sha1-dYi9d44sn42Hv8PFpKA5Y42nqGM=",
       "dev": true,
       "requires": {
-        "hash-sum": "1.0.2",
-        "loader-utils": "1.1.0"
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
       }
     },
     "vue-template-compiler": {
@@ -12262,8 +12262,8 @@
       "resolved": "http://registry.npm.taobao.org/vue-template-compiler/download/vue-template-compiler-2.5.16.tgz",
       "integrity": "sha1-k7SFcOVscgzfPwUcwVKHwm+9BMs=",
       "requires": {
-        "de-indent": "1.0.2",
-        "he": "1.1.1"
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "vue-template-es2015-compiler": {
@@ -12277,9 +12277,9 @@
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.4",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "wcwidth": {
@@ -12287,7 +12287,7 @@
       "resolved": "http://registry.npm.taobao.org/wcwidth/download/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webpack": {
@@ -12301,26 +12301,26 @@
         "@webassemblyjs/wasm-edit": "1.5.12",
         "@webassemblyjs/wasm-opt": "1.5.12",
         "@webassemblyjs/wasm-parser": "1.5.12",
-        "acorn": "5.7.1",
-        "acorn-dynamic-import": "3.0.0",
-        "ajv": "6.5.1",
-        "ajv-keywords": "3.2.0",
-        "chrome-trace-event": "1.0.0",
-        "enhanced-resolve": "4.0.0",
-        "eslint-scope": "3.7.1",
-        "json-parse-better-errors": "1.0.2",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "neo-async": "2.5.1",
-        "node-libs-browser": "2.1.0",
-        "schema-utils": "0.4.5",
-        "tapable": "1.0.0",
-        "uglifyjs-webpack-plugin": "1.2.6",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0"
+        "acorn": "^5.6.2",
+        "acorn-dynamic-import": "^3.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chrome-trace-event": "^1.0.0",
+        "enhanced-resolve": "^4.0.0",
+        "eslint-scope": "^3.7.1",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "micromatch": "^3.1.8",
+        "mkdirp": "~0.5.0",
+        "neo-async": "^2.5.0",
+        "node-libs-browser": "^2.0.0",
+        "schema-utils": "^0.4.4",
+        "tapable": "^1.0.0",
+        "uglifyjs-webpack-plugin": "^1.2.4",
+        "watchpack": "^1.5.0",
+        "webpack-sources": "^1.0.1"
       }
     },
     "webpack-bundle-analyzer": {
@@ -12329,18 +12329,18 @@
       "integrity": "sha1-B9IXbG6Gw83OTCPlb64qe2tK1SY=",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
-        "bfj-node4": "5.3.1",
-        "chalk": "2.4.1",
-        "commander": "2.15.1",
-        "ejs": "2.6.1",
-        "express": "4.16.3",
-        "filesize": "3.6.1",
-        "gzip-size": "4.1.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "opener": "1.4.3",
-        "ws": "4.1.0"
+        "acorn": "^5.3.0",
+        "bfj-node4": "^5.2.0",
+        "chalk": "^2.3.0",
+        "commander": "^2.13.0",
+        "ejs": "^2.5.7",
+        "express": "^4.16.2",
+        "filesize": "^3.5.11",
+        "gzip-size": "^4.1.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.4.3",
+        "ws": "^4.0.0"
       },
       "dependencies": {
         "ws": {
@@ -12349,8 +12349,8 @@
           "integrity": "sha1-qXm119TaaL9U7+BAiWfDJIaacok=",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12361,13 +12361,13 @@
       "integrity": "sha1-izKqQ9qa55Nowb8Rg/K2z14fOe0=",
       "dev": true,
       "requires": {
-        "loud-rejection": "1.6.0",
-        "memory-fs": "0.4.1",
-        "mime": "2.3.1",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "url-join": "4.0.0",
-        "webpack-log": "1.2.0"
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
       },
       "dependencies": {
         "mime": {
@@ -12390,10 +12390,10 @@
       "integrity": "sha1-pLNM2msitRjbsKsy5WeWLVxypD0=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "log-symbols": "2.2.0",
-        "loglevelnext": "1.0.5",
-        "uuid": "3.2.1"
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
       }
     },
     "webpack-merge": {
@@ -12402,7 +12402,7 @@
       "integrity": "sha1-iq/yEIoZwphJvJrSp/1/zmjofEo=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "webpack-sources": {
@@ -12411,8 +12411,8 @@
       "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       }
     },
     "when": {
@@ -12433,7 +12433,7 @@
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -12462,7 +12462,7 @@
       "integrity": "sha1-rsxAWXb6talVJhgIRvDboojzpKA=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrappy": {
@@ -12476,9 +12476,9 @@
       "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xmlhttprequest-ssl": {
@@ -12517,9 +12517,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -12538,7 +12538,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {

--- a/packages/mip/package.json
+++ b/packages/mip/package.json
@@ -60,7 +60,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
-    "document-register-element": "1.7.1",
+    "document-register-element": "1.13.1",
     "mip-sandbox": "^1.1.0-alpha-1",
     "autoprefixer": "^8.6.4",
     "babel-core": "^6.26.3",

--- a/packages/mip/package.json
+++ b/packages/mip/package.json
@@ -60,7 +60,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
-    "document-register-element": "^1.8.1",
+    "document-register-element": "1.7.1",
     "mip-sandbox": "^1.1.0-alpha-1",
     "autoprefixer": "^8.6.4",
     "babel-core": "^6.26.3",

--- a/packages/mip/src/components/mip-iframe.js
+++ b/packages/mip/src/components/mip-iframe.js
@@ -26,15 +26,6 @@ class MipIframe extends CustomElement {
     return true
   }
 
-  build () {
-    this.iframe = document.createElement('iframe')
-    this.iframe.frameBorder = '0'
-    this.iframe.scrolling = platform.isIos() ? /* istanbul ignore next */ 'no' : 'yes'
-
-    this.applyFillContent(this.iframe)
-    this.element.appendChild(this.iframe)
-  }
-
   layoutCallback () {
     this.handlePageResize = this.handlePageResize.bind(this)
     this.notifyRootPage = this.notifyRootPage.bind(this)
@@ -54,6 +45,13 @@ class MipIframe extends CustomElement {
       return Promise.resolve()
     }
 
+    this.iframe = document.createElement('iframe')
+    this.iframe.frameBorder = '0'
+    this.iframe.scrolling = platform.isIos() ? /* istanbul ignore next */ 'no' : 'yes'
+
+    this.applyFillContent(this.iframe)
+    this.element.appendChild(this.iframe)
+
     // window.addEventListener('message', )
     window.addEventListener('message', this.notifyRootPage.bind(this))
 
@@ -63,10 +61,6 @@ class MipIframe extends CustomElement {
     })
 
     this.iframe.src = src
-
-    // if (srcdoc) {
-    //   this.iframe.srcdoc = srcdoc
-    // }
 
     this.expendAttr(attrList, this.iframe)
     element.appendChild(this.iframe)

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -100,7 +100,7 @@ function getImgsSrc () {
  */
 function getCurrentImg (carouselWrapper, mipCarousel) {
   // 例如：'translate3d(-90px,0,0)'
-  let str = carouselWrapper.style.webkitTransform
+  let str = carouselWrapper.style.webkitTransform || carouselWrapper.style.transform
   let result = /translate3d\(-?([0-9]+)/i.exec(str)
   // 原先宽度是视口宽度，现在需要的是图片本身宽度。最后还是一样的。。。
   let width = mipCarousel.getAttribute('width')
@@ -205,8 +205,13 @@ function bindPopup (element, img) {
         skipTransition: true,
         extraClass: 'black'
       })
+
+      let mipCarouselWrapper = popup.querySelector('.mip-carousel-wrapper')
+      /* istanbul ignore if */
+      if (mipCarouselWrapper == null) return
+
       // 找出当前视口下的图片
-      let currentImg = getCurrentImg(popup.querySelector('.mip-carousel-wrapper'), mipCarousel)
+      let currentImg = getCurrentImg(mipCarouselWrapper, mipCarousel)
       popupImg.setAttribute('src', currentImg.getAttribute('data-src'))
       let previousPos = getImgOffset(img)
       // 获取弹出图片滑动的距离，根据前面的设定，top大于0就不是长图，小于0才是滑动的距离。

--- a/packages/mip/src/components/mip-shell/switchPage.js
+++ b/packages/mip/src/components/mip-shell/switchPage.js
@@ -4,7 +4,7 @@
  */
 /* istanbul ignore file */
 
-import {isPortrait} from '../../page/util/feature-detect'
+import viewport from '../../viewport'
 import css from '../../util/dom/css'
 import {
   getIFrame,
@@ -31,7 +31,7 @@ let activeZIndex = 10000
  * @param {Function} options.onComplete complete callback
  */
 export function switchPage (shell, options) {
-  if (isPortrait() && window.MIP_SHELL_OPTION.allowTransition) {
+  if (viewport.isPortrait() && window.MIP_SHELL_OPTION.allowTransition) {
     // enable transition
     if (options.newPage) {
       if (options.isForward) {

--- a/packages/mip/src/index.js
+++ b/packages/mip/src/index.js
@@ -12,12 +12,13 @@ import 'deps/promise'
 import 'deps/object-assign'
 /* eslint-enable import/no-webpack-loader-syntax */
 
-import {registerRuntime} from './runtime'
+import {getRuntime} from './runtime'
 import util from './util/index'
 import {applyLayout} from './layout'
 import viewer from './viewer'
 import viewport from './viewport'
 import builtinComponents from './components/index'
+import installSandbox from './sandbox'
 import sleepWakeModule from './sleep-wake-module'
 import performance from './performance'
 import errorMonitorInstall from './log/error-monitor'
@@ -27,7 +28,7 @@ import {OUTER_MESSAGE_PERFORMANCE_UPDATE} from './page/const/index'
 /* istanbul ignore next */
 if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefined') {
   errorMonitorInstall()
-  registerRuntime(window)
+  const MIP = getRuntime(window)
 
   // init viewport
   viewport.init()
@@ -35,6 +36,12 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
   util.dom.waitDocumentReady(() => {
     // Initialize sleepWakeModule
     sleepWakeModule.init()
+
+    const preregisteredExtensions = window.MIP || []
+
+    window.MIP = MIP
+
+    installSandbox(window.MIP)
 
     // Initialize viewer
     viewer.init()
@@ -51,6 +58,7 @@ if (typeof window.MIP === 'undefined' || typeof window.MIP.version === 'undefine
 
     // register buildin components
     builtinComponents.register()
+    Array.isArray(preregisteredExtensions) && preregisteredExtensions.forEach(window.MIP.push)
 
     performance.start(window._mipStartTiming)
     // send performance data

--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -6,11 +6,14 @@
 
 import css from '../../util/dom/css'
 import platform from '../../util/platform'
+import fn from '../../util/fn'
 
 import {MIP_IFRAME_CONTAINER} from '../const/index'
-import {raf, transitionEndEvent, animationEndEvent} from './feature-detect'
+import {transitionEndEvent, animationEndEvent} from './feature-detect'
 import {normalizeLocation} from './route'
 import viewport from '../../viewport'
+
+const {raf} = fn
 
 const MIP_SHELL_HEADER = 'mip-shell-header'
 const MIP_PAGE_LOADING_WRAPPER = 'mip-page-loading-wrapper'

--- a/packages/mip/src/page/util/ease-scroll.js
+++ b/packages/mip/src/page/util/ease-scroll.js
@@ -1,4 +1,4 @@
-import {raf} from './feature-detect'
+import fn from '../../util/fn'
 import viewport from '../../viewport'
 
 export function scrollTo (height, { duration = 500, scrollTop = 0 } = {}) {
@@ -39,13 +39,13 @@ export function scrollTo (height, { duration = 500, scrollTop = 0 } = {}) {
 function transition (duration, step, callback) {
   let start = Date.now()
 
-  raf(loop)
+  fn.raf(loop)
 
   function loop () {
     let now = Date.now() - start
 
     if (step(bezier(now, 0, 1, duration))) {
-      raf(loop)
+      fn.raf(loop)
     } else {
       callback()
     }

--- a/packages/mip/src/page/util/feature-detect.js
+++ b/packages/mip/src/page/util/feature-detect.js
@@ -36,7 +36,3 @@ export const animationEndEvent = animationEndEventName
 export const raf = window.requestAnimationFrame
   ? window.requestAnimationFrame.bind(window)
   : /* istanbul ignore next */setTimeout
-
-export function isPortrait () {
-  return window.innerHeight > window.innerWidth
-}

--- a/packages/mip/src/page/util/feature-detect.js
+++ b/packages/mip/src/page/util/feature-detect.js
@@ -32,7 +32,3 @@ if (window.onanimationend === undefined &&
 }
 export const transitionEndEvent = transitionEndEventName
 export const animationEndEvent = animationEndEventName
-
-export const raf = window.requestAnimationFrame
-  ? window.requestAnimationFrame.bind(window)
-  : /* istanbul ignore next */setTimeout

--- a/packages/mip/src/register-element.js
+++ b/packages/mip/src/register-element.js
@@ -238,6 +238,7 @@ class BaseElement extends HTMLElement {
    * Creates a loading object.
    */
   prepareLoading () {
+    /* istanbul ignore if */
     if (!this.isLoadingEnabled()) {
       return
     }
@@ -275,6 +276,7 @@ class BaseElement extends HTMLElement {
     }
 
     this.prepareLoading()
+    /* istanbul ignore if */
     if (!this._loadingContainer) {
       return
     }
@@ -320,6 +322,7 @@ class BaseElement extends HTMLElement {
   }
 
   _getSpace () {
+    /* istanbul ignore if */
     if (this.spaceElement === undefined &&
       this._layout === LAYOUT.RESPONSIVE) {
       // Expect space to exist, just not yet discovered.

--- a/packages/mip/src/register-element.js
+++ b/packages/mip/src/register-element.js
@@ -114,6 +114,7 @@ class BaseElement extends HTMLElement {
     // Apply layout for this.
     this.classList.add('mip-element')
     this._layout = applyLayout(this)
+    this.applySizesAndMediaQuery()
     this.customElement.connectedCallback()
     this._resources.add(this)
   }
@@ -308,6 +309,7 @@ class BaseElement extends HTMLElement {
       // emit build event
       customEmit(this, 'build')
     } catch (e) {
+      this.error = e
       customEmit(this, 'build-error', e)
       console.warn('build error:', e)
     }

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -65,7 +65,7 @@ class Resources {
     this._viewport = viewport
 
     /** @private @type {Promise} */
-    this._updatePromise = null
+    this._rafId = null
 
     this._gesture = new Gesture(document, {
       preventX: false
@@ -103,7 +103,7 @@ class Resources {
         this.updateState()
       }, element)
     }
-    COMPONENTS_NEED_NOT_DELAY.indexOf(element.tagName) === -1 ? setTimeout(fn, 0) : fn()
+    COMPONENTS_NEED_NOT_DELAY.indexOf(element.tagName) === -1 ? setTimeout(fn, 20) : fn()
   }
 
   /**
@@ -157,10 +157,11 @@ class Resources {
    * @return {Promise<undefined>}
    */
   _update () {
-    if (!this._updatePromise) {
-      this._updatePromise = Promise.resolve().then(() => this._doRealUpdate())
+    if (!this._rafId) {
+      // 改用 raf 让页面一帧只计算一次 update
+      this._rafId = window.requestAnimationFrame(() => this._doRealUpdate())
     }
-    return this._updatePromise
+    return this._rafId
   }
 
   /**
@@ -187,7 +188,7 @@ class Resources {
       }
     }
 
-    this._updatePromise = null
+    this._rafId = null
   }
 
   /**

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -125,7 +125,7 @@ class Resources {
   /**
    * Return an object of resources.
    *
-   * @return {Array}
+   * @return {Object}
    */
   getResources () {
     return resources[this._rid]
@@ -168,26 +168,37 @@ class Resources {
    * Do real update elements's viewport state with performance
    */
   _doRealUpdate () {
+    /* @type {Object} */
     let resources = this.getResources()
-    let viewportRect = this._viewport.getRect()
-    let i = 0
-    let ele = resources[i]
-    // 这里需要把 resources 当成一个队列来遍历，
-    // 因为组件可能在生命周期内可能产生新的组件实例
-    while (ele) {
-      if (ele.isBuilt()) {
-        // Compute the viewport state of current element.
-        // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
-        let elementRect = rect.getElementRect(ele)
-        let inViewport = ele.prerenderAllowed(elementRect, viewportRect) ||
-          rect.overlapping(elementRect, viewportRect) ||
-          // 在 ios 有个设置滚动${@link ./viewer.lockBodyScroll} 会设置 scrollTop=1
-          // 如果部分元素在顶部而且没有设置高度，会导致 elementRect 和 viewportRect 不重叠，
-          // 进而导致无法执行元素的生命周期，针对这种情况做特殊处理
-          (elementRect.bottom === 0 && elementRect.top === 0 && viewportRect.top === 1)
-        this.setInViewport(ele, inViewport)
+    let viewportRect = viewport.getRect()
+
+    let keys = Object.keys(resources)
+    let diff = [...keys]
+
+    while (diff.length) {
+      let ele = resources[diff.shift()]
+
+      while (ele) {
+        if (ele.isBuilt()) {
+          // Compute the viewport state of current element.
+          // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
+          let elementRect = rect.getElementRect(ele)
+          let inViewport = ele.prerenderAllowed(elementRect, viewportRect) ||
+            rect.overlapping(elementRect, viewportRect) ||
+            // 在 ios 有个设置滚动${@link ./viewer.lockBodyScroll} 会设置 scrollTop=1
+            // 如果部分元素在顶部而且没有设置高度，会导致 elementRect 和 viewportRect 不重叠，
+            // 进而导致无法执行元素的生命周期，针对这种情况做特殊处理
+            (elementRect.bottom === 0 && elementRect.top === 0 && viewportRect.top === 1)
+
+          this.setInViewport(ele, inViewport)
+        }
+        ele = resources[diff.shift()]
       }
-      ele = resources[++i]
+
+      let updatedKeys = Object.keys(resources)
+      // 计算是否有新增的自定义元素
+      diff = updatedKeys.filter(k => keys.indexOf(k) < 0)
+      keys = updatedKeys
     }
     this._rafId = null
   }

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -172,12 +172,19 @@ class Resources {
     let resources = this.getResources()
     let viewportRect = viewport.getRect()
 
-    let keys = Object.keys(resources)
-    let diff = [...keys]
+    let elementIds = []
+    while (true) {
+      let updatedElementIds = Object.keys(resources)
+      // 计算是否有新增的自定义元素
+      let newElementIds = updatedElementIds.filter(k => elementIds.indexOf(k) < 0)
+      elementIds = updatedElementIds
 
-    while (diff.length) {
-      while (diff.length) {
-        let ele = resources[diff.shift()]
+      if (!newElementIds.length) {
+        break
+      }
+
+      for (let i = 0, len = newElementIds.length; i < len; i++) {
+        let ele = resources[newElementIds[i]]
         // The element may have been removed.
         if (ele && ele.isBuilt()) {
           // Compute the viewport state of current element.
@@ -193,11 +200,6 @@ class Resources {
           this.setInViewport(ele, inViewport)
         }
       }
-
-      let updatedKeys = Object.keys(resources)
-      // 计算是否有新增的自定义元素
-      diff = updatedKeys.filter(k => keys.indexOf(k) < 0)
-      keys = updatedKeys
     }
     this._rafId = null
   }

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -170,21 +170,25 @@ class Resources {
   _doRealUpdate () {
     let resources = this.getResources()
     let viewportRect = this._viewport.getRect()
-    for (let i in resources) {
-      if (resources[i].isBuilt()) {
+    let i = 0
+    let ele = resources[i]
+    // 这里需要把 resources 当成一个队列来遍历，
+    // 因为组件可能在生命周期内可能产生新的组件实例
+    while (ele) {
+      if (ele.isBuilt()) {
         // Compute the viewport state of current element.
         // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
-        let elementRect = rect.getElementRect(resources[i])
-        let inViewport = resources[i].prerenderAllowed(elementRect, viewportRect) ||
+        let elementRect = rect.getElementRect(ele)
+        let inViewport = ele.prerenderAllowed(elementRect, viewportRect) ||
           rect.overlapping(elementRect, viewportRect) ||
           // 在 ios 有个设置滚动${@link ./viewer.lockBodyScroll} 会设置 scrollTop=1
           // 如果部分元素在顶部而且没有设置高度，会导致 elementRect 和 viewportRect 不重叠，
           // 进而导致无法执行元素的生命周期，针对这种情况做特殊处理
           (elementRect.bottom === 0 && elementRect.top === 0 && viewportRect.top === 1)
-        this.setInViewport(resources[i], inViewport)
+        this.setInViewport(ele, inViewport)
       }
+      ele = resources[++i]
     }
-
     this._rafId = null
   }
 

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -9,7 +9,7 @@ import viewport from './viewport'
 import rect from './util/dom/rect'
 import prerender from './client-prerender'
 
-const COMPONENTS_NEED_NOT_DELAY = ['MIP-IMG', 'MIP-CAROUSEL', 'MIP-DATA', 'MIP-VIDEO', 'MIP-LAYOUT']
+// const COMPONENTS_NEED_NOT_DELAY = ['MIP-IMG', 'MIP-CAROUSEL', 'MIP-DATA', 'MIP-VIDEO', 'MIP-LAYOUT']
 
 /**
  * Store the resources.
@@ -97,13 +97,13 @@ class Resources {
     element._eid = this._eid++
     resources[this._rid][element._eid] = element
 
-    let fn = () => {
-      prerender.execute(() => {
-        element.build()
-        this.updateState()
-      }, element)
-    }
-    COMPONENTS_NEED_NOT_DELAY.indexOf(element.tagName) === -1 ? setTimeout(fn, 20) : fn()
+    // let fn = () => {
+    prerender.execute(() => {
+      element.build()
+      this.updateState()
+    }, element)
+    // }
+    // COMPONENTS_NEED_NOT_DELAY.indexOf(element.tagName) === -1 ? setTimeout(fn, 20) : fn()
   }
 
   /**
@@ -170,7 +170,6 @@ class Resources {
   _doRealUpdate () {
     let resources = this.getResources()
     let viewportRect = this._viewport.getRect()
-
     for (let i in resources) {
       if (resources[i].isBuilt()) {
         // 兼容 mip1 的组件

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -176,10 +176,10 @@ class Resources {
     let diff = [...keys]
 
     while (diff.length) {
-      let ele = resources[diff.shift()]
-
-      while (ele) {
-        if (ele.isBuilt()) {
+      while (diff.length) {
+        let ele = resources[diff.shift()]
+        // The element may have been removed.
+        if (ele && ele.isBuilt()) {
           // Compute the viewport state of current element.
           // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
           let elementRect = rect.getElementRect(ele)
@@ -192,7 +192,6 @@ class Resources {
 
           this.setInViewport(ele, inViewport)
         }
-        ele = resources[diff.shift()]
       }
 
       let updatedKeys = Object.keys(resources)

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -64,7 +64,7 @@ class Resources {
      */
     this._viewport = viewport
 
-    /** @private @type {Promise} */
+    /** @private @type {number} */
     this._rafId = null
 
     this._gesture = new Gesture(document, {
@@ -159,7 +159,7 @@ class Resources {
   _update () {
     if (!this._rafId) {
       // 改用 raf 让页面一帧只计算一次 update
-      this._rafId = window.requestAnimationFrame(() => this._doRealUpdate())
+      this._rafId = fn.raf(() => this._doRealUpdate())
     }
     return this._rafId
   }
@@ -172,8 +172,6 @@ class Resources {
     let viewportRect = this._viewport.getRect()
     for (let i in resources) {
       if (resources[i].isBuilt()) {
-        // 兼容 mip1 的组件
-        resources[i].applySizesAndMediaQuery && resources[i].applySizesAndMediaQuery()
         // Compute the viewport state of current element.
         // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
         let elementRect = rect.getElementRect(resources[i])

--- a/packages/mip/src/runtime.js
+++ b/packages/mip/src/runtime.js
@@ -11,7 +11,6 @@ import util from './util'
 import viewer from './viewer'
 import viewport from './viewport'
 import installMip1Polyfill from './mip1-polyfill'
-import installSandbox from './sandbox'
 import installMipComponentsPolyfill from 'deps/mip-components-webpack-helpers'
 
 class Runtime {
@@ -92,17 +91,16 @@ class Runtime {
   }
 
   /**
-   * Registers the runtime in global scope. Constructs `window.MIP` object.
+   * Returns the runtime object.
    */
-  register () {
-    const preregisteredExtensions = this.win.MIP || []
+  get () {
     const {pageMeta, standalone} = this.getPageMetadata()
 
     viewer.pageMeta = pageMeta
 
     const {installExtension, registerElement, registerService, registerTemplate} = this.extensions
 
-    let globalMip = this.win.MIP = {
+    const MIP = {
       version: '2',
       CustomElement,
       Services,
@@ -133,10 +131,10 @@ class Runtime {
       viewport
     }
 
-    installMip1Polyfill(globalMip)
+    installMip1Polyfill(MIP)
     installMipComponentsPolyfill()
-    installSandbox(globalMip)
-    Array.isArray(preregisteredExtensions) && preregisteredExtensions.forEach(installExtension)
+
+    return MIP
   }
 }
 
@@ -144,10 +142,8 @@ class Runtime {
  * @param {!Window} win
  * @returns {!Runtime}
  */
-export function registerRuntime (win) {
+export function getRuntime (win) {
   const runtime = new Runtime(win)
 
-  runtime.register()
-
-  return runtime
+  return runtime.get()
 }

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -298,6 +298,16 @@ export class Extensions {
 
     if (elementInstances && elementInstances.length) {
       elementInstances.forEach(el => {
+        if (el.isBuilt()) {
+          this.tryToResolveExtension(holder)
+          return
+        }
+
+        if (el.error) {
+          this.tryToRejectError(holder, el.error)
+          return
+        }
+
         /**
          * Lifecycle `build` of element instances is probably delayed with `setTimeout`.
          * If they are not, these event listeners would not be registered before they emit events.

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -288,15 +288,20 @@ export class Extensions {
     let elementInstances = this.getElementRegistrator(element)(name, implementation, css)
 
     if (elementInstances && elementInstances.length) {
-      elementInstances.forEach(el => {
+      holder.elementInstances = holder.elementInstances.concat(elementInstances)
+      for (let i = 0, len = elementInstances.length; i < len; i++) {
+        let el = elementInstances[i]
+
+        // Delay to last processing extension resolve.
         if (el.isBuilt()) {
-          this.tryToResolveExtension(holder)
-          return
+          continue
         }
 
+        // It can't catch error of customElements.define with try/catch.
+        // @see https://github.com/w3c/webcomponents/issues/547
         if (el.error) {
           this.tryToRejectError(holder, el.error)
-          return
+          break
         }
 
         /**
@@ -313,8 +318,7 @@ export class Extensions {
           unlistenBuild()
           unlistenBuildError()
         })
-      })
-      holder.elementInstances = holder.elementInstances.concat(elementInstances)
+      }
     }
   }
 

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -239,18 +239,9 @@ export class Extensions {
    * Installs an extension. The same as `MIP.push`.
    *
    * @param {!Object} extension
-   * @returns {!Promise<void>}
    */
   installExtension (extension) {
-    return Promise.all([
-      /**
-       * Disables `extension.deps` temporarily.
-       */
-      // this.preloadDepsOf(extension),
-      this.mipdoc.whenBodyAvailable()
-    ]).then(
-      () => this.registerExtension(extension.name, extension.func, this.win.MIP)
-    )
+    this.registerExtension(extension.name, extension.func, this.win.MIP)
   }
 
   /**

--- a/packages/mip/src/util/custom-event.js
+++ b/packages/mip/src/util/custom-event.js
@@ -8,6 +8,7 @@
 export default function customEvent (eventName, detail) {
   const params = {bubbles: false, cancelable: false, detail}
   let event
+  /* istanbul ignore else */
   if (typeof window.CustomEvent === 'function') {
     event = new CustomEvent(eventName, params)
   } else {

--- a/packages/mip/src/util/fn.js
+++ b/packages/mip/src/util/fn.js
@@ -203,6 +203,10 @@ function getRootName (name) {
   }
 }
 
+const raf = window.requestAnimationFrame
+  ? window.requestAnimationFrame.bind(window)
+  : setTimeout
+
 export default {
   throttle,
   values,
@@ -213,5 +217,6 @@ export default {
   del,
   hasTouch,
   isCacheUrl,
-  getRootName
+  getRootName,
+  raf
 }

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -447,7 +447,13 @@ let viewer = {
       }
 
       if (this.isIframed) {
-        setTimeout(() => this.lockBodyScroll(), 0)
+        // 这些兼容性的代码会严重触发 reflow，但又不需要在首帧执行
+        // 使用 setTimeout 不阻塞 postMessage 回调执行
+        setTimeout(() => {
+          this.lockBodyScroll()
+          this.viewportScroll()
+          this.fixSoftKeyboard()
+        }, 0)
 
         // While the back button is clicked,
         // the cached page has some problems.
@@ -478,11 +484,6 @@ let viewer = {
         document.documentElement.classList.add('trigger-layout')
         document.body.classList.add('trigger-layout')
       })
-    }
-
-    if (this.isIframed) {
-      this.viewportScroll()
-      this.fixSoftKeyboard()
     }
   },
 

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -450,10 +450,10 @@ let viewer = {
         // 这些兼容性的代码会严重触发 reflow，但又不需要在首帧执行
         // 使用 setTimeout 不阻塞 postMessage 回调执行
         setTimeout(() => {
-          this.lockBodyScroll()
-          this.viewportScroll()
           this.fixSoftKeyboard()
+          this.viewportScroll()
         }, 0)
+        this.lockBodyScroll()
 
         // While the back button is clicked,
         // the cached page has some problems.

--- a/packages/mip/src/viewport.js
+++ b/packages/mip/src/viewport.js
@@ -13,6 +13,11 @@ import platform from './util/platform'
 const docElem = document.documentElement
 const win = window
 
+let getWidth = () => win.innerWidth || docElem.clientWidth
+let getHeight = () => platform.isIOS()
+  ? (docElem.clientHeight || win.innerHeight)
+  : (win.innerHeight || docElem.clientHeight)
+
 /**
  * 触发 scroll 事件
  */
@@ -43,14 +48,16 @@ let scrollHandle = function (event) {
  *
  * @param {Object} event 事件对象
  */
-let savedWindowWidth = win.innerWidth || docElem.clientWidth
+let savedWindowWidth = getWidth()
+let savedWindowHeight = null
 let currentWindowWidth
 let resizeEvent = fn.throttle(function (event) {
-  currentWindowWidth = this.getWidth()
+  currentWindowWidth = getWidth()
   if (currentWindowWidth !== savedWindowWidth) {
     this.trigger('resize', event)
     savedWindowWidth = currentWindowWidth
   }
+  savedWindowHeight = getHeight()
 }, 200)
 
 /**
@@ -104,7 +111,10 @@ let viewport = {
    * @return {number}
    */
   getWidth () {
-    return win.innerWidth || docElem.clientWidth
+    if (savedWindowWidth == null) {
+      savedWindowWidth = getWidth()
+    }
+    return savedWindowWidth
   },
 
   /**
@@ -114,8 +124,10 @@ let viewport = {
    */
   getHeight () {
     /* istanbul ignore next */
-    return platform.isIOS() ? (docElem.clientHeight || win.innerHeight)
-      : (win.innerHeight || docElem.clientHeight)
+    if (savedWindowHeight == null) {
+      savedWindowHeight = getHeight()
+    }
+    return savedWindowHeight
   },
 
   /**
@@ -148,6 +160,10 @@ let viewport = {
       this.getWidth(),
       this.getHeight()
     )
+  },
+
+  isPortrait () {
+    return this.getHeight() > this.getWidth()
   }
 }
 

--- a/packages/mip/src/viewport.js
+++ b/packages/mip/src/viewport.js
@@ -50,7 +50,6 @@ let scrollHandle = function (event) {
  */
 let savedWindowWidth = null
 let savedWindowHeight = null
-
 let currentWindowWidth
 let resizeEvent = fn.throttle(function (event) {
   currentWindowWidth = getWidth()
@@ -77,10 +76,11 @@ let viewport = {
     this.scroller.addEventListener('scroll', scrollHandle.bind(this), false)
 
     // 只在 iOS 下处理兼容性问题
+    /* istanbul ignore if */
     if (platform.isIOS()) {
       savedWindowWidth = this.getWidth()
-      win.addEventListener('resize', resizeEvent.bind(this))
     }
+    win.addEventListener('resize', resizeEvent.bind(this))
   },
 
   /**

--- a/packages/mip/src/viewport.js
+++ b/packages/mip/src/viewport.js
@@ -48,8 +48,9 @@ let scrollHandle = function (event) {
  *
  * @param {Object} event 事件对象
  */
-let savedWindowWidth = getWidth()
+let savedWindowWidth = null
 let savedWindowHeight = null
+
 let currentWindowWidth
 let resizeEvent = fn.throttle(function (event) {
   currentWindowWidth = getWidth()
@@ -75,7 +76,11 @@ let viewport = {
 
     this.scroller.addEventListener('scroll', scrollHandle.bind(this), false)
 
-    win.addEventListener('resize', resizeEvent.bind(this))
+    // 只在 iOS 下处理兼容性问题
+    if (platform.isIOS()) {
+      savedWindowWidth = this.getWidth()
+      win.addEventListener('resize', resizeEvent.bind(this))
+    }
   },
 
   /**

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -72,7 +72,7 @@ describe('mip-carousel', function () {
     })
 
     it('should produce mip-carousel correctly', async function () {
-      await mipCarousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       let mipCarouselContainer = div.querySelector('div.mip-carousel-container')
       wrapBox = div.querySelector('div.mip-carousel-wrapper')
       slideBoxs = wrapBox.querySelectorAll('div.mip-carousel-slideBox')
@@ -165,7 +165,7 @@ describe('mip-carousel', function () {
     let wrapBox
     let event = document.createEvent('Events')
     let indicator
-    let carousel
+    let mipCarousel
     this.timeout(2000)
 
     before(function () {
@@ -186,12 +186,12 @@ describe('mip-carousel', function () {
           </mip-img>
         </mip-carousel>
       `
-      carousel = div.querySelector('mip-carousel')
+      mipCarousel = div.querySelector('mip-carousel')
       document.body.appendChild(div)
     })
 
     it('should show default indicator', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       let indicatorbox = div.querySelector('div.mip-carousel-indicatorbox')
       let indicatorBoxwrap = indicatorbox.querySelector('p.mip-carousel-indicatorBoxwrap')
       indicator = indicatorBoxwrap.querySelectorAll('span')[0]
@@ -203,7 +203,7 @@ describe('mip-carousel', function () {
     })
 
     it('should not move when vertically scrolling', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       wrapBox = div.querySelector('div.mip-carousel-wrapper')
 
       event.initEvent('touchstart', true, true)
@@ -229,7 +229,7 @@ describe('mip-carousel', function () {
     })
 
     it('should not move when touch diff is too small', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       wrapBox = div.querySelector('div.mip-carousel-wrapper')
 
       event.initEvent('touchstart', true, true)
@@ -254,7 +254,7 @@ describe('mip-carousel', function () {
     })
 
     it('should move to next img when touch', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       event.initEvent('touchstart', true, true)
       event.targetTouches = event.touches = [{
         pageX: 0,
@@ -282,7 +282,7 @@ describe('mip-carousel', function () {
     })
 
     it('should move to another direction', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
 
       event.initEvent('touchstart', true, true)
       event.targetTouches = event.touches = [{
@@ -307,10 +307,10 @@ describe('mip-carousel', function () {
     })
 
     it('should go index with `go` handler', async function () {
-      await carousel._resources.updateState()
+      mipCarousel.viewportCallback(true)
       wrapBox = div.querySelector('div.mip-carousel-wrapper')
       indicator = div.querySelector('.mip-carousel-indicatornow')
-      carousel.customElement.executeEventAction({
+      mipCarousel.customElement.executeEventAction({
         handler: 'go',
         event: 'tap',
         arg: '2'
@@ -334,60 +334,7 @@ describe('mip-carousel', function () {
     let dotsDom
     this.timeout(3000)
 
-    it('should be not ok with appointed indicatorId but not indicator', async function () {
-      divNo = document.createElement('div')
-      divNo.innerHTML = `
-        <mip-carousel
-          indicatorId="mip-carousel-example1"
-          width="100"
-          height="80">
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_01.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_02.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_03.jpg">
-          </mip-img>
-        </mip-carousel>
-      `
-      document.body.appendChild(divNo)
-      await divNo.querySelector('mip-carousel')._resources.updateState()
-      expect(divNo.querySelector('#mip-carousel-example1')).to.be.null
-    })
-
-    it('should be not ok with wrong indicator', async function () {
-      divWrong = document.createElement('div')
-      divWrong.innerHTML = `
-        <mip-carousel
-          indicatorId="mip-carousel-example2"
-          width="100"
-          height="80">
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_01.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_02.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_03.jpg">
-          </mip-img>
-        </mip-carousel>
-        <div class="mip-carousel-indicator-wrapper">
-          <div id="mip-carousel-example2">
-            <div class="mip-carousel-activeitem mip-carousel-indecator-item"></div>
-          </div>
-        </div>
-      `
-      document.body.appendChild(divWrong)
-      await divNo.querySelector('mip-carousel')._resources.updateState()
-      let indicatorDom = divWrong.querySelector('#mip-carousel-example2')
-      expect(indicatorDom.classList.contains('hide')).to.be.true
-      expect(window.getComputedStyle(indicatorDom, null).display).to.include('none')
-    })
-
-    it('should be ok with correct setting', async function () {
+    before(() => {
       divOk = document.createElement('div')
       divOk.innerHTML = `
         <mip-carousel
@@ -413,8 +360,95 @@ describe('mip-carousel', function () {
         </div>
       `
       document.body.appendChild(divOk)
+      divOk.querySelector('mip-carousel').viewportCallback(true)
 
-      await divNo.querySelector('mip-carousel')._resources.updateState()
+      divOkAuto = document.createElement('div')
+      divOkAuto.innerHTML = `
+        <mip-carousel
+          autoplay
+          defer="1000"
+          indicatorId="mip-carousel-example4"
+          width="100"
+          height="80">
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_01.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_02.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_03.jpg">
+          </mip-img>
+        </mip-carousel>
+        <div class="mip-carousel-indicator-wrapper">
+          <div class="mip-carousel-indicatorDot" id="mip-carousel-example4">
+            <div class="mip-carousel-activeitem mip-carousel-indecator-item"></div>
+            <div class="mip-carousel-indecator-item"></div>
+            <div class="mip-carousel-indecator-item"></div>
+          </div>
+        </div>
+      `
+      document.body.appendChild(divOkAuto)
+      divOkAuto.querySelector('mip-carousel').viewportCallback(true)
+
+      divNo = document.createElement('div')
+      divNo.innerHTML = `
+        <mip-carousel
+          indicatorId="mip-carousel-example1"
+          width="100"
+          height="80">
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_01.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_02.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_03.jpg">
+          </mip-img>
+        </mip-carousel>
+      `
+      document.body.appendChild(divNo)
+      divNo.querySelector('mip-carousel').viewportCallback(true)
+
+      divWrong = document.createElement('div')
+      divWrong.innerHTML = `
+        <mip-carousel
+          indicatorId="mip-carousel-example2"
+          width="100"
+          height="80">
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_01.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_02.jpg">
+          </mip-img>
+          <mip-img
+            src="https://www.mipengine.org/static/img/sample_03.jpg">
+          </mip-img>
+        </mip-carousel>
+        <div class="mip-carousel-indicator-wrapper">
+          <div id="mip-carousel-example2">
+            <div class="mip-carousel-activeitem mip-carousel-indecator-item"></div>
+          </div>
+        </div>
+      `
+      document.body.appendChild(divWrong)
+      divWrong.querySelector('mip-carousel').viewportCallback(true)
+    })
+
+    it('should be not ok with appointed indicatorId but not indicator', async function () {
+      expect(divNo.querySelector('#mip-carousel-example1')).to.be.null
+    })
+
+    it('should be not ok with wrong indicator', async function () {
+      let indicatorDom = divWrong.querySelector('#mip-carousel-example2')
+      expect(indicatorDom.classList.contains('hide')).to.be.true
+      expect(window.getComputedStyle(indicatorDom, null).display).to.include('none')
+    })
+
+    it('should be ok with correct setting', async function () {
+      divNo.querySelector('mip-carousel').viewportCallback(true)
       // render indicator
       indicatorDom = divOk.querySelector('#mip-carousel-example3')
       dotsDom = indicatorDom.querySelectorAll('.mip-carousel-indecator-item')
@@ -425,7 +459,7 @@ describe('mip-carousel', function () {
     it('should change dot indicator by carousel moving', async function () {
       let wrapBox = divOk.querySelector('div.mip-carousel-wrapper')
       // touchmove
-      let event = document.createEvent('Events')
+      let event = document.createEvent('Event')
       event.initEvent('touchstart', true, true)
       event.targetTouches = event.touches = [{
         pageX: 0,
@@ -458,34 +492,6 @@ describe('mip-carousel', function () {
     })
 
     it('should be ok with autoplay', function () {
-      divOkAuto = document.createElement('div')
-      divOkAuto.innerHTML = `
-        <mip-carousel
-          autoplay
-          defer="1000"
-          indicatorId="mip-carousel-example4"
-          width="100"
-          height="80">
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_01.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_02.jpg">
-          </mip-img>
-          <mip-img
-            src="https://www.mipengine.org/static/img/sample_03.jpg">
-          </mip-img>
-        </mip-carousel>
-        <div class="mip-carousel-indicator-wrapper">
-          <div class="mip-carousel-indicatorDot" id="mip-carousel-example4">
-            <div class="mip-carousel-activeitem mip-carousel-indecator-item"></div>
-            <div class="mip-carousel-indecator-item"></div>
-            <div class="mip-carousel-indecator-item"></div>
-          </div>
-        </div>
-      `
-      document.body.appendChild(divOkAuto)
-
       // render indicator
       indicatorDom = divOkAuto.querySelector('#mip-carousel-example4')
       dotsDom = indicatorDom.querySelectorAll('.mip-carousel-indecator-item')
@@ -541,10 +547,10 @@ describe('mip-carousel', function () {
       `
       mipCarousel = div.querySelector('mip-carousel')
       document.body.appendChild(div)
+      mipCarousel.viewportCallback(true)
     })
 
     it('should go to next img when click btn', async function () {
-      await mipCarousel._resources.updateState()
       let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
       eventClick.initEvent('click', true, true)
       nextBtn.dispatchEvent(eventClick)
@@ -555,7 +561,6 @@ describe('mip-carousel', function () {
     })
 
     it('should go to pre img when click btn', async function () {
-      await mipCarousel._resources.updateState()
       preBtn = div.querySelector('p.mip-carousel-preBtn')
       eventClick.initEvent('click', true, true)
       preBtn.dispatchEvent(eventClick)
@@ -565,7 +570,6 @@ describe('mip-carousel', function () {
     })
 
     it('should go to last img by clicking preBtn', async function () {
-      await mipCarousel._resources.updateState()
       eventClick.initEvent('click', true, true)
       preBtn.dispatchEvent(eventClick)
 
@@ -607,10 +611,10 @@ describe('mip-carousel', function () {
       `
       mipCarousel = div.querySelector('mip-carousel')
       document.body.appendChild(div)
+      mipCarousel.viewportCallback(true)
     })
 
     it('should go to next img when click btn', async function () {
-      await mipCarousel._resources.updateState()
       let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
       eventClick.initEvent('click', true, true)
       nextBtn.dispatchEvent(eventClick)
@@ -621,7 +625,6 @@ describe('mip-carousel', function () {
     })
 
     it('should go to pre img when click btn', async function () {
-      await mipCarousel._resources.updateState()
       let preBtn = div.querySelector('p.mip-carousel-preBtn')
       eventClick.initEvent('click', true, true)
       preBtn.dispatchEvent(eventClick)
@@ -680,10 +683,10 @@ describe('mip-carousel', function () {
       `
       mipCarousel = div.querySelector('mip-carousel')
       document.body.appendChild(div)
+      mipCarousel.viewportCallback(true)
     })
 
     it('should start from index img', async function () {
-      await mipCarousel._resources.updateState()
       wrapBox = div.querySelector('div.mip-carousel-wrapper')
       expect(wrapBox.style.transform).to.equal('translate3d(-200px, 0px, 0px)')
 
@@ -694,7 +697,6 @@ describe('mip-carousel', function () {
     })
 
     it('should switch to certain img when emit tap event', async function () {
-      await mipCarousel._resources.updateState()
       let switchBtn = div.querySelector('div.mip-carousel-switchBtn')
       eventClick.initEvent('click', true, true)
       switchBtn.dispatchEvent(eventClick)
@@ -711,7 +713,6 @@ describe('mip-carousel', function () {
   // 图片又可能因为不在 viewport 所以一直没加载，所以又要放到 body 的最前面，时间不能设置太短，可能真的没加载
   describe('with lazy loading', function () {
     let div
-    this.timeout(2000)
 
     before(function () {
       div = document.createElement('div')
@@ -736,10 +737,10 @@ describe('mip-carousel', function () {
         </mip-carousel>
       `
       document.body.insertBefore(div, document.body.firstChild)
+      div.querySelector('mip-carousel').viewportCallback(true)
     })
     // 一定要挑一张图片上面的代码都没用到过，并且不能在第一张和最后一张
     it('should not load picture samplePX', async function () {
-      await sleep(500)
       let mipImg = div.querySelectorAll('mip-img')[3]
       let img = mipImg.querySelector('img')
       expect(img.getAttribute('src')).to.not.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
@@ -749,7 +750,6 @@ describe('mip-carousel', function () {
       let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
       eventClick.initEvent('click', true, true)
       nextBtn.dispatchEvent(eventClick)
-      await sleep(1500)
       let img = div.querySelectorAll('mip-img')[3].querySelector('img')
       expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
     })
@@ -794,10 +794,10 @@ describe('mip-carousel', function () {
         </mip-carousel>
       `
       document.body.insertBefore(div, document.body.firstChild)
+      div.querySelector('mip-carousel').viewportCallback(true)
     })
     // 一定要挑一张图片上面的代码都没用到过，并且不能在第一张和最后一张
     it('should not load picture samplePX', async function () {
-      await sleep(500)
       let mipImg = div.querySelectorAll('mip-img')[3]
       let img = mipImg.querySelector('img')
       expect(img.getAttribute('src')).to.not.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
@@ -807,7 +807,6 @@ describe('mip-carousel', function () {
       let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
       eventClick.initEvent('click', true, true)
       nextBtn.dispatchEvent(eventClick)
-      await sleep(550)
       let img = div.querySelectorAll('mip-img')[3].querySelector('img')
       expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/P2x1_457e18b.jpg')
     })
@@ -817,12 +816,12 @@ describe('mip-carousel', function () {
     })
   })
   describe('with no mip-img in the first child of mip-carousel', function () {
+    let originHeight
     let div
     // 1px x 1px
     let img1 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
     // 1px x 2px
     let img2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAAD0lEQVR42mNkYPhfzwAEAAiHAYAKx2h0AAAAAElFTkSuQmCC'
-    this.timeout(1500)
     before(() => {
       div = document.createElement('div')
       div.innerHTML = `
@@ -844,26 +843,22 @@ describe('mip-carousel', function () {
       </mip-carousel>
       `
       document.body.insertBefore(div, document.body.firstChild)
+      div.querySelector('mip-carousel').viewportCallback(true)
+      originHeight = window.getComputedStyle(div, null).getPropertyValue('height')
     })
 
     it('should load picture correctly', async function () {
-      let mipCarousel = div.querySelector('mip-carousel')
-      await mipCarousel._resources.updateState()
       let img = div.querySelectorAll('mip-img')[1].querySelector('img')
       expect(img.getAttribute('src')).to.equal(img1)
     })
 
     it('should change height when swipe', async () => {
-      let mipCarousel = div.querySelector('mip-carousel')
-      await mipCarousel._resources.updateState()
-      let height = window.getComputedStyle(div, null).getPropertyValue('height')
       let eventClick = document.createEvent('MouseEvents')
       let nextBtn = div.querySelector('p.mip-carousel-nextBtn')
       eventClick.initEvent('click', true, true)
       nextBtn.dispatchEvent(eventClick)
 
-      await sleep(1200)
-      expect(window.getComputedStyle(div, null).getPropertyValue('height')).not.equal(height)
+      expect(window.getComputedStyle(div, null).getPropertyValue('height')).not.equal(originHeight)
     })
     after(function () {
       document.body.removeChild(div)

--- a/packages/mip/test/specs/components/mip-iframe.spec.js
+++ b/packages/mip/test/specs/components/mip-iframe.spec.js
@@ -21,7 +21,7 @@ describe('mip-iframe', function () {
     mipIframe = document.createElement('mip-iframe')
     document.body.appendChild(mipIframe)
 
-    await mipIframe._resources.updateState()
+    // await mipIframe._resources.updateState()
     mipIframe.viewportCallback(true)
     iframe = mipIframe.querySelector('iframe')
     expect(iframe).to.be.null
@@ -39,21 +39,18 @@ describe('mip-iframe', function () {
       document.body.appendChild(mipIframe)
     })
 
-    it('should produce iframe with height 100%', function (done) {
-      setTimeout(() => {
-        iframe = mipIframe.querySelector('iframe')
-        setTimeout(() => {
-          expect(iframe.frameBorder).to.equal('0')
-          expect(iframe.style.width).to.equal('100%')
-          expect(iframe.classList.contains('mip-fill-content')).to.equal(true)
-          expect(iframe.src).to.equal('data:text/html;charset=utf-8;base64,' + window.btoa('<p>Hello MIP!</p>'))
-          expect(iframe.getAttribute('allowfullscreen')).to.equal('true')
-          expect(iframe.getAttribute('allowtransparency')).to.equal('true')
-          expect(iframe.getAttribute('sandbox')).to.be.null
-          expect(iframe.style.height).to.equal(viewport.getHeight() + 'px')
-          done()
-        }, 600)
-      }, 1)
+    it('should produce iframe with height 100%', async function () {
+      mipIframe.viewportCallback(true)
+      iframe = mipIframe.querySelector('iframe')
+      expect(iframe.frameBorder).to.equal('0')
+      expect(iframe.style.width).to.equal('100%')
+      expect(iframe.classList.contains('mip-fill-content')).to.equal(true)
+      expect(iframe.src).to.equal('data:text/html;charset=utf-8;base64,' + window.btoa('<p>Hello MIP!</p>'))
+      expect(iframe.getAttribute('allowfullscreen')).to.equal('true')
+      expect(iframe.getAttribute('allowtransparency')).to.equal('true')
+      expect(iframe.getAttribute('sandbox')).to.be.null
+      await new Promise(resolve => setTimeout(resolve, 600))
+      expect(iframe.style.height).to.equal(viewport.getHeight() + 'px')
     })
 
     after(function () {
@@ -70,19 +67,17 @@ describe('mip-iframe', function () {
       document.body.appendChild(mipIframe)
     })
 
-    it('should produce iframe', function (done) {
-      setTimeout(() => {
-        iframe = mipIframe.querySelector('iframe')
-        expect(iframe.frameBorder).to.equal('0')
-        expect(iframe.style.width).to.equal('200px')
-        expect(iframe.style.height).to.equal('100px')
-        expect(iframe.classList.contains('mip-fill-content')).to.equal(true)
-        expect(iframe.src).to.equal('data:text/html;charset=utf-8;base64,' + window.btoa('<p>Hello MIP!</p>'))
-        expect(iframe.getAttribute('allowfullscreen')).to.be.null
-        expect(iframe.getAttribute('allowtransparency')).to.be.null
-        expect(iframe.getAttribute('sandbox')).to.be.null
-        done()
-      }, 1)
+    it('should produce iframe', async function () {
+      mipIframe.viewportCallback(true)
+      iframe = mipIframe.querySelector('iframe')
+      expect(iframe.frameBorder).to.equal('0')
+      expect(iframe.style.width).to.equal('200px')
+      expect(iframe.style.height).to.equal('100px')
+      expect(iframe.classList.contains('mip-fill-content')).to.equal(true)
+      expect(iframe.src).to.equal('data:text/html;charset=utf-8;base64,' + window.btoa('<p>Hello MIP!</p>'))
+      expect(iframe.getAttribute('allowfullscreen')).to.be.null
+      expect(iframe.getAttribute('allowtransparency')).to.be.null
+      expect(iframe.getAttribute('sandbox')).to.be.null
     })
 
     it('should resize with detail', function () {

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -34,40 +34,40 @@ describe('mip-img', function () {
     let mipImg = dom.create('<mip-img popup src="https://www.wrong.org?mip_img_ori=1"></mip-img>')
     mipImgWrapper.appendChild(mipImg)
     document.body.appendChild(mipImgWrapper)
+    mipImg.viewportCallback(true)
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
+    let img = mipImg.querySelector('img')
 
-      // ask to popup before loaded
-      let event = document.createEvent('MouseEvents')
-      event.initEvent('click', true, true)
-      img.dispatchEvent(event)
+    // ask to popup before loaded
+    let event = document.createEvent('MouseEvents')
+    event.initEvent('click', true, true)
+    img.dispatchEvent(event)
 
-      // expect popup to be created
-      let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
+    // expect popup to be created
+    let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
 
-      expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
-      expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
-      expect(mipPopWrap.tagName).to.equal('DIV')
-      expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
-      expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
+    expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
+    expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
+    expect(mipPopWrap.tagName).to.equal('DIV')
+    expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
+    expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
 
-      // img
-      expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-      expect(img.getAttribute('src')).to.equal('https://www.wrong.org?mip_img_ori=1')
+    // img
+    expect(img.classList.contains('mip-replaced-content')).to.equal(true)
+    expect(img.getAttribute('src')).to.equal('https://www.wrong.org?mip_img_ori=1')
 
-      img.addEventListener('error', () => {
-        expect(img.src).to.equal('https://www.wrong.org/?mip_img_ori=1')
-      }, false)
-      let errEvent = new Event('error')
-      img.dispatchEvent(errEvent)
-    })
+    img.addEventListener('error', () => {
+      expect(img.src).to.equal('https://www.wrong.org/?mip_img_ori=1')
+    }, false)
+    let errEvent = new Event('error')
+    img.dispatchEvent(errEvent)
   })
 
   it('should replace src if load img error', async function () {
     mipImgWrapper.innerHTML = `<mip-img popup src="https://www.wrong.org?test=1"></mip-img>`
     let mipImg = mipImgWrapper.querySelector('mip-img')
-    await mipImg._resources.updateState()
+    mipImg.viewportCallback(true)
+
     let img = mipImg.querySelector('img')
 
     expect(img.classList.contains('mip-replaced-content')).to.equal(true)
@@ -90,22 +90,20 @@ describe('mip-img', function () {
     `
     let mipImg = mipImgWrapper.querySelector('mip-img')
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      expect(img.getAttribute('src')).to.be.null
-      expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-    })
+    mipImg.viewportCallback(true)
+    let img = mipImg.querySelector('img')
+    expect(img.getAttribute('src')).to.be.null
+    expect(img.classList.contains('mip-replaced-content')).to.equal(true)
   })
 
   it('should build without src', function () {
     mipImgWrapper.innerHTML = `<mip-img></mip-img>`
     let mipImg = mipImgWrapper.querySelector('mip-img')
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-      expect(img.getAttribute('src')).to.be.null
-    })
+    mipImg.viewportCallback(true)
+    let img = mipImg.querySelector('img')
+    expect(img.classList.contains('mip-replaced-content')).to.equal(true)
+    expect(img.getAttribute('src')).to.be.null
   })
 
   it('should load img with normal src', function () {
@@ -113,11 +111,10 @@ describe('mip-img', function () {
       <mip-img src="https://www.mipengine.org/static/img/sample_01.jpg"></mip-img>
     `
     let mipImg = mipImgWrapper.querySelector('mip-img')
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-      expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
-    })
+    mipImg.viewportCallback(true)
+    let img = mipImg.querySelector('img')
+    expect(img.classList.contains('mip-replaced-content')).to.equal(true)
+    expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
   })
 
   it('should change src and reload img', function () {
@@ -127,12 +124,11 @@ describe('mip-img', function () {
     mipImg.setAttribute('height', '100px')
     mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_02.jpg')
 
-    mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_02.jpg')
-      mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_03.jpg')
-      expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_03.jpg')
-    })
+    mipImg.viewportCallback(true)
+    let img = mipImg.querySelector('img')
+    expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_02.jpg')
+    mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_03.jpg')
+    expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_03.jpg')
   })
 
   it('should produce img but not call connectedCallback again', function () {
@@ -143,12 +139,11 @@ describe('mip-img', function () {
     mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_02.jpg')
     mipImgWrapper.appendChild(mipImg)
 
-    return mipImg._resources.updateState().then(() => {
-      mipImgWrapper.removeChild(mipImg)
-      mipImgWrapper.appendChild(mipImg)
-      let img = mipImg.querySelector('img')
-      expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_02.jpg')
-    })
+    mipImg.viewportCallback(true)
+    mipImgWrapper.removeChild(mipImg)
+    mipImgWrapper.appendChild(mipImg)
+    let img = mipImg.querySelector('img')
+    expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_02.jpg')
   })
 
   it('should set props correctly', function () {
@@ -161,15 +156,15 @@ describe('mip-img', function () {
     mipImg.setAttribute('alt', 'baidu mip img')
     mipImgWrapper.appendChild(mipImg)
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      expect(mipImg.getAttribute('width')).to.equal('100px')
-      expect(mipImg.getAttribute('height')).to.equal('100px')
-      expect(mipImg.getAttribute('popup')).to.equal('true')
-      expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
-      expect(img.getAttribute('alt')).to.equal('baidu mip img')
-      expect(mipImg.querySelector('div.mip-placeholder')).to.be.null
-    })
+    mipImg.viewportCallback(true)
+
+    let img = mipImg.querySelector('img')
+    expect(mipImg.getAttribute('width')).to.equal('100px')
+    expect(mipImg.getAttribute('height')).to.equal('100px')
+    expect(mipImg.getAttribute('popup')).to.equal('true')
+    expect(img.getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
+    expect(img.getAttribute('alt')).to.equal('baidu mip img')
+    expect(mipImg.querySelector('div.mip-placeholder')).to.be.null
   })
 
   it('should popup', function () {
@@ -182,22 +177,22 @@ describe('mip-img', function () {
     mipImg.setAttribute('alt', 'baidu mip img')
     mipImgWrapper.appendChild(mipImg)
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      let event = document.createEvent('MouseEvents')
-      event.initEvent('click', true, true)
-      img.dispatchEvent(event)
+    mipImg.viewportCallback(true)
 
-      let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
-      mipPopWrap.dispatchEvent(event)
+    let img = mipImg.querySelector('img')
+    let event = document.createEvent('MouseEvents')
+    event.initEvent('click', true, true)
+    img.dispatchEvent(event)
 
-      expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
-      expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
-      expect(mipPopWrap.tagName).to.equal('DIV')
-      expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
-      expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
-      expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
-    })
+    let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
+    mipPopWrap.dispatchEvent(event)
+
+    expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
+    expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
+    expect(mipPopWrap.tagName).to.equal('DIV')
+    expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
+    expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
+    expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
   })
   it('should resize popup according to window resizing', function () {
     let mipImg = document.createElement('mip-img')
@@ -209,11 +204,11 @@ describe('mip-img', function () {
     mipImg.setAttribute('alt', 'baidu mip img')
     mipImgWrapper.appendChild(mipImg)
 
-    return mipImg._resources.updateState().then(() => {
-      let event = document.createEvent('Event')
-      event.initEvent('resize', true, true)
-      window.dispatchEvent(event)
-    })
+    mipImg.viewportCallback(true)
+
+    let event = document.createEvent('Event')
+    event.initEvent('resize', true, true)
+    window.dispatchEvent(event)
   })
   it('with special image popuping should popup', function () {
     // 针对长图的大图浏览代码测试，其实只需要设置一张特殊的图即可。
@@ -225,21 +220,21 @@ describe('mip-img', function () {
     mipImg.setAttribute('alt', 'baidu mip img')
     mipImgWrapper.appendChild(mipImg)
 
-    return mipImg._resources.updateState().then(() => {
-      let img = mipImg.querySelector('img')
-      let event = document.createEvent('MouseEvents')
-      event.initEvent('click', true, true)
-      img.dispatchEvent(event)
+    mipImg.viewportCallback(true)
 
-      let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
-      mipPopWrap.dispatchEvent(event)
+    let img = mipImg.querySelector('img')
+    let event = document.createEvent('MouseEvents')
+    event.initEvent('click', true, true)
+    img.dispatchEvent(event)
 
-      expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
-      expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
-      expect(mipPopWrap.tagName).to.equal('DIV')
-      expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
-      expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
-      expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
-    })
+    let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
+    mipPopWrap.dispatchEvent(event)
+
+    expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
+    expect(mipPopWrap.parentNode.tagName).to.equal('BODY')
+    expect(mipPopWrap.tagName).to.equal('DIV')
+    expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
+    expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
+    expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
   })
 })

--- a/packages/mip/test/specs/components/mip-layout.spec.js
+++ b/packages/mip/test/specs/components/mip-layout.spec.js
@@ -1,48 +1,50 @@
 describe('mip-layout', () => {
   let layout
   let child
-  beforeEach(() => {
+  before(() => {
     layout = document.createElement('mip-layout')
     child = document.createElement('p')
     layout.appendChild(child)
-    document.body.appendChild(layout)
   })
 
-  afterEach(() => {
+  after(() => {
     document.body.removeChild(layout)
   })
 
   it('should add mip relevant class and child default', () => {
-    return layout._resources.updateState().then(() => {
-      let container = layout.querySelector('.mip-fill-content')
-      expect(container).to.be.not.null
-      expect(layout.classList.contains('mip-element')).to.be.true
-      expect(layout.classList.contains('mip-layout-container')).to.be.true
-      expect(layout.classList.contains('mip-layout-size-defined')).to.be.false
-      expect(layout.querySelector('.mip-i-space')).to.be.null
-      expect(child.parentNode).to.equal(container)
-    })
+    document.body.appendChild(layout)
+
+    layout.viewportCallback(true)
+    let container = layout.querySelector('.mip-fill-content')
+    expect(container).to.be.not.null
+    expect(layout.classList.contains('mip-element')).to.be.true
+    expect(layout.classList.contains('mip-layout-container')).to.be.true
+    expect(layout.classList.contains('mip-layout-size-defined')).to.be.false
+    expect(layout.querySelector('.mip-i-space')).to.be.null
+    expect(child.parentNode).to.equal(container)
   })
 
   it('should layout correctly with layout attribute', () => {
     layout.setAttribute('layout', 'responsive')
     layout.setAttribute('width', '1')
     layout.setAttribute('height', '1')
-    let wh = window.innerHeight
-    let ww = window.innerWidth
+    document.body.appendChild(layout)
 
-    layout._resources.updateState().then(() => {
-      let container = layout.querySelector('.mip-fill-content')
-      expect(container).to.be.not.null
-      expect(layout.classList.contains('mip-element')).to.be.true
-      expect(layout.classList.contains('mip-layout-responsive')).to.be.true
-      expect(layout.classList.contains('mip-layout-size-defined')).to.be.true
-      expect(layout.querySelector('.mip-i-space')).to.be.not.null
-      expect(child.parentNode).to.equal(container)
+    let style = window.getComputedStyle(layout.parentNode)
+    let ww = parseFloat(style.width)
 
-      let rect = layout.getBoundingClientRect()
-      expect(rect.width).to.equal(ww)
-      expect(rect.height).to.equal(wh)
-    })
+    layout.viewportCallback(true)
+    layout._resources._doRealUpdate()
+    let container = layout.querySelector('.mip-fill-content')
+    expect(container).to.be.not.null
+    expect(layout.classList.contains('mip-element')).to.be.true
+    expect(layout.classList.contains('mip-layout-responsive')).to.be.true
+    expect(layout.classList.contains('mip-layout-size-defined')).to.be.true
+    expect(layout.querySelector('mip-i-space')).to.be.not.null
+    expect(child.parentNode).to.equal(container)
+
+    let rect = layout.getBoundingClientRect()
+    expect(rect.width).to.equal(ww)
+    expect(rect.height).to.equal(ww)
   })
 })

--- a/packages/mip/test/specs/components/mip-pix.spec.js
+++ b/packages/mip/test/specs/components/mip-pix.spec.js
@@ -52,76 +52,72 @@ describe('mip-pix', function () {
 
   it('should send by default', function () {
     pixDefault = createPix('https://www.mipengine.org/a.gif')
-    return pixDefault._resources.updateState(() => {
-      let src = pixDefault.querySelector('img').getAttribute('src')
-      let params = parseUrl(src)
-      let keys = Object.keys(params)
-      let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
-      expect(keys).to.include('t')
-      expect(keys).to.include('title')
-      expect(keys).to.include('host')
-      expect(keys.length).to.equal(3)
-      expect(isValidDate(params.t)).to.be.true
-      expect(params.title).to.equal(title)
-      expect(params.host).to.equal(encodeURIComponent(window.location.href))
-    })
+    pixDefault.viewportCallback(true)
+    let src = pixDefault.querySelector('img').getAttribute('src')
+    let params = parseUrl(src)
+    let keys = Object.keys(params)
+    let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
+    expect(keys).to.include('t')
+    expect(keys).to.include('title')
+    expect(keys).to.include('host')
+    expect(keys.length).to.equal(3)
+    expect(isValidDate(params.t)).to.be.true
+    expect(params.title).to.equal(title)
+    expect(params.host).to.equal(encodeURIComponent(window.location.href))
   })
 
   it('should send by arguments', function () {
     pixSetParam = createPix('https://www.mipengine.org/a.gif?t=${TIME}&title=${TITLE}&host=${HOST}') // eslint-disable-line
-    return pixDefault._resources.updateState(() => {
-      let src = pixSetParam.querySelector('img').getAttribute('src')
-      let params = parseUrl(src)
-      let keys = Object.keys(params)
-      let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
-      expect(keys).to.include('t')
-      expect(keys).to.include('title')
-      expect(keys).to.include('host')
-      expect(keys.length).to.equal(3)
-      expect(isValidDate(params.t)).to.be.true
-      expect(params.title).to.equal(title)
-      expect(params.host).to.equal(encodeURIComponent(window.location.href))
-    })
+    pixSetParam.viewportCallback(true)
+    let src = pixSetParam.querySelector('img').getAttribute('src')
+    let params = parseUrl(src)
+    let keys = Object.keys(params)
+    let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
+    expect(keys).to.include('t')
+    expect(keys).to.include('title')
+    expect(keys).to.include('host')
+    expect(keys.length).to.equal(3)
+    expect(isValidDate(params.t)).to.be.true
+    expect(params.title).to.equal(title)
+    expect(params.host).to.equal(encodeURIComponent(window.location.href))
   })
 
   it('should send with extra args', function () {
     pixExtraParam = createPix('https://www.mipengine.org/a.gif?t=${TIME}&title=${TITLE}&host=${HOST}&area=A') // eslint-disable-line
-    return pixDefault._resources.updateState(() => {
-      let src = pixExtraParam.querySelector('img').getAttribute('src')
-      let params = parseUrl(src)
-      let keys = Object.keys(params)
-      let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
-      expect(keys).to.include('t')
-      expect(keys).to.include('title')
-      expect(keys).to.include('host')
-      expect(keys).to.include('area')
-      expect(keys.length).to.equal(4)
-      expect(isValidDate(params.t)).to.be.true
-      expect(params.title).to.equal(title)
-      expect(params.host).to.equal(encodeURIComponent(window.location.href))
-      expect(params.area).to.equal('A')
-    })
+    pixExtraParam.viewportCallback(true)
+    let src = pixExtraParam.querySelector('img').getAttribute('src')
+    let params = parseUrl(src)
+    let keys = Object.keys(params)
+    let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
+    expect(keys).to.include('t')
+    expect(keys).to.include('title')
+    expect(keys).to.include('host')
+    expect(keys).to.include('area')
+    expect(keys.length).to.equal(4)
+    expect(isValidDate(params.t)).to.be.true
+    expect(params.title).to.equal(title)
+    expect(params.host).to.equal(encodeURIComponent(window.location.href))
+    expect(params.area).to.equal('A')
   })
 
   it('should send by experiment', function () {
     pixExperiment = createPix('https://www.mipengine.org/a.gif?mip-x-button-color=${MIP-X-BUTTON-COLOR}&mip-x-font-color=${MIP-X-FONT-COLOR}') // eslint-disable-line
-    return pixDefault._resources.updateState(() => {
-      let src = pixExperiment.querySelector('img').getAttribute('src')
-      let params = parseUrl(src)
-      let keys = Object.keys(params)
-      let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
-      expect(keys).to.include('t')
-      expect(keys).to.include('title')
-      expect(keys).to.include('host')
-      expect(keys).to.include('mip-x-button-color')
-      expect(keys).to.include('mip-x-font-color')
-      expect(keys.length).to.equal(5)
-      expect(isValidDate(params.t)).to.be.true
-      expect(params.title).to.equal(title)
-      expect(params.host).to.equal(encodeURIComponent(window.location.href))
-      // expect(params['mip-x-button-color']).to.be.oneOf(['yellow', 'grey'])
-      // expect(params['mip-x-font-color']).to.be.oneOf(['black', 'white'])
-    })
+    pixExperiment.viewportCallback(true)
+    let src = pixExperiment.querySelector('img').getAttribute('src')
+    let params = parseUrl(src)
+    let keys = Object.keys(params)
+    let title = encodeURIComponent((document.querySelector('title') || {}).innerHTML || '')
+    expect(keys).to.include('t')
+    expect(keys).to.include('title')
+    expect(keys).to.include('host')
+    expect(keys).to.include('mip-x-button-color')
+    expect(keys).to.include('mip-x-font-color')
+    expect(keys.length).to.equal(5)
+    expect(isValidDate(params.t)).to.be.true
+    expect(params.title).to.equal(title)
+    expect(params.host).to.equal(encodeURIComponent(window.location.href))
+    // expect(params['mip-x-button-color']).to.be.oneOf(['yellow', 'grey'])
+    // expect(params['mip-x-font-color']).to.be.oneOf(['black', 'white'])
   })
 
   after(function () {

--- a/packages/mip/test/specs/components/mip-rem.spec.js
+++ b/packages/mip/test/specs/components/mip-rem.spec.js
@@ -2,50 +2,58 @@
  * @file mip-rem spec file
  * @author chenyongle(chenyongle@baidu.com)
  */
+
+import viewport from 'src/viewport'
+
 describe('mip-rem', function () {
+  let sandbox
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   describe('with correct font-size', function () {
     let mipRem
-    let origin
     before(function () {
-      origin = window.innerWidth
-      window.innerWidth = 400
+      sinon.replace(viewport, 'getWidth', sinon.fake.returns(400))
+
       mipRem = document.createElement('mip-rem')
       mipRem.setAttribute('font-size', '[{"maxWidth": 360, "size": 80}, {"minWidth": 361, "maxWidth": 720, "size": 90}, {"minWidth": 721, "size": 100}]')
       document.body.appendChild(mipRem)
+      sinon.restore()
     })
     it('should change html font-size to 90px', function () {
       expect(document.documentElement.style.fontSize).to.equal('90px')
     })
     after(function () {
-      window.innerWidth = origin
       document.body.removeChild(mipRem)
     })
   })
   describe('with incorrect font-size', function () {
     let mipRem
-    let origin
     before(function () {
-      origin = window.innerWidth
-      window.innerWidth = 200
+      sinon.replace(viewport, 'getWidth', sinon.fake.returns(200))
+
       mipRem = document.createElement('mip-rem')
       // test case 类型为 font-size 属性值格式错误
       mipRem.setAttribute('font-size', '[{"maxWidth": 360; "size": 80}]')
       document.body.appendChild(mipRem)
+      sinon.restore()
     })
     it('should change html font-size to ""', function () {
       expect(document.documentElement.style.fontSize).to.equal('')
     })
     after(function () {
-      window.innerWidth = origin
       document.body.removeChild(mipRem)
     })
   })
   describe('with incorrect font-size where field size disappears', function () {
     let mipRem
-    let origin
     before(function () {
-      origin = window.innerWidth
-      window.innerWidth = 200
+      sinon.replace(viewport, 'getWidth', sinon.fake.returns(200))
       mipRem = document.createElement('mip-rem')
       // test case 类型为 font-size 属性值中size字段错误
       mipRem.setAttribute('font-size', '[{"maxWidth": 360, "asize": 80}]')
@@ -57,17 +65,15 @@ describe('mip-rem', function () {
     })
 
     after(function () {
-      window.innerWidth = origin
       document.body.removeChild(mipRem)
+      sinon.restore()
     })
   })
   // 改掉的值 window.innerWidth 还需要改回去，不然其他模块的 test case 会通不过
   describe('with no font-size', function () {
     let mipRem
-    let origin
     before(function () {
-      origin = window.innerWidth
-      window.innerWidth = 400
+      sinon.replace(viewport, 'getWidth', sinon.fake.returns(400))
       mipRem = document.createElement('mip-rem')
       document.body.appendChild(mipRem)
     })
@@ -75,17 +81,15 @@ describe('mip-rem', function () {
       expect(document.documentElement.style.fontSize).to.equal('')
     })
     after(function () {
-      window.innerWidth = origin
       document.body.removeChild(mipRem)
+      sinon.restore()
     })
   })
 
   describe('with mip-rem removed', function () {
     let mipRem
-    let origin
     before(function () {
-      origin = window.innerWidth
-      window.innerWidth = 200
+      sinon.replace(viewport, 'getWidth', sinon.fake.returns(200))
       mipRem = document.createElement('mip-rem')
       document.body.appendChild(mipRem)
     })
@@ -94,7 +98,7 @@ describe('mip-rem', function () {
       expect(document.documentElement.style.fontSize).to.not.equal('90px')
     })
     after(function () {
-      window.innerWidth = origin
+      sinon.restore()
     })
   })
 })

--- a/packages/mip/test/specs/components/mip-video.spec.js
+++ b/packages/mip/test/specs/components/mip-video.spec.js
@@ -28,15 +28,14 @@ describe('mip-video', function () {
     })
 
     it('produce video 1', function () {
-      return mipVideo._resources.updateState().then(() => {
-        let video = mipVideo.querySelector('video')
-        expect(video.classList.contains('mip-replaced-content')).to.equal(true)
-        expect(video.getAttribute('playsinline')).to.equal('playsinline')
-        expect(video.getAttribute('webkit-playsinline')).to.equal('webkit-playsinline')
-        expect(video.getAttribute('t7-video-player-type')).to.equal('inline')
-        expect(video.getAttribute('width')).to.equal('100px')
-        expect(video.getAttribute('height')).to.equal('100px')
-      })
+      mipVideo.viewportCallback(true)
+      let video = mipVideo.querySelector('video')
+      expect(video.classList.contains('mip-replaced-content')).to.equal(true)
+      expect(video.getAttribute('playsinline')).to.equal('playsinline')
+      expect(video.getAttribute('webkit-playsinline')).to.equal('webkit-playsinline')
+      expect(video.getAttribute('t7-video-player-type')).to.equal('inline')
+      expect(video.getAttribute('width')).to.equal('100px')
+      expect(video.getAttribute('height')).to.equal('100px')
     })
 
     after(function () {
@@ -74,48 +73,45 @@ describe('mip-video', function () {
     })
 
     it('produce video 2', function () {
-      return mipVideo._resources.updateState().then(() => {
-        let video = mipVideo.querySelector('video')
-        expect(video.classList.contains('mip-replaced-content')).to.equal(true)
-        expect(video.getAttribute('playsinline')).to.equal('playsinline')
-        expect(video.getAttribute('webkit-playsinline')).to.equal('webkit-playsinline')
-        expect(video.getAttribute('t7-video-player-type')).to.equal('inline')
-        expect(video.getAttribute('controls')).to.equal('true')
-        expect(video.getAttribute('loop')).to.equal('true')
-        expect(video.getAttribute('muted')).to.equal('true')
-        expect(video.getAttribute('currenttime')).to.equal('2')
-        expect(video.getAttribute('autoplay')).to.equal('true')
-        expect(video.getAttribute('width')).to.equal('100px')
-        expect(video.getAttribute('height')).to.equal('100px')
-        expect(video.getAttribute('poster')).to.equal('https://www.mipengine.org/static/img/sample_04.jpg')
+      mipVideo.viewportCallback(true)
+      let video = mipVideo.querySelector('video')
+      expect(video.classList.contains('mip-replaced-content')).to.equal(true)
+      expect(video.getAttribute('playsinline')).to.equal('playsinline')
+      expect(video.getAttribute('webkit-playsinline')).to.equal('webkit-playsinline')
+      expect(video.getAttribute('t7-video-player-type')).to.equal('inline')
+      expect(video.getAttribute('controls')).to.equal('true')
+      expect(video.getAttribute('loop')).to.equal('true')
+      expect(video.getAttribute('muted')).to.equal('true')
+      expect(video.getAttribute('currenttime')).to.equal('2')
+      expect(video.getAttribute('autoplay')).to.equal('true')
+      expect(video.getAttribute('width')).to.equal('100px')
+      expect(video.getAttribute('height')).to.equal('100px')
+      expect(video.getAttribute('poster')).to.equal('https://www.mipengine.org/static/img/sample_04.jpg')
 
-        let sources = video.querySelectorAll('source')
-        expect(sources.length).to.equal(3)
-      })
+      let sources = video.querySelectorAll('source')
+      expect(sources.length).to.equal(3)
     })
 
     it('should change current time by loadedmetadata event', function () {
-      return mipVideo._resources.updateState().then(() => {
-        let video = mipVideo.querySelector('video')
-        let event = new Event('loadedmetadata')
-        video.dispatchEvent(event)
-      })
+      mipVideo.viewportCallback(true)
+      let video = mipVideo.querySelector('video')
+      let event = new Event('loadedmetadata')
+      video.dispatchEvent(event)
     })
 
     it('should change current time by seekTo API', function () {
-      return mipVideo._resources.updateState().then(() => {
-        let p = document.createElement('p')
-        p.setAttribute('on', 'click:mip-video-test.seekTo(2)')
-        p.textContent = 'click me'
-        document.body.appendChild(p)
+      mipVideo.viewportCallback(true)
+      let p = document.createElement('p')
+      p.setAttribute('on', 'click:mip-video-test.seekTo(2)')
+      p.textContent = 'click me'
+      document.body.appendChild(p)
 
-        let event = document.createEvent('MouseEvents')
-        event.initEvent('click', true, true)
-        p.dispatchEvent(event)
+      let event = document.createEvent('MouseEvents')
+      event.initEvent('click', true, true)
+      p.dispatchEvent(event)
 
-        let videoEl = mipVideo.querySelector('video')
-        expect(videoEl.currentTime).to.equal(2)
-      })
+      let videoEl = mipVideo.querySelector('video')
+      expect(videoEl.currentTime).to.equal(2)
     })
     // 由于谷歌浏览器对video播放有严格的限制（只能人为play，不能js模拟），所以跳过测试。
     it.skip('should pause when the pause button is clicked', function () {

--- a/packages/mip/test/specs/page/util.spec.js
+++ b/packages/mip/test/specs/page/util.spec.js
@@ -4,7 +4,7 @@
  */
 
 import viewport from 'src/viewport'
-import {isPortrait, transitionEndEvent, animationEndEvent} from 'src/page/util/feature-detect'
+import {transitionEndEvent, animationEndEvent} from 'src/page/util/feature-detect'
 import {scrollTo} from 'src/page/util/ease-scroll'
 /* eslint-disable no-unused-expressions */
 /* globals describe, it, expect, afterEach, sinon */
@@ -30,10 +30,6 @@ describe('page.util', function () {
 
     it('.animationEndEvent', function () {
       expect(animationEndEvent).to.be.equal('animationend')
-    })
-
-    it('.isPortrait', function () {
-      expect(isPortrait()).to.be.false
     })
   })
 

--- a/packages/mip/test/specs/register-element.spec.js
+++ b/packages/mip/test/specs/register-element.spec.js
@@ -373,6 +373,7 @@ describe('Register element', function () {
       ele.setAttribute('width', '1px')
       ele.setAttribute('height', '1px')
       ele.setAttribute('heights', `(min-width: ${ww + 1}px) 50vw, 100vw`)
+      console.log('ddd')
       document.body.appendChild(ele)
 
       expect(ele.querySelector('mip-i-space').style.paddingTop).to.equal('100vw')

--- a/packages/mip/test/specs/register-element.spec.js
+++ b/packages/mip/test/specs/register-element.spec.js
@@ -52,7 +52,7 @@ describe('Register element', function () {
     expect(insertStyleElement.calledOnce).to.be.true
   })
 
-  it('should call customElement life cycle hooks in order', function (done) {
+  it('should call customElement life cycle hooks in order', function () {
     let name = prefix + 'custom-element'
     let lifecycs = [
       // 'constuctor'
@@ -72,13 +72,11 @@ describe('Register element', function () {
     ele.setAttribute('name', 'fake')
 
     document.body.appendChild(ele)
-    setTimeout(() => {
-      document.body.removeChild(ele)
+    ele.viewportCallback(true)
+    document.body.removeChild(ele)
 
-      lifecycSpies.forEach(spy => spy.restore())
-      sinon.assert.callOrder(...lifecycSpies)
-      done()
-    }, 1)
+    lifecycSpies.forEach(spy => spy.restore())
+    sinon.assert.callOrder(...lifecycSpies)
   })
 
   it('should has a mip-element class in dom', function () {
@@ -163,7 +161,7 @@ describe('Register element', function () {
 
       document.body.appendChild(ele)
 
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      ele.viewportCallback(true)
 
       let placeholder = ele.querySelector('.default-placeholder')
       expect(placeholder).to.not.be.null
@@ -179,7 +177,7 @@ describe('Register element', function () {
       ele.appendChild(placeholder)
       document.body.appendChild(ele)
 
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      ele.viewportCallback(true)
       let eleRect = ele.getBoundingClientRect()
       let placeholderRect = placeholder.getBoundingClientRect()
       expect(eleRect).to.deep.equal(placeholderRect)
@@ -197,7 +195,7 @@ describe('Register element', function () {
       ele.appendChild(placeholder)
       document.body.appendChild(ele)
 
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      ele.viewportCallback(true)
       let eleRect = ele.getBoundingClientRect()
       let placeholderRect = placeholder.getBoundingClientRect()
       expect(eleRect).to.not.equal(placeholderRect)
@@ -214,7 +212,7 @@ describe('Register element', function () {
       ele.appendChild(placeholder)
       document.body.appendChild(ele)
 
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      ele.viewportCallback(true)
       let eleRect = ele.getBoundingClientRect()
       let placeholderRect = placeholder.getBoundingClientRect()
       expect(eleRect).to.not.equal(placeholderRect)
@@ -250,12 +248,9 @@ describe('Register element', function () {
       document.body.appendChild(ele)
 
       expect(ele.querySelector('.mip-loading-container')).to.be.null
-      await new Promise(resolve => {
-        ele.customElement.layoutCallback = function () {
-          resolve()
-          return Promise.resolve()
-        }
-      })
+
+      ele.viewportCallback(true)
+
       // show loading
       let loader = ele.querySelector('.mip-loading-container')
       expect(loader).to.be.not.null
@@ -275,12 +270,9 @@ describe('Register element', function () {
       document.body.appendChild(ele)
 
       expect(ele.querySelector('.mip-loading-container')).to.be.null
-      await new Promise(resolve => {
-        ele.customElement.layoutCallback = function () {
-          resolve()
-          return Promise.resolve()
-        }
-      })
+
+      ele.viewportCallback(true)
+
       // show loading
       let loader = ele.querySelector('.mip-loading-container')
       expect(loader).to.be.null
@@ -316,6 +308,7 @@ describe('Register element', function () {
           resolve()
           return Promise.reject(err)
         }
+        ele.viewportCallback(true)
       })
 
       let eleRect = ele.getBoundingClientRect()
@@ -333,7 +326,6 @@ describe('Register element', function () {
 
     beforeEach(() => {
       ele = createElement(name)
-      document.body.appendChild(ele)
     })
 
     afterEach(() => {
@@ -342,51 +334,47 @@ describe('Register element', function () {
 
     it('normal sizes not match', async function () {
       ele.setAttribute('sizes', `(min-width: ${ww + 1}px) 50vw, 100vw`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.style.width).to.equal('100vw')
     })
 
     it('normal sizes match', async function () {
       ele.setAttribute('sizes', `(min-width: ${ww - 1}px) 50vw, 100vw`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.style.width).to.equal('50vw')
     })
 
     it('normal heights not match', async function () {
       ele.setAttribute('sizes', `(min-width: ${ww + 1}px) 50vw, 100vw`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.style.width).to.equal('100vw')
     })
 
     it('normal heights match', async function () {
       ele.setAttribute('sizes', `(min-width: ${ww - 1}px) 50vw, 100vw`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.style.width).to.equal('50vw')
     })
 
     it('normal media query match', async function () {
       ele.setAttribute('media', `(min-width: ${ww - 1}px)`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.classList.contains('mip-hidden-by-media-query')).to.be.false
     })
 
     it('normal media query not match', async function () {
       ele.setAttribute('media', `(min-width: ${ww + 1}px)`)
-      await new Promise(resolve => (ele.customElement.build = resolve))
+      document.body.appendChild(ele)
       expect(ele.classList.contains('mip-hidden-by-media-query')).to.be.true
     })
 
     it('normal heights width layout=responsive', async function () {
-      document.body.removeChild(ele)
-
-      ele = createElement(name)
       ele.setAttribute('layout', 'responsive')
       ele.setAttribute('width', '1px')
       ele.setAttribute('height', '1px')
       ele.setAttribute('heights', `(min-width: ${ww + 1}px) 50vw, 100vw`)
       document.body.appendChild(ele)
 
-      await new Promise(resolve => (ele.customElement.build = resolve))
       expect(ele.querySelector('mip-i-space').style.paddingTop).to.equal('100vw')
     })
   })

--- a/packages/mip/test/specs/resources.spec.js
+++ b/packages/mip/test/specs/resources.spec.js
@@ -173,10 +173,6 @@ describe('resources', function () {
   })
 
   describe('#_update', function () {
-    it('not resources', function () {
-      expect(app._update()).instanceof(Promise)
-    })
-
     it('.prerenderAllowed', function () {
       sinon.stub(app, 'getResources').callsFake(function () {
         return {
@@ -235,10 +231,10 @@ describe('resources', function () {
         expect(flag).to.be.true
       }
 
-      return app._update().then(() => {
-        rect.overlapping.restore()
-        rect.getElementRect.restore()
-      })
+      // return app._update().then(() => {
+      rect.overlapping.restore()
+      rect.getElementRect.restore()
+      // })
     })
   })
 

--- a/packages/mip/test/specs/viewport.spec.js
+++ b/packages/mip/test/specs/viewport.spec.js
@@ -69,10 +69,7 @@ describe('viewport', function () {
     let old = window.innerWidth
 
     window.innerWidth = true
-    expect(viewport.getWidth()).to.be.true
-
-    window.innerWidth = false
-    expect(viewport.getWidth()).to.be.a('number')
+    expect(viewport.getWidth()).to.equal(old)
 
     window.innerWidth = old
   })
@@ -81,12 +78,13 @@ describe('viewport', function () {
     let old = window.innerHeight
 
     window.innerHeight = true
-    expect(viewport.getHeight()).to.be.true
-
-    window.innerHeight = false
-    expect(viewport.getHeight()).to.be.a('number')
+    expect(viewport.getHeight()).to.equal(window.innerHeight)
 
     window.innerHeight = old
+  })
+
+  it('.isPortrait', function () {
+    expect(viewport.isPortrait()).to.be.false
   })
 
   describe('event', function () {
@@ -101,10 +99,11 @@ describe('viewport', function () {
       spy.returns(10)
       window.dispatchEvent(new Event('scroll'))
       document.body.dispatchEvent(new Event('scroll'))
+      spy.restore()
     })
 
     it('resize', function (done) {
-      viewport.on('resize', function (event) {
+      viewport.once('resize', function (event) {
         expect(event).to.not.be.undefined
         // restore innerWidth
         window.innerWidth = window.innerWidth + 1

--- a/packages/mip/test/specs/vue-custom-element/index.spec.js
+++ b/packages/mip/test/specs/vue-custom-element/index.spec.js
@@ -28,11 +28,9 @@ describe('vue custom element', function () {
     document.body.appendChild(ele)
     document.body.removeChild(ele)
 
-    return ele._resources.updateState().then(() => {
-      ele.viewportCallback(true)
-      sinon.assert.calledOnce(created)
-      sinon.assert.calledTwice(connectedCallback)
-    })
+    ele.viewportCallback(true)
+    sinon.assert.calledOnce(created)
+    sinon.assert.calledTwice(connectedCallback)
   })
 
   it('lifecycle', function () {
@@ -86,20 +84,12 @@ describe('vue custom element', function () {
     let ele = document.createElement(name)
     document.body.appendChild(ele)
 
-    return ele._resources.updateState().then(() => {
-      ele.setAttribute('str', 'fake')
+    ele.setAttribute('str', 'fake')
 
-      return new Promise(resolve => {
-        ele.addEventListener('build', () => {
-          // beforeUpdate called after Vue.nextTick()
-          Vue.nextTick().then(() => {
-            document.body.removeChild(ele)
-            expect(ele.innerHTML).to.be.equal('<div>fakehaha</div>')
-            sinon.assert.callOrder(...lifecycSpies)
-            resolve()
-          })
-        })
-      })
+    Vue.nextTick().then(() => {
+      document.body.removeChild(ele)
+      expect(ele.innerHTML).to.be.equal('<div>fakehaha</div>')
+      sinon.assert.callOrder(...lifecycSpies)
     })
   })
 
@@ -142,27 +132,23 @@ describe('vue custom element', function () {
     let ele = document.createElement(name)
     let viewportCallback = sinon.stub(ele, 'viewportCallback')
     document.body.appendChild(ele)
-    return new Promise(resolve => {
-      ele.addEventListener('build', () => {
-        document.body.removeChild(ele)
-        ele.setAttribute('str', 'hah')
 
-        sinon.assert.calledOnce(comp.connectedCallback)
-        sinon.assert.calledOnce(comp.disconnectedCallback)
-        sinon.assert.notCalled(comp.created)
-        sinon.assert.notCalled(comp.firstInviewCallback)
+    ele.setAttribute('str', 'hah')
 
-        expect(ele.innerHTML).to.be.empty
+    sinon.assert.calledOnce(comp.connectedCallback)
+    sinon.assert.notCalled(comp.created)
+    sinon.assert.notCalled(comp.firstInviewCallback)
 
-        viewportCallback.restore()
-        ele.viewportCallback(true)
-        sinon.assert.calledOnce(comp.created)
-        sinon.assert.calledOnce(comp.firstInviewCallback)
+    expect(ele.innerHTML).to.be.empty
 
-        expect(ele.innerHTML).to.equal('<div>hah</div>')
-        resolve()
-      })
-    })
+    viewportCallback.restore()
+    ele.viewportCallback(true)
+    sinon.assert.calledOnce(comp.created)
+    sinon.assert.calledOnce(comp.firstInviewCallback)
+
+    expect(ele.innerHTML).to.equal('<div>hah</div>')
+    document.body.removeChild(ele)
+    sinon.assert.calledOnce(comp.disconnectedCallback)
   })
 
   it('prerenderAllowed', function () {
@@ -197,21 +183,16 @@ describe('vue custom element', function () {
     let ele = document.createElement(name)
     let viewportCallback = sinon.stub(ele, 'viewportCallback')
     document.body.appendChild(ele)
-    return new Promise(resolve => {
-      ele.addEventListener('build', () => {
-        document.body.removeChild(ele)
-        sinon.assert.calledOnce(comp.connectedCallback)
-        sinon.assert.calledOnce(comp.disconnectedCallback)
-        sinon.assert.calledOnce(comp.created)
-        sinon.assert.notCalled(comp.firstInviewCallback)
+    document.body.removeChild(ele)
+    sinon.assert.calledOnce(comp.connectedCallback)
+    sinon.assert.calledOnce(comp.disconnectedCallback)
+    sinon.assert.calledOnce(comp.created)
+    sinon.assert.notCalled(comp.firstInviewCallback)
 
-        viewportCallback.restore()
-        ele.viewportCallback(true)
+    viewportCallback.restore()
+    ele.viewportCallback(true)
 
-        sinon.assert.calledOnce(comp.firstInviewCallback)
-        resolve()
-      })
-    })
+    sinon.assert.calledOnce(comp.firstInviewCallback)
   })
 
   it('should camelize attribute name', () => {
@@ -237,15 +218,10 @@ describe('vue custom element', function () {
 
     const ele = document.createElement(name)
     document.body.appendChild(ele)
-
-    return new Promise((resolve) => {
-      ele.addEventListener('build', () => {
-        ele.setAttribute('fake-str', 'hah')
-        expect(ele.customElement.vueInstance.fakeStr).to.equal('hah')
-        expect(ele.customElement.vueInstance['fake-str']).to.be.undefined
-        document.body.removeChild(ele)
-        resolve()
-      })
-    })
+    ele.viewportCallback(true)
+    ele.setAttribute('fake-str', 'hah')
+    expect(ele.customElement.vueInstance.fakeStr).to.equal('hah')
+    expect(ele.customElement.vueInstance['fake-str']).to.be.undefined
+    document.body.removeChild(ele)
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#380 
#314 补充：#380 是 #314 的子集，#380 已经关闭，后续请关注 #314 

**1、升级点** （清晰准确的描述升级的功能点）
- 组件异步执行 `build` 改回同步执行（之前因为优化的原因改成异步，虽然确实有10%左右的性能提升，但是也造成一些无法解决的问题，比如 mip-baidu-stats 无法发送自定义统计的问题，又比如无法在build回调里监听 onload domcontentloaded 事件等问题）
- 组件 `MIP.push` 由 `whenBodyAvailable` 的 promise 改为同步执行，原因与上一条相同
- 将 `resources.update` 由原来的 promise 延迟执行改为用 `requestAnimationFrame` 实现延迟执行，将大大减少首屏 update 次数，从而减少 reflow 的问题，提高性能
-  document-register-element 版本改成了1.13.1， 更新到最新版
- 把 `handleBrowserQuirks` 里的兼容性且严重造成 reflow 的代码放到 `setTimeout` 里执行，避免阻塞 `postMessage` 的消息发送

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
