### PR TITLE
修复 MIP1 升级页面切换页面时标题不变化的问题

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -48,6 +48,7 @@ let isHeaderShown = false
 
 window.MIP_PAGE_META_CACHE = Object.create(null)
 window.MIP_SHELL_CONFIG = null
+window.MIP_SHELL_ROUTES_AUTO_GENERATED = false
 
 class MipShell extends CustomElement {
   // ===================== CustomElement LifeCycle =====================
@@ -94,6 +95,7 @@ class MipShell extends CustomElement {
             pattern: '*',
             meta: DEFAULT_SHELL_CONFIG
           }]
+          window.MIP_SHELL_ROUTES_AUTO_GENERATED = true
         }
       } catch (e) {
         !this.ignoreWarning && console.warn('检测到格式非法的 MIP Shell 配置，MIP 将使用默认的配置代替。')
@@ -103,6 +105,7 @@ class MipShell extends CustomElement {
             meta: DEFAULT_SHELL_CONFIG
           }]
         }
+        window.MIP_SHELL_ROUTES_AUTO_GENERATED = true
       }
     } else {
       !this.ignoreWarning && console.warn('没有检测到 MIP Shell 配置，MIP 将使用默认的配置代替。')
@@ -112,6 +115,7 @@ class MipShell extends CustomElement {
           meta: DEFAULT_SHELL_CONFIG
         }]
       }
+      window.MIP_SHELL_ROUTES_AUTO_GENERATED = true
     }
 
     if (page.isRootPage) {
@@ -190,6 +194,9 @@ class MipShell extends CustomElement {
 
       if (!pageMeta) {
         pageMeta = this.findMetaByPageId(pageId)
+      }
+      if (window.parent.MIP_SHELL_ROUTES_AUTO_GENERATED) {
+        window.parent.document.title = pageMeta.header.title = (document.querySelector('title') || {}).innerHTML || ''
       }
 
       page.emitCustomEvent(window.parent, page.isCrossOrigin, {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#437 
**1、升级点** （清晰准确的描述升级的功能点）
修复 MIP1 升级页面切换页面时标题不变化的问题
**2、影响范围** （描述该需求上线会影响什么功能）
自动生成 `<mip-shell>` 标签时，会读取目标 `<title>` 的值作为标题。
已有 `<mip-shell>` 或者子类标签时不影响（如小说）
**3、自测 Checklist**
使用代理的方式
测试问题站点 [http://m.9978.tv](http://m.9978.tv)，切换页面后标题可以变化
测试小说页面，和线上效果一致
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [x] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
