### PR TITLE
fix: .mip-img class

### DIFF
--- a/packages/mip/src/styles/mip-img.less
+++ b/packages/mip/src/styles/mip-img.less
@@ -6,6 +6,17 @@
     transition: opacity linear 300ms;
   }
 
+  &.mip-img-loaded {
+    background: transparent;
+    &::before {
+      content: none;
+      display: none;
+    }
+    img.mip-fill-content {
+      opacity: 1;
+    }
+  }
+
   &-container {
     margin: 16px auto;
     font-size: 0;


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）
修复 mip2 替换 mip1 后，mip-img上有 .mip-img class 的图片不显示的问题

**2、影响范围** （描述该需求上线会影响什么功能）
无

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
