### PR TITLE
feat: first screen label

### DIFF
--- a/packages/mip/src/client-prerender.js
+++ b/packages/mip/src/client-prerender.js
@@ -17,7 +17,11 @@ let parsePrerender = ele => {
   }
 
   let prerender = ele.getAttribute('prerender')
-  return prerender != null && prerender !== 'false'
+  let isFirstScreenElement = ele.getAttribute('firstscreen')
+  if (isFirstScreenElement) {
+    ele.viewportCallback && ele.viewportCallback(true)
+  }
+  return isFirstScreenElement != null && prerender != null && prerender !== 'false'
 }
 
 let resetPrerenderHash = () => {
@@ -33,7 +37,7 @@ let resetPrerenderHash = () => {
 class ClientPrerender {
   constructor () {
     // 预渲染环境标记, 是否是预渲染状态
-    this.prerender = false
+    this.isPrerendering = false
 
     // 是否执行过预渲染
     this.isPrerendered = false
@@ -46,11 +50,11 @@ class ClientPrerender {
     })
 
     if (util.hash.get('prerender') === '1') {
-      this.prerender = true
+      this.isPrerendering = true
       new Promise(resolve => {
         // set client prerender event
         this.messager.on(MESSAGE_PAGE_ACTIVE, () => {
-          this.prerender = false
+          this.isPrerendering = false
           resetPrerenderHash()
           resolve()
         })
@@ -60,6 +64,8 @@ class ClientPrerender {
         })
       }).then(() => {
         this.isPrerendered = true
+        performance.recordTiming('MIPPageShow')
+        performance.lockFirstScreen()
         performance.recordTiming('MIPElementBuildStart')
         let fn
         while ((fn = this.queue.shift())) {
@@ -72,7 +78,7 @@ class ClientPrerender {
   }
 
   execute (fn, ele) {
-    if (this.prerender && !parsePrerender(ele)) {
+    if (this.isPrerendering && !parsePrerender(ele)) {
       this.queue.push(fn)
     } else {
       fn()

--- a/packages/mip/src/log/firstscreen-label.js
+++ b/packages/mip/src/log/firstscreen-label.js
@@ -30,7 +30,7 @@ function getPathTo(element) {
 }
 
 function sendLog() {
-  let allLabelImgs = [...document.querySelectorAll('mip-img[firstScreen="1"]')]
+  let allLabelImgs = [...document.querySelectorAll('mip-img[firstscreen]')]
   let allFirstScreenImgs = [...document.querySelectorAll('mip-img[mip-firstscreen-element]')]
   allLabelImgs.forEach(element => {
     if (!element.hasAttribute('mip-firstscreen-element')) {

--- a/packages/mip/src/log/firstscreen-label.js
+++ b/packages/mip/src/log/firstscreen-label.js
@@ -1,0 +1,56 @@
+/**
+ * @file 首屏标记识别
+ * @author liwenqian@baidu.com
+ */
+
+import viewer from '../viewer'
+import { OUTER_MESSAGE_PERFORMANCE_ANALYSIS_LOG } from '../page/const/index'
+let missList = [];
+let incorrectList = [];
+
+function getPathTo(element) {
+  if (element.tagName === 'HTML') {
+      return 'html.1';
+  }
+  if (element === document.body) {
+      return 'html.1/body.1';
+  }
+
+  var ix = 0;
+  var siblings = element.parentNode.childNodes;
+  for (var i = 0; i < siblings.length; i++) {
+      var sibling = siblings[i];
+      if (sibling === element) {
+          return getPathTo(element.parentNode) + '/' + element.tagName.toLowerCase() + '.' + (ix + 1) + '';
+      }
+      if (sibling.nodeType === 1 && sibling.tagName === element.tagName) {
+          ix++;
+      }
+  }
+}
+
+function sendLog() {
+  let allLabelImgs = [...document.querySelectorAll('mip-img[firstScreen="1"]')]
+  let allFirstScreenImgs = [...document.querySelectorAll('mip-img[mip-firstscreen-element]')]
+  console.log(allLabelImgs)
+  console.log(allFirstScreenImgs)
+  allLabelImgs.forEach(element => {
+    if (!element.hasAttribute('mip-firstscreen-element')) {
+      incorrectList.push(getPathTo(element))
+    }
+  })
+  allFirstScreenImgs.forEach(element => {
+    if (!element.hasAttribute('firstscreen')) {
+      missList.push(getPathTo(element))
+    }
+  })
+  let info = missList.join(',') + '!!' + incorrectList.join(',')
+  viewer.sendMessage(OUTER_MESSAGE_PERFORMANCE_ANALYSIS_LOG, {
+    type: 'fslabel',
+    info: info
+  });
+}
+
+export default {
+  sendLog
+}

--- a/packages/mip/src/log/firstscreen-label.js
+++ b/packages/mip/src/log/firstscreen-label.js
@@ -32,8 +32,6 @@ function getPathTo(element) {
 function sendLog() {
   let allLabelImgs = [...document.querySelectorAll('mip-img[firstScreen="1"]')]
   let allFirstScreenImgs = [...document.querySelectorAll('mip-img[mip-firstscreen-element]')]
-  console.log(allLabelImgs)
-  console.log(allFirstScreenImgs)
   allLabelImgs.forEach(element => {
     if (!element.hasAttribute('mip-firstscreen-element')) {
       incorrectList.push(getPathTo(element))

--- a/packages/mip/src/page/const/index.js
+++ b/packages/mip/src/page/const/index.js
@@ -55,6 +55,7 @@ export const MAX_PAGE_NUM = 6
 // 和 SF 通讯的事件名称
 export const OUTER_MESSAGE_PERFORMANCE_UPDATE = 'performance-update'
 export const OUTER_MESSAGE_STABILITY_LOG = 'stability-log'
+export const OUTER_MESSAGE_PERFORMANCE_ANALYSIS_LOG = 'performance-analysis-log'
 export const OUTER_MESSAGE_CHANGE_STATE = 'change-state'
 export const OUTER_MESSAGE_VIDEO_JUMP = 'video-jump'
 export const OUTER_MESSAGE_HISTORY_NAVIGATE = 'history-navigate'

--- a/packages/mip/src/performance.js
+++ b/packages/mip/src/performance.js
@@ -5,6 +5,7 @@
 
 import util from './util/index'
 import viewer from './viewer'
+import viewport from './viewport'
 import firstScreenLabel from './log/firstscreen-label'
 import prerender from './client-prerender'
 
@@ -111,9 +112,10 @@ function lockFirstScreen() {
   if (prerender.isPrerendering) {
     return
   }
+  let viewportRect = viewport.getRect()
   fsElements = fsElements.filter((element) => {
     if (prerender.isPrerendered) {
-      return element._resources.isInViewport(element)
+      return element._resources.isInViewport(element, viewportRect)
     }
     return element.inViewport()
   }).map((element) => {

--- a/packages/mip/src/performance.js
+++ b/packages/mip/src/performance.js
@@ -6,8 +6,6 @@
 import util from './util/index'
 import viewer from './viewer'
 import firstScreenLabel from './log/firstscreen-label'
-import rect from './util/dom/rect'
-import viewport from './viewport'
 import prerender from './client-prerender'
 
 const EventEmitter = util.EventEmitter
@@ -95,18 +93,6 @@ function recordTiming (name, timing) {
 }
 
 /**
- * check element if inViewport
- *
- * @param {HTMLElement} element html element
- */
-function isInViewport (element) {
-  let elementRect = rect.getElementRect(element)
-  let viewportRect = viewport.getRect()
-  return element.prerenderAllowed(elementRect, viewportRect) ||
-    rect.overlapping(elementRect, viewportRect)
-}
-
-/**
  * Try recording first-screen loaded.
  */
 function tryRecordFirstScreen () {
@@ -127,7 +113,7 @@ function lockFirstScreen() {
   }
   fsElements = fsElements.filter((element) => {
     if (prerender.isPrerendered) {
-      return isInViewport(element)
+      return element._resources.isInViewport(element)
     }
     return element.inViewport()
   }).map((element) => {

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -153,6 +153,25 @@ class Resources {
   }
 
   /**
+   * Check element in viewport
+   *
+   * @param {MIPElement} element element
+   * @return {boolean} is inViewport
+   */
+  isInViewport (element) {
+    let elementRect = rect.getElementRect(element)
+    let viewportRect = this._viewport.getRect()
+    // Compute the viewport state of current element.
+    // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
+    return element.prerenderAllowed(elementRect, viewportRect) ||
+      rect.overlapping(elementRect, viewportRect) ||
+      // 在 ios 有个设置滚动${@link ./viewer.lockBodyScroll} 会设置 scrollTop=1
+      // 如果部分元素在顶部而且没有设置高度，会导致 elementRect 和 viewportRect 不重叠，
+      // 进而导致无法执行元素的生命周期，针对这种情况做特殊处理
+      (elementRect.bottom === 0 && elementRect.top === 0 && viewportRect.top === 1)
+  }
+
+  /**
    * Deffered update elements's viewport state.
    * @return {Promise<undefined>}
    */
@@ -170,8 +189,6 @@ class Resources {
   _doRealUpdate () {
     /* @type {Object} */
     let resources = this.getResources()
-    let viewportRect = viewport.getRect()
-
     let elementIds = []
     while (true) {
       let updatedElementIds = Object.keys(resources)
@@ -187,16 +204,7 @@ class Resources {
         let ele = resources[newElementIds[i]]
         // The element may have been removed.
         if (ele && ele.isBuilt()) {
-          // Compute the viewport state of current element.
-          // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
-          let elementRect = rect.getElementRect(ele)
-          let inViewport = ele.prerenderAllowed(elementRect, viewportRect) ||
-            rect.overlapping(elementRect, viewportRect) ||
-            // 在 ios 有个设置滚动${@link ./viewer.lockBodyScroll} 会设置 scrollTop=1
-            // 如果部分元素在顶部而且没有设置高度，会导致 elementRect 和 viewportRect 不重叠，
-            // 进而导致无法执行元素的生命周期，针对这种情况做特殊处理
-            (elementRect.bottom === 0 && elementRect.top === 0 && viewportRect.top === 1)
-
+          let inViewport = this.isInViewport(ele)
           this.setInViewport(ele, inViewport)
         }
       }

--- a/packages/mip/src/resources.js
+++ b/packages/mip/src/resources.js
@@ -156,11 +156,11 @@ class Resources {
    * Check element in viewport
    *
    * @param {MIPElement} element element
+   * @param {Object} viewportRect viewport Rect
    * @return {boolean} is inViewport
    */
-  isInViewport (element) {
+  isInViewport (element, viewportRect) {
     let elementRect = rect.getElementRect(element)
-    let viewportRect = this._viewport.getRect()
     // Compute the viewport state of current element.
     // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
     return element.prerenderAllowed(elementRect, viewportRect) ||
@@ -189,6 +189,7 @@ class Resources {
   _doRealUpdate () {
     /* @type {Object} */
     let resources = this.getResources()
+    let viewportRect = this._viewport.getRect()
     let elementIds = []
     while (true) {
       let updatedElementIds = Object.keys(resources)
@@ -204,7 +205,7 @@ class Resources {
         let ele = resources[newElementIds[i]]
         // The element may have been removed.
         if (ele && ele.isBuilt()) {
-          let inViewport = this.isInViewport(ele)
+          let inViewport = this.isInViewport(ele, viewportRect)
           this.setInViewport(ele, inViewport)
         }
       }

--- a/packages/mip/test/specs/client-prerender.spec.js
+++ b/packages/mip/test/specs/client-prerender.spec.js
@@ -98,4 +98,14 @@ describe('client-prerender', function () {
     prerender.execute(fn, ele)
     sinon.assert.calledOnce(fn)
   })
+
+  it('firstscreen attribute should be not delay fn', function () {
+    let prerender = new ClientPrerender()
+    let fn = sinon.spy()
+    let ele = document.createElement('div')
+    ele.setAttribute('firstsceen', '1')
+
+    prerender.execute(fn, ele)
+    sinon.assert.calledOnce(fn)
+  })
 })

--- a/packages/mip/test/specs/log/error-monitor.spec.js
+++ b/packages/mip/test/specs/log/error-monitor.spec.js
@@ -8,7 +8,7 @@
 import viewer from 'src/viewer'
 import { errorHandler } from 'src/log/error-monitor'
 
-describe('monitor', function () {
+describe('error-monitor', function () {
   it('catch error', function (done) {
     let filename = 'https://c.mipcdn.com/static/v2/mip-sidebar/mip-sidebar.js'
     let message = 'test monitor'

--- a/packages/mip/test/specs/log/firstsceen-label.spec.js
+++ b/packages/mip/test/specs/log/firstsceen-label.spec.js
@@ -1,0 +1,43 @@
+/**
+ * @file monitor spec
+ * @author liwenqian(liwenqian@baidu.com)
+ */
+
+/* globals describe, it, expect, sinon */
+
+import viewer from 'src/viewer'
+import firstSceenLabel from 'src/log/firstscreen-label'
+
+describe('firstscreen-label', () => {
+  let div
+  before(() => {
+    div = document.createElement('div')
+    div.innerHTML = `
+      <div class="test-img1">
+        <mip-img firstscreen="1" src="https://www.mipengine.org/static/img/sample_01.jpg"></mip-img>
+      </div>
+      <div class="test-img2">
+        <mip-img mip-firstscreen-element src="https://www.mipengine.org/static/img/sample_02.jpg"></mip-img>
+      </div>
+    `
+    document.body.appendChild(div)
+  })
+  
+  it('correct firstsceen label log', function (done) {
+    let spy = sinon.stub(viewer, 'sendMessage').callsFake(function (eventName, data = {}) {
+      expect(eventName).to.be.equal('performance-analysis-log')
+      expect(data).to.be.a('object')
+      expect(data.type).to.be.equal('fslabel')
+      expect(data.info).to.be.equal('html.1/body.1/div.12/div.2/mip-img.1!!html.1/body.1/div.12/div.1/mip-img.1')
+      done()
+      spy.restore()
+    })
+    firstSceenLabel.sendLog()
+  })
+  
+  after(() => {
+    document.body.removeChild(div)
+  })
+})
+
+


### PR DESCRIPTION
**1、升级点** 
1. 预渲染对标记为 `firstscreen=1` 首屏元素（主要是图片）进行提前渲染
2. 修正在预渲染下因 iframe 隐藏无法识别元素是否在首屏，造成的 otm 指标统计不准确
3. 发送首屏标记准确度日志给外层用于分析

**2、影响范围** 
1. 一定程度上影响预渲染下的 otm 指标
2. 有首屏标记图片的预渲染过程

**3、自测 Checklist**
1. 预渲染功能正常
2. otm 指标符合预期
3. 首屏准确度日志反馈正常


**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百