### PR TITLE
在直接打开MIP的情况下记录滚动位置

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -596,7 +596,7 @@ class MipShell extends CustomElement {
   // ===================== All Page Functions =====================
   bindAllEvents () {
     // Don't let browser restore scroll position.
-    if ('scrollRestoration' in window.history) {
+    if (!window.MIP.standalone && 'scrollRestoration' in window.history) {
       window.history.scrollRestoration = 'manual'
     }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#426 
**1、升级点** （清晰准确的描述升级的功能点）
在直接打开MIP页面的情况下允许浏览器记录滚动位置
**2、影响范围** （描述该需求上线会影响什么功能）
所有直接打开MIP页面时。
在搜索结果页用 SF 打开的不受影响。
**3、自测 Checklist**
采用代理方式直接打开线上小说页面（mipcdn地址的），滚动到下方之后刷新，能恢复到刚才滚动的位置
**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
