### PR TITLE
change hide to mip-hide

### DIFF
--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -603,7 +603,7 @@ class MIPCarousel extends CustomElement {
         }
       } else {
         // 若个数不匹配，则隐藏掉indicator
-        addClass(indicDom, 'hide')
+        addClass(indicDom, 'mip-hide')
         dotItems = []
       }
     }

--- a/packages/mip/src/components/mip-shell/switchPage.js
+++ b/packages/mip/src/components/mip-shell/switchPage.js
@@ -332,7 +332,7 @@ function backwardTransition (shell, options) {
   // If source page is root page, skip transition
   if (!iframe) {
     document.documentElement.classList.add('mip-no-scroll')
-    window.MIP.viewer.page.getElementsInRootPage().forEach(e => e.classList.add('hide'))
+    window.MIP.viewer.page.getElementsInRootPage().forEach(e => e.classList.add('mip-hide'))
 
     onComplete && onComplete()
     shell.afterSwitchPage(options)
@@ -447,7 +447,6 @@ function skipTransition (shell, options) {
   skipTransitionAndCreate(shell, options)
 }
 
-
 /**
  * Disable scrolling of root page when covered by an iframe
  * NOTE: it doesn't work in iOS, see `_lockBodyScroll()` in viewer.js
@@ -456,11 +455,11 @@ function fixRootPageScroll (shell, {sourcePageId, targetPageId} = {}) {
   let page = window.MIP.viewer.page
   if (sourcePageId === page.pageId) {
     document.documentElement.classList.add('mip-no-scroll')
-    page.getElementsInRootPage().forEach(e => e.classList.add('hide'))
+    page.getElementsInRootPage().forEach(e => e.classList.add('mip-hide'))
   }
   if (targetPageId === page.pageId) {
     document.documentElement.classList.remove('mip-no-scroll')
-    page.getElementsInRootPage().forEach(e => e.classList.remove('hide'))
+    page.getElementsInRootPage().forEach(e => e.classList.remove('mip-hide'))
     shell.restoreScrollPosition()
   }
 }

--- a/packages/mip/src/styles/mip-base.less
+++ b/packages/mip/src/styles/mip-base.less
@@ -187,7 +187,7 @@ mip-i-space {
   overflow: hidden;
 }
 
-.hide {
+.mip-hide {
   display: none !important;
 }
 

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -443,7 +443,7 @@ describe('mip-carousel', function () {
 
     it('should be not ok with wrong indicator', async function () {
       let indicatorDom = divWrong.querySelector('#mip-carousel-example2')
-      expect(indicatorDom.classList.contains('hide')).to.be.true
+      expect(indicatorDom.classList.contains('mip-hide')).to.be.true
       expect(window.getComputedStyle(indicatorDom, null).display).to.include('none')
     })
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#436

**1、升级点** （清晰准确的描述升级的功能点）
由于mip1有组件使用到 hide class，导致了元素被强制隐藏的bug，因此修改hide为mip-hide，添加mip前缀，这样就不容易产生冲突与误用

**2、影响范围** （描述该需求上线会影响什么功能）
所有使用到 hide class的组件，目前已知包括核心的mip-carousel和mip-shell、mip1第三方组件mip-header-qiehuan，修改后显示正常

**3、自测 Checklist**
相关mip2站点

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
