### PR TITLE
fix: hide loading in mip1 site

### DIFF
--- a/packages/mip/src/components/mip-fixed.js
+++ b/packages/mip/src/components/mip-fixed.js
@@ -10,6 +10,12 @@ class MipFixed extends CustomElement {
     const viewer = window.MIP.viewer
     const platform = window.MIP.util.platform
 
+    // Hack: mip1 站点强制重写 mip-layout-container display，导致无法隐藏 loading
+    // 针对 mip-fixed 先把 mip-layout-container 去掉，这个不会对现有样式造成影响
+    // TODO: 1. 考虑针对 mip-fixed 统一不使用 layout 处理 2. 推动下游去掉这个 class 的重写
+    // 站点 http://mip.cntrades.com/15995352952/sell/itemid-170607633.html
+    this.element.classList.remove('mip-layout-container')
+
     if (this.element.getAttribute('mipdata-fixedidx')) {
       return
     }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
**问题：**
MIP1站点重写 mip-layout-container 导致 MIP2 替换 MIP1 后无法隐藏 loading，
> 之前针对 mip-fixed display none 改为 mip-fixed display: none!important 在 ios9以下手机有兼容性问题，无法解决

站点 http://mip.cntrades.com/15995352952/sell/itemid-170607633.html

**方案：**
针对 mip-fixed 先把 mip-layout-container 去掉，这个不会对现有样式造成影响

**1、升级点** （清晰准确的描述升级的功能点）

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
