### PR TITLE
【免测】移除 mip-bind 依赖的 Set 特性

### DIFF
--- a/packages/mip/src/components/mip-bind/bind.js
+++ b/packages/mip/src/components/mip-bind/bind.js
@@ -237,7 +237,7 @@ class Bind {
     Object.assign(win.m, data.pageData)
     // record props of pageData
     !cancel && Object.keys(data.pageData).forEach(k => {
-      win.pgStates[k] = null
+      win.pgStates[k] = true
     })
 
     let globalData = data.globalData

--- a/packages/mip/src/components/mip-bind/bind.js
+++ b/packages/mip/src/components/mip-bind/bind.js
@@ -17,7 +17,7 @@ class Bind {
     // save and check watcher defined by MIP.watch
     this.watcherIds = []
     // save local states of page
-    this.win.pgStates = new Set()
+    this.win.pgStates = {}
     // require mip data extension runtime
     this.compile = new Compile()
     this.observer = new Observer()
@@ -132,7 +132,7 @@ class Bind {
         }
         data = classified.pageData
         Object.keys(data).forEach(field => {
-          if (win.pgStates.has(field)) {
+          if (win.pgStates.hasOwnProperty(field)) {
             assign(win.m, {
               [field]: data[field]
             })
@@ -236,12 +236,14 @@ class Bind {
     let win = this.win
     Object.assign(win.m, data.pageData)
     // record props of pageData
-    !cancel && Object.keys(data.pageData).forEach(k => win.pgStates.add(k))
+    !cancel && Object.keys(data.pageData).forEach(k => {
+      win.pgStates[k] = null
+    })
 
     let globalData = data.globalData
     // update props from globalData
     Object.keys(globalData).forEach(key => {
-      if (!win.pgStates.has(key) && win.m.hasOwnProperty(key)) {
+      if (!win.pgStates.hasOwnProperty(key) && win.m.hasOwnProperty(key)) {
         if (isObject(globalData[key]) && win.m[key] && isObject(win.m[key])) {
           assign(win.m[key], globalData[key])
           win.m[key] = JSON.parse(JSON.stringify(win.m[key]))


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/413

**1、升级点** 
 - 将 `mip-bind` 的 `Set` 换成了 `{}`

**2、影响范围** 
 - 含有 `m-bind` 和 `mip-data` 的页面

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
