### PR TITLE
【免测】在sf环境下隐藏position: fixed元素

### DIFF
--- a/packages/mip/src/fixed-element.js
+++ b/packages/mip/src/fixed-element.js
@@ -267,7 +267,7 @@ class FixedElement {
                 // elements[j].parentElement.removeChild(elements[j])
                 let ele = elements[j]
                 ele.style.cssText = 'display: none!important'
-                console.warn(`Can not use "position: fixed" in ${ele.tagName}!`)
+                console.warn(ele, '请使用 mip-fixed 组件代替')
               }
             }
           } catch (e) {

--- a/packages/mip/src/fixed-element.js
+++ b/packages/mip/src/fixed-element.js
@@ -267,7 +267,7 @@ class FixedElement {
                 // elements[j].parentElement.removeChild(elements[j])
                 let ele = elements[j]
                 ele.style.cssText = 'display: none!important'
-                console.warn(ele, '请使用 mip-fixed 组件代替')
+                console.warn(ele, '发现 position: fixed 样式, 请使用 mip-fixed 组件代替')
               }
             }
           } catch (e) {

--- a/packages/mip/src/fixed-element.js
+++ b/packages/mip/src/fixed-element.js
@@ -77,7 +77,7 @@ class FixedElement {
       }
     }
     /* istanbul ignore if */
-    if (isIframed) {
+    if (!window.MIP.standalone) {
       this.doCustomElements()
     }
   }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#442 

**1、升级点** （清晰准确的描述升级的功能点）
保持与mip1逻辑一致，在sf环境下隐藏position: fixed元素，而在原始页中可以显示position: fixed元素

**2、影响范围** （描述该需求上线会影响什么功能）
使用了position: fixed的站点，原来在独立站被隐藏的position: fixed元素现在可以显示了

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
