### PR TITLE
修复轮播图因第三方站点加入div clear:both 而导致效果消失的问题

### DIFF
--- a/packages/mip/src/styles/mip-carousel.less
+++ b/packages/mip/src/styles/mip-carousel.less
@@ -2,6 +2,11 @@ mip-carousel a {
   -webkit-tap-highlight-color: transparent;
 }
 
+// 因为第三方站点设置了 `div clear:both` 需要重置一下
+.mip-carousel-wrapper div {
+  clear: none;
+}
+
 .mip-carousle-subtitle {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#399 

**1、升级点** （清晰准确的描述升级的功能点）
修复轮播图因第三方站点加入div clear:both 而导致效果消失的问题

**2、影响范围** （描述该需求上线会影响什么功能）
目前仅发现一个站点，[测试链接](http://cp01-sys-rpm14.cp01.baidu.com:8003/mip/c/mip.ruiwen.com/wenxue/tonghua/347183.html?s_j=1)

**3、自测 Checklist**
上述站点利用代理自测成功，效果恢复。

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
