### PR TITLE
修复预取使 preregisterExtensions 可能为对象的问题

### DIFF
--- a/packages/mip/src/runtime.js
+++ b/packages/mip/src/runtime.js
@@ -134,7 +134,8 @@ class Runtime {
 
     installMip1Polyfill(globalMip)
     installSandbox(globalMip)
-    preregisteredExtensions.forEach(installExtension)
+
+    Array.isArray(preregisteredExtensions) && preregisteredExtensions.forEach(installExtension)
   }
 }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** 
 - 修复预取使 preregisterExtensions 可能为对象的问题

**2、影响范围** 

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
