### PR TITLE
解决异步模块导致的组件执行顺序不一致的问题

### DIFF
--- a/packages/mip/test/specs/services/extensions.spec.js
+++ b/packages/mip/test/specs/services/extensions.spec.js
@@ -568,7 +568,7 @@ describe('extensions', () => {
     expect(Services.getService(window, 'mip-service')).instanceOf(implementation)
   })
 
-  it.only('should register element in order', async function () {
+  it('should register element in order', async function () {
     let order = []
 
     await new Promise(resolve => {

--- a/packages/mip/test/specs/services/extensions.spec.js
+++ b/packages/mip/test/specs/services/extensions.spec.js
@@ -568,6 +568,43 @@ describe('extensions', () => {
     expect(Services.getService(window, 'mip-service')).instanceOf(implementation)
   })
 
+  it.only('should register element in order', async function () {
+    let order = []
+
+    await new Promise(resolve => {
+      extensions.installExtension({
+        name: 'mip-ext-a',
+        func () {
+          setTimeout(() => {
+            order.push('a')
+            extensions.registerElement('mip-a', class extends CustomElement {})
+          }, 100)
+        }
+      })
+
+      extensions.installExtension({
+        name: 'mip-ext-b',
+        func () {
+          setTimeout(() => {
+            order.push('b')
+            extensions.registerElement('mip-b', class extends CustomElement {})
+          })
+        }
+      })
+
+      extensions.installExtension({
+        name: 'mip-ext-c',
+        func () {
+          order.push('c')
+          extensions.registerElement('mip-c', class extends CustomElement {})
+          resolve()
+        }
+      })
+    })
+
+    expect(order).to.deep.equal(['a', 'b', 'c'])
+  })
+
   it('should register template in registration', () => {
     const implementation = templates.inheritTemplate()
     implementation.prototype.cache = html => html


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）
**背景：**
mip1 的 zepto.js 是打包到核心js里的，require 是同步返回模块，而 mip2 的zepto 是分离异步加载的，require是异步返回的，导致依赖了zepto 的mip1组件在 mip1 和 mip2 registerElement 执行时机不一致。

如： 
mip-cambrian.js
```js
(window.MIP = window.MIP || []).push({
    name: "mip-cambrian",
    func: function() {
        define("mip-cambrian/mip-cambrian", ["require", "customElement", "zepto", "viewer"], function(e) {
            var t = e("customElement").create()
              , n = e("zepto")
              , i = e("viewer")
              , a = !1;
            return t.prototype.build = function() {
                // omit...
            }, t
        }),
        define("mip-cambrian", ["mip-cambrian/mip-cambrian"], function(e) {
            return e
        }),
        function() {
            function e(e, t) {
                e.registerMipElement("mip-cambrian", t)
            }
            if (window.MIP)
                require(["mip-cambrian"], function(t) {
                    e(window.MIP, t)
                });
            else
                require(["mip", "mip-cambrian"], e)
        }()
    }
});
```
由于 mip-cambrian.js 依赖了 zepto，在mip1下，由于zepto在核心里已经define，所以根据 amd 的规范，直接同步返回zepto 实例，然后同步执行 `e.registerMipElement("mip-cambrian", t)`。而在 mip2 下，zepto 没有打包在 mip2 核心里，根据 amd 规范，模块管理器会先先去异步加载 zepto 模块，直到依赖的模块全部加载好才会执行 require 后的回调，而 `e.registerMipElement("mip-cambrian", t)` 是在回调里的。

**解决方案：**
- 思路：
改写 MIP.push 的实现，把 push 传入的 extensions 先放到一个队列里，然后执行队列里第一个extension 的 func，并设置一个标记 `waitingRegisterElement=true` , 在执行 执行 registerElement 时将 标记设置为 `waitingRegisterElement=false` ，如果没有异步模块，代码会同步执行 registerElement，并把标记设置回 false，接着继续执行下一个extensions, 如果有异步模块，waitingRegisterElement 没有被设置为 false，循环跳出，等待 registerElement 执行，一旦 registerElement 执行，将会重新触发执行队列里的组件。

- 可能存在的问题
mip2 组件存在一个 extension 里存在多个组件的情况，如： [mip-tabs](https://github.com/mipengine/mip2-extensions/tree/master/components/mip-tabs) 这里假定，两个组件在执行时是同步的。这里的同步是指，两个 registerElement 是顺序执行的。

所有的组件都是规范的，通过如下的包装
```
(window.MIP = window.MIP || []).push({
    name: "mip-cambrian",
    func: function() {
```
**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
