### PR TITLE
fix: mip-video在mip2下无法在视频开始前展示默认图(mip1可以) mipengine#385

### DIFF
--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -114,7 +114,7 @@ class MipVideo extends CustomElement {
         videoEl.setAttribute(k, this.attributes[k])
       }
     }
-    let currentTime = this.attributes['currenttime'] || 0
+    let currentTime = Number(this.attributes['currenttime'])
     videoEl.setAttribute('playsinline', 'playsinline')
     // 兼容qq浏览器
     videoEl.setAttribute('x5-playsinline', 'x5-playsinline')
@@ -129,7 +129,9 @@ class MipVideo extends CustomElement {
     })
     // 如果设置了播放时间点，则直接跳转至播放时间的位置开始播放
     videoEl.addEventListener('loadedmetadata', function () {
-      this.currentTime = currentTime
+      if (!Number.isNaN(currentTime)) {
+        this.currentTime = currentTime
+      }
     })
     this.element.appendChild(videoEl)
     return videoEl


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#385 
**1、升级点** （清晰准确的描述升级的功能点）
修复mip-video在mip2下无法在视频开始前展示默认图(mip1可以)
**2、影响范围** （描述该需求上线会影响什么功能）
mip-video
**3、自测 Checklist**
chrome
**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百