### PR TITLE
【免测】兼容 mip1 存量站点和组件中关于 mip-fixed 组件在 iOS + iframe 情况下挪出 body

### DIFF
--- a/packages/mip/src/components/mip-fixed.js
+++ b/packages/mip/src/components/mip-fixed.js
@@ -17,9 +17,11 @@ class MipFixed extends CustomElement {
     // should not move
     const still = this.element.hasAttribute('still')
 
-    // only in iOS + iframe need moving element to fixedlayer
-    const shouldMoveToFixedLayer = !still && platform.isIos() && viewer.isIframed
-    viewer.fixedElement.setFixedElement([this.element], shouldMoveToFixedLayer)
+    if (!still) {
+      // only in iOS + iframe need moving element to fixedlayer
+      const shouldMoveToFixedLayer = platform.isIos() && viewer.isIframed
+      viewer.fixedElement.setFixedElement([this.element], shouldMoveToFixedLayer)
+    }
   }
 }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#90 

**1、升级点** （清晰准确的描述升级的功能点）
- mip-fixed 作用范围通过 still 属性进一步收敛，避免对 mip1 现有组件和站点污染
**2、影响范围** （描述该需求上线会影响什么功能）
mip-fixed 组件（mip1 的站点和 mip2 的站点）
**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
