### PR TITLE
fix: mip-video在mip2下无法在视频开始前展示默认图(mip1可以) mipengine#385

### DIFF
--- a/docs/guide/mip-cli/contribute-to-official-repo.md
+++ b/docs/guide/mip-cli/contribute-to-official-repo.md
@@ -37,7 +37,7 @@ $ git add XXX.js
 $ git commit -m 'update_log...'
 # pull 保持和远程分支一致
 $ git remote add upstream https://github.com/mipengine/mip2-extensions.git
-$ git pull upsteam master
+$ git pull upstream master
 # push 本次提交
 $ git push 
 ```

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -331,7 +331,16 @@ class MipImg extends CustomElement {
   attributeChangedCallback (attributeName, oldValue, newValue, namespace) {
     if (attributeName === 'src' && oldValue !== newValue) {
       let img = this.element.querySelector('img')
-      img && (img.src = newValue)
+
+      if (!img) {
+        return
+      }
+
+      event.loadPromise(img).then(() => {
+        this.element.toggleFallback(false)
+      })
+
+      img.src = newValue
     }
   }
 

--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -371,9 +371,6 @@ class MipShell extends CustomElement {
         case 'updateShell':
           this.refreshShell({pageMeta: data.pageMeta})
           break
-        case 'slide':
-          this.slideHeader(data.direction)
-          break
         case 'togglePageMask':
           this.togglePageMask(data.toggle, data.options)
           break
@@ -498,13 +495,6 @@ class MipShell extends CustomElement {
     }
 
     // Refresh header
-    this.toggleTransition(false)
-    /* eslint-disable no-unused-expressions */
-    window.innerHeight
-    this.slideHeader('down')
-    window.innerHeight
-    /* eslint-enable no-unused-expressions */
-    this.toggleTransition(true)
     if (asyncRefresh) {
       // In async mode: (Invoked from `processShellConfig` by user)
       // 1. Render fade header with updated pageMeta
@@ -549,17 +539,6 @@ class MipShell extends CustomElement {
 
       // Rebind header events
       this.bindHeaderEvents()
-    }
-  }
-
-  slideHeader (direction) {
-    if (this.pauseBouncyHeader) {
-      return
-    }
-    if (direction === 'up') {
-      this.$el.classList.add('slide-up')
-    } else {
-      this.$el.classList.remove('slide-up')
     }
   }
 
@@ -623,14 +602,10 @@ class MipShell extends CustomElement {
       window.history.scrollRestoration = 'manual'
     }
 
-    let {show: showHeader, bouncy} = this.currentPageMeta.header
+    let {show: showHeader} = this.currentPageMeta.header
     // Set `padding-top` on scroller
     if (showHeader) {
       document.body.classList.add('with-header')
-    }
-
-    if (bouncy) {
-      page.setupBouncyHeader()
     }
 
     // Cross origin

--- a/packages/mip/src/components/mip-shell/render.js
+++ b/packages/mip/src/components/mip-shell/render.js
@@ -72,11 +72,6 @@ export function render (shell, from, to) {
   // Hide page mask and skip transition
   shell.togglePageMask(false, {skipTransition: true})
 
-  // Show header
-  shell.toggleTransition(false)
-  shell.slideHeader('down')
-  shell.pauseBouncyHeader = true
-
   let params = {
     targetPageId,
     targetPageMeta,
@@ -95,8 +90,9 @@ export function render (shell, from, to) {
   // 如果不是 rootPage，则要求 iframe 和 page 同时存在
   // 之所以要判断两个都存在，是因为预渲染情况在 iframe load 之后才添加 page，所以可能 page=null 但是 iframe 已经有了
   let targetExists = isTargetRootPage || (targetIFrame && targetPage)
+  let isCacheFirst = to.meta && to.meta.cacheFirst && !isTargetRootPage
 
-  if (!targetExists || (to.meta && to.meta.reload && !to.meta.cacheFirst)) {
+  if (!targetExists || (to.meta && to.meta.reload && !isCacheFirst)) {
     // 进入这个分支表示需要创建新的 iframe，有以下情况：
     // 1. 目标页面不存在
     // 2. 目标页面的 iframe 和 page 虽然都存在，但是因为是点击链接跳转的（to.meta.reload = true)，因此为了实时性需要重新加载。
@@ -198,8 +194,6 @@ export function render (shell, from, to) {
         display: 'block',
         opacity: 1
       })
-      shell.toggleTransition(true)
-      shell.pauseBouncyHeader = false
 
       // Get <mip-shell> from root page
       let shellDOM = document.querySelector('mip-shell') || document.querySelector('[mip-shell]')
@@ -270,8 +264,6 @@ export function render (shell, from, to) {
       } else {
         shell.refreshShell({pageMeta: targetPageMeta})
       }
-      shell.toggleTransition(true)
-      shell.pauseBouncyHeader = false
 
       // Get <mip-shell> from root page
       let shellDOM = document.querySelector('mip-shell') || document.querySelector('[mip-shell]')

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -114,7 +114,7 @@ class MipVideo extends CustomElement {
         videoEl.setAttribute(k, this.attributes[k])
       }
     }
-    let currentTime = this.attributes['currenttime'] || 0
+    let currentTime = Number(this.attributes['currenttime'])
     videoEl.setAttribute('playsinline', 'playsinline')
     // 兼容qq浏览器
     videoEl.setAttribute('x5-playsinline', 'x5-playsinline')
@@ -129,7 +129,9 @@ class MipVideo extends CustomElement {
     })
     // 如果设置了播放时间点，则直接跳转至播放时间的位置开始播放
     videoEl.addEventListener('loadedmetadata', function () {
-      this.currentTime = currentTime
+      if (!Number.isNaN(currentTime)) {
+        this.currentTime = currentTime
+      }
     })
     this.element.appendChild(videoEl)
     return videoEl

--- a/packages/mip/src/page/const/index.js
+++ b/packages/mip/src/page/const/index.js
@@ -9,8 +9,7 @@ export const DEFAULT_SHELL_CONFIG = {
     title: '',
     logo: '',
     buttonGroup: [],
-    show: false,
-    bouncy: true
+    show: false
   },
   view: {
     isIndex: false

--- a/packages/mip/src/page/index.js
+++ b/packages/mip/src/page/index.js
@@ -10,7 +10,6 @@ import {
   toggleFadeHeader
 } from './util/dom'
 import {getCleanPageId, parsePath} from './util/path'
-import Debouncer from './util/debounce'
 import {supportsPassive} from './util/feature-detect'
 import {scrollTo} from './util/ease-scroll'
 import {
@@ -88,73 +87,6 @@ class Page {
   }
 
   /**
-   * listen to viewport.scroller, toggle header when scrolling up & down
-   *
-   */
-  setupBouncyHeader () {
-    if (this.bouncyHeaderSetup) {
-      return
-    }
-    const THRESHOLD = 10
-    let scrollTop
-    let lastScrollTop = 0
-    let scrollDistance
-    let scrollHeight = viewport.getScrollHeight()
-    let viewportHeight = viewport.getHeight()
-
-    // viewportHeight = 0 before frameMoveIn animation ends
-    // Wait a minute
-    /* istanbul ignore next */
-    if (viewportHeight === 0) {
-      setTimeout(this.setupBouncyHeader.bind(this), 100)
-      return
-    }
-
-    this.bouncyHeaderSetup = true
-    this.debouncer = new Debouncer(() => {
-      scrollTop = viewport.getScrollTop()
-      scrollDistance = Math.abs(scrollTop - lastScrollTop)
-
-      // ignore bouncy scrolling in iOS
-      /* istanbul ignore next */
-      if (scrollTop < 0 || scrollTop + viewportHeight > scrollHeight) {
-        return
-      }
-
-      /* istanbul ignore next */
-      if (lastScrollTop < scrollTop && scrollDistance >= THRESHOLD) {
-        let target = this.isRootPage ? window : window.parent
-        this.emitCustomEvent(target, this.isCrossOrigin, {
-          name: 'mipShellEvents',
-          data: {
-            type: 'slide',
-            data: {
-              direction: 'up'
-            }
-          }
-        })
-      }/* istanbul ignore next */ else if (lastScrollTop > scrollTop && scrollDistance >= THRESHOLD) {
-        let target = this.isRootPage ? window : window.parent
-        this.emitCustomEvent(target, this.isCrossOrigin, {
-          name: 'mipShellEvents',
-          data: {
-            type: 'slide',
-            data: {
-              direction: 'down'
-            }
-          }
-        })
-      }
-
-      lastScrollTop = scrollTop
-    })
-
-    // use passive event listener to improve scroll performance
-    viewport.scroller.addEventListener('scroll', this.debouncer, eventListenerOptions)
-    this.debouncer.handleEvent()
-  }
-
-  /**
    * notify root page with an eventdata
    *
    * @param {Object} data eventdata
@@ -173,8 +105,7 @@ class Page {
    *
    */
   destroy () {
-    /* istanbul ignore next */
-    viewport.scroller.removeEventListener('scroll', this.debouncer, false)
+    // 原本用于 bouncy 的 removeListener，现在不需要了，但方法还是保留，避免报错
   }
 
   start () {
@@ -263,6 +194,7 @@ class Page {
       customEmit(window, event.name, event.data)
 
       this.children.forEach(pageMeta => {
+        /* istanbul ignore next */
         if (pageMeta.targetWindow) {
           pageMeta.targetWindow.postMessage({
             type: MESSAGE_CROSS_ORIGIN,
@@ -315,7 +247,8 @@ class Page {
       return
     }
 
-    let target = this.isRootPage ? this : /* istanbul ignore next */ window.parent.MIP.viewer.page
+    /* istanbul ignore next */
+    let target = this.isRootPage ? this : window.parent.MIP.viewer.page
     return target.prerenderPages(urls)
   }
 
@@ -358,6 +291,7 @@ class Page {
       console.warn('该方法只能在 rootPage 调用')
       return
     }
+    /* istanbul ignore next */
     if (this.children.length >= MAX_PAGE_NUM) {
       let currentPage
       let prerenderIFrames = []
@@ -405,6 +339,7 @@ class Page {
    * @return {Page} page
    */
   getPageById (pageId) {
+    /* istanbul ignore next */
     if (!pageId) {
       return this
     }
@@ -458,23 +393,32 @@ class Page {
       console.warn('该方法只能在 rootPage 调用')
       return Promise.reject()
     }
+
+    /* istanbul ignore next */
     if (typeof urls === 'string') {
       urls = [urls]
     }
 
+    /* istanbul ignore next */
     if (!Array.isArray(urls)) {
       return Promise.reject('预渲染参数必须是一个数组')
     }
 
+    /* istanbul ignore next */
     let createPrerenderIFrame = ({fullpath, pageId}) => {
       return new Promise((resolve, reject) => {
         let me = this
         let iframe = getIFrame(pageId)
         /* istanbul ignore next */
         if (iframe) {
-          // 预加载前已经存在，直接返回即可
-          resolve(iframe)
-          return
+          if (iframe.contentWindow.MIP.version === '2') {
+            // 预加载前已经存在，直接返回即可
+            resolve(iframe)
+            return
+          } else {
+            // 如果在断网情况下，内部的 window.MIP 会是一个数组。这样实际上这个 iframe 也不可复用，应当删除
+            iframe.parentNode.removeChild(iframe)
+          }
         }
 
         createIFrame({fullpath: fullpath + '#prerender=1', pageId}, {
@@ -503,16 +447,15 @@ class Page {
       })
     }
 
+    /* istanbul ignore next */
     let findMetaByPageId = pageId => {
       let target
-      /* istanbul ignore next */
       if (!this.isRootPage && !this.isCrossOrigin) {
         target = window.parent
       } else {
         target = window
       }
 
-      /* istanbul ignore next */
       if (target.MIP_PAGE_META_CACHE[pageId]) {
         return target.MIP_PAGE_META_CACHE[pageId]
       } else {
@@ -525,9 +468,7 @@ class Page {
         }
       }
 
-      /* istanbul ignore next */
       console.warn('Cannot find MIP Shell Config for current page. Use default instead.')
-      /* istanbul ignore next */
       return Object.assign({}, DEFAULT_SHELL_CONFIG)
     }
 

--- a/packages/mip/src/page/util/debounce.js
+++ b/packages/mip/src/page/util/debounce.js
@@ -1,3 +1,9 @@
+/**
+ * @file 控制回调次数
+ * @deprecated 这个功能本来使用在 bouncy header，不过因为使用很少，为了代码体积考虑删除了
+ * @author panyuqi@baidu.com (panyuqi)
+ */
+
 import {raf} from './feature-detect'
 
 export default class Debouncer {

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -101,7 +101,7 @@ class Resources {
       prerender.execute(() => {
         element.build()
         this.updateState()
-      })
+      }, element)
     }
     COMPONENTS_NEED_NOT_DELAY.indexOf(element.tagName) === -1 ? setTimeout(fn, 0) : fn()
   }

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -336,6 +336,7 @@ export class Extensions {
    * Registers a service in extension currently being registered (by calling `MIP.push`).
    * A service in extension is still a class contains some useful functions,
    * it's no conceptual difference with other internal services.
+   * However, external services will be instantiated immediately.
    *
    * @param {string} name
    * @param {!Function} implementation
@@ -345,7 +346,7 @@ export class Extensions {
 
     holder.extension.services[name] = {implementation}
 
-    Services.registerService(this.win, name, implementation)
+    Services.registerService(this.win, name, implementation, true)
   }
 
   /**

--- a/packages/mip/src/services/services.js
+++ b/packages/mip/src/services/services.js
@@ -81,9 +81,10 @@ class ServicesInternal {
    * @param {string} id
    * @param {!Object} context
    * @param {!Function} Constructor
+   * @param {?boolean} instantiate
    * @returns {!Object}
    */
-  static registerService (holder, id, context, Constructor) {
+  static registerService (holder, id, context, Constructor, instantiate) {
     const services = this.getServices(holder)
     let service = services[id]
 
@@ -113,7 +114,7 @@ class ServicesInternal {
     /**
      * Service may have been requested already, in which case we need to fulfill the pending promise.
      */
-    if (service.resolve) {
+    if (service.resolve || instantiate) {
       this.instantiateService(service)
     }
 
@@ -227,9 +228,10 @@ class Services extends ServicesFactory {
    * @param {!Window} holder currently represents `Window`.
    * @param {string} id of the service.
    * @param {!Function} Constructor of the service.
+   * @param {?boolean} instantiate service immediately.
    */
-  static registerService (holder, id, Constructor) {
-    ServicesInternal.registerService(holder, id, holder, Constructor)
+  static registerService (holder, id, Constructor, instantiate) {
+    ServicesInternal.registerService(holder, id, holder, Constructor, instantiate)
   }
 
   /**

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -387,29 +387,33 @@ let viewer = {
     // add normal scroll class to body. except ios in iframe.
     // Patch for ios+iframe is default in mip.css
     if (!platform.needSpecialScroll) {
-      document.documentElement.classList.add('mip-i-android-scroll')
-      document.body.classList.add('mip-i-android-scroll')
+      setTimeout(() => {
+        document.documentElement.classList.add('mip-i-android-scroll')
+        document.body.classList.add('mip-i-android-scroll')
+      }, 0)
     }
 
     // prevent bouncy scroll in iOS 7 & 8
     if (platform.isIos()) {
       let iosVersion = platform.getOsVersion()
       iosVersion = iosVersion ? iosVersion.split('.')[0] : ''
-      document.documentElement.classList.add('mip-i-ios-scroll')
-      window.addEventListener('orientationchange', () => {
-        document.documentElement.classList.remove('mip-i-ios-scroll')
-        setTimeout(() => {
-          document.documentElement.classList.add('mip-i-ios-scroll')
+      setTimeout(() => {
+        document.documentElement.classList.add('mip-i-ios-scroll')
+        document.documentElement.classList.add('mip-i-ios-width')
+        window.addEventListener('orientationchange', () => {
+          document.documentElement.classList.remove('mip-i-ios-scroll')
+          setTimeout(() => {
+            document.documentElement.classList.add('mip-i-ios-scroll')
+          })
         })
-      })
-      document.documentElement.classList.add('mip-i-ios-width')
+      }, 0)
 
       if (!this.page.isRootPage) {
         this.fixIOSPageFreeze()
       }
 
       if (this.isIframed) {
-        this.lockBodyScroll()
+        setTimeout(() => this.lockBodyScroll(), 0)
 
         // While the back button is clicked,
         // the cached page has some problems.

--- a/packages/mip/test/specs/page/page.spec.js
+++ b/packages/mip/test/specs/page/page.spec.js
@@ -195,11 +195,6 @@ describe('page API #UI', function () {
     }
   })
 
-  it('.setupBouncyHeader', function () {
-    page.setupBouncyHeader()
-    expect(page.bouncyHeaderSetup).to.be.true
-  })
-
   it('.destroy', function () {
     page.destroy()
   })

--- a/packages/mip/test/specs/services/services.spec.js
+++ b/packages/mip/test/specs/services/services.spec.js
@@ -57,6 +57,14 @@ describe('services', () => {
       expect(Constructor).to.be.calledOnce
     })
 
+    it('should instantiate service immediately', () => {
+      Services.registerService(window, 'a', Constructor, true)
+      const a = window.services.a
+      expect(a.instance).instanceOf(Constructor)
+      expect(a.context).to.be.null
+      expect(a.Constructor).to.be.null
+    })
+
     it('should return the service when it exists', () => {
       const a0 = Services.getServiceOrNull(window, 'a')
       expect(a0).to.be.null


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#385 
**1、升级点** （清晰准确的描述升级的功能点）
修复mip-video在mip2下无法在视频开始前展示默认图(mip1可以)
**2、影响范围** （描述该需求上线会影响什么功能）
mip-video
**3、自测 Checklist**
chrome
**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
