### PR TITLE
fix: Controls video when page is switching

### DIFF
--- a/packages/mip/examples/builtin-components/mip-video.html
+++ b/packages/mip/examples/builtin-components/mip-video.html
@@ -200,8 +200,8 @@
 
     @font-face {
       font-family: iconfont;
-      src: url(/static/fonts/fontawesome-webfont.eot?v=4.7.0);
-      src: url(/static/fonts/fontawesome-webfont.eot?#iefix&v=4.7.0) format("embedded-opentype"), url(/static/fonts/fontawesome-webfont.woff2?v=4.7.0) format("woff2"), url(/static/fonts/fontawesome-webfont.woff?v=4.7.0) format("woff"), url(/static/fonts/fontawesome-webfont.ttf?v=4.7.0) format("truetype"), url(/static/fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular) format("svg")
+      src: url(/examples/static/fonts/fontawesome-webfont.eot?v=4.7.0);
+      src: url(/examples/static/fonts/fontawesome-webfont.eot?#iefix&v=4.7.0) format("embedded-opentype"), url(/examples/static/fonts/fontawesome-webfont.woff2?v=4.7.0) format("woff2"), url(/examples/static/fonts/fontawesome-webfont.woff?v=4.7.0) format("woff"), url(/examples/static/fonts/fontawesome-webfont.ttf?v=4.7.0) format("truetype"), url(/examples/static/fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular) format("svg")
     }
 
     .fa {
@@ -297,7 +297,7 @@
       white-space: nowrap;
       font-size: 0;
       cursor: pointer;
-      background: url(/static/img/mip_logo_white_8c902ec.png);
+      background: url(/examples/static/img/mip_logo_white_8c902ec.png);
       -webkit-background-size: 100% 100%;
       -moz-background-size: 100% 100%;
       background-size: 100% 100%
@@ -1233,7 +1233,7 @@
       width: 351.7px;
       height: 723.1px;
       margin: 10px auto;
-      background-image: url(/static/img/iphone@2x_463a1e2.png);
+      background-image: url(/examples/static/img/iphone@2x_463a1e2.png);
       background-repeat: no-repeat;
       background-size: 100%
     }

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -7,7 +7,7 @@
 import util from '../util/index'
 import viewer from '../viewer'
 import CustomElement from '../custom-element'
-import {CUSTOM_EVENT_SHOW_PAGE, CUSTOM_EVENT_HIDE_PAGE} from '../page/const'
+import {CUSTOM_EVENT_SHOW_PAGE, CUSTOM_EVENT_HIDE_PAGE} from '../page/const/index'
 
 let videoAttributes = [
   'ads',

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -9,8 +9,6 @@ import viewer from '../viewer'
 import CustomElement from '../custom-element'
 import {CUSTOM_EVENT_SHOW_PAGE, CUSTOM_EVENT_HIDE_PAGE} from '../page/const'
 
-let windowInIframe = viewer.isIframed
-
 let videoAttributes = [
   'ads',
   'src',
@@ -50,64 +48,31 @@ function getAttributeSet (attributes) {
 class MipVideo extends CustomElement {
   layoutCallback () {
     this.attributes = getAttributeSet(this.element.attributes)
-    this.sourceDoms = this.element.querySelectorAll('source')
-    this.src = this.attributes.src
+    this.sourceDoms = [...this.element.querySelectorAll('source')]
 
-    // if window is https
-    let windowProHttps = !!window.location.protocol.match(/^https:/)
-    // if video source is https
-    let sourceIsHttps = true
-    if (!this.sourceDoms.length) {
-      sourceIsHttps = false
-    }
-    Array.prototype.slice.apply(this.sourceDoms).forEach(function (node) {
-      if (!node.src.match(/^https:|^\/\//)) {
-        sourceIsHttps = false
-      }
-    })
-    let videoProHttps = (this.src && this.src.match(/^https:|^\/\//)) ||
-                            (this.sourceDoms && sourceIsHttps)
+    const videoElement = this.renderVideo()
 
-    // page ishttps         + video is https    = renderInView
-    // page ishttps(in iframe) + video is http    = renderPlayElsewhere
-    // page ishttps(else)   + video is http     = renderInView（not mip）
-    // page ishttp          + random video      = renderInView
-    // page not iframe || video src is https ||  video http + page http
-    /* istanbul ignore else */
-    if (!windowInIframe || videoProHttps ||
-    /* istanbul ignore next */ (windowInIframe && !videoProHttps && !windowProHttps)
-    ) {
-      this.videoElement = this.renderInView()
-    } else {
-      // 再细分为 iframe 外层页面是否为百度搜索结果页，如果是就 renderPlayElsewhere，否则就 renderError
-      // 考虑安全性，renderPlayElsewhere 可以在其他地方来打开视频，而renderError 则是直接显示X，不建议播放
-      if (!window.MIP.standalone) {
-        this.videoElement = this.renderPlayElsewhere()
-      } else {
-        this.videoElement = this.renderError()
-      }
-    }
     window.addEventListener(CUSTOM_EVENT_SHOW_PAGE, () => {
-      this.videoElement.load && this.videoElement.load()
+      videoElement.load && videoElement.load()
     })
     window.addEventListener(CUSTOM_EVENT_HIDE_PAGE, () => {
-      this.videoElement.pause && this.videoElement.pause()
+      videoElement.pause && videoElement.pause()
     })
     this.addEventAction('seekTo', (e, currentTime) => {
-      this.videoElement.currentTime = currentTime
+      videoElement.currentTime = currentTime
     })
     this.addEventAction('play', () => {
       // renderPlayElsewhere 的 videoElement 是 div，没有 play
       /* istanbul ignore next */
-      this.videoElement.play && this.videoElement.play()
+      videoElement.play && videoElement.play()
     })
     this.addEventAction('pause', () => {
       // renderPlayElsewhere 的 videoElement 是 div，没有 pause
       /* istanbul ignore next */
-      this.videoElement.pause && this.videoElement.pause()
+      videoElement.pause && videoElement.pause()
     })
 
-    this.applyFillContent(this.videoElement, true)
+    this.applyFillContent(videoElement, true)
     return Promise.resolve()
   }
 
@@ -119,7 +84,7 @@ class MipVideo extends CustomElement {
         videoEl.setAttribute(k, this.attributes[k])
       }
     }
-    let currentTime = this.attributes['currenttime']
+    let currentTime = this.attributes.currenttime
     videoEl.setAttribute('playsinline', 'playsinline')
     // 兼容qq浏览器
     videoEl.setAttribute('x5-playsinline', 'x5-playsinline')
@@ -174,12 +139,7 @@ class MipVideo extends CustomElement {
     videoEl.addEventListener('click', sendVideoMessage, false)
 
     // make sourceList, send to outer iframe
-    let sourceList = []
-    Array.prototype.slice.apply(this.sourceDoms).forEach(function (node) {
-      let obj = {}
-      obj[node.type] = node.src
-      sourceList.push(obj)
-    })
+    let sourceList = this.sourceDoms.map(({type, src}) => ({[type]: src}))
 
     if (!sourceList.length) {
       urlSrc = videoEl.dataset.videoSrc
@@ -189,7 +149,7 @@ class MipVideo extends CustomElement {
 
     function sendVideoMessage () {
       /* istanbul ignore if */
-      if (windowInIframe) {
+      if (viewer.isIframed) {
         // mip_video_jump is written outside iframe
         // TODO 改成 OUTER_MESSAGE_VIDEO_JUMP
         viewer.sendMessage('mip-video-jump', {
@@ -200,6 +160,30 @@ class MipVideo extends CustomElement {
     }
     this.element.appendChild(videoEl)
     return videoEl
+  }
+
+  renderVideo () {
+    const src = this.attributes.src
+    const sources = this.sourceDoms
+    const isHttps = src => /^https:|^\/\//.test(src)
+
+    const isPageHttps = isHttps(window.location.protocol)
+    const isSourcesHttps = sources.length && sources.every(node => isHttps(node.src))
+    const isVideoHttps = isHttps(src) || isSourcesHttps
+    // page ishttps         + video is https    = renderInView
+    // page ishttps(in iframe) + video is http    = renderPlayElsewhere
+    // page ishttps(else)   + video is http     = renderInView（not mip）
+    // page ishttp          + random video      = renderInView
+    /* istanbul ignore else */
+    if (!(viewer.isIframed && !isVideoHttps && isPageHttps)) {
+      return this.renderInView()
+    }
+    // 再细分为 iframe 外层页面是否为百度搜索结果页，如果是就 renderPlayElsewhere，否则就 renderError
+    // 考虑安全性，renderPlayElsewhere 可以在其他地方来打开视频，而renderError 则是直接显示X，不建议播放
+    if (window.MIP.standalone) {
+      return this.renderError()
+    }
+    return this.renderPlayElsewhere()
   }
 }
 

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -50,10 +50,12 @@ class MipVideo extends CustomElement {
     this.attributes = getAttributeSet(this.element.attributes)
     this.sourceDoms = [...this.element.querySelectorAll('source')]
 
-    const videoElement = this.renderVideo()
+    let videoElement = this.renderVideo()
 
     window.addEventListener(CUSTOM_EVENT_SHOW_PAGE, () => {
-      videoElement.load && videoElement.load()
+      videoElement.parentElement.removeChild(videoElement)
+      videoElement = this.renderVideo()
+      this.applyFillContent(videoElement, true)
     })
     window.addEventListener(CUSTOM_EVENT_HIDE_PAGE, () => {
       videoElement.pause && videoElement.pause()
@@ -78,6 +80,7 @@ class MipVideo extends CustomElement {
 
   // Render the `<video>` element, and append to `this.element`
   renderInView () {
+    console.log('view')
     let videoEl = document.createElement('video')
     for (let k in this.attributes) {
       if (this.attributes.hasOwnProperty(k) && videoAttributes.indexOf(k) > -1) {
@@ -108,6 +111,7 @@ class MipVideo extends CustomElement {
   }
   // 混合内容警告：出于安全因素的考虑，不予播放，显示一个 X
   renderError () {
+    console.log('error')
     let videoEl = document.createElement('div')
     videoEl.setAttribute('class', 'mip-video-poster')
     if (this.attributes.poster) {
@@ -123,6 +127,7 @@ class MipVideo extends CustomElement {
   }
   // Render the `<div>` element with poster and play btn, and append to `this.element`
   renderPlayElsewhere () {
+    console.log('else')
     let videoEl = document.createElement('div')
     let urlSrc
     videoEl.setAttribute('class', 'mip-video-poster')

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -7,7 +7,7 @@
 import util from '../util/index'
 import viewer from '../viewer'
 import CustomElement from '../custom-element'
-// import {OUTER_MESSAGE_CHANGE_STATE} from '../page/const/index'
+import {CUSTOM_EVENT_SHOW_PAGE, CUSTOM_EVENT_HIDE_PAGE} from '../page/const'
 
 let windowInIframe = viewer.isIframed
 
@@ -87,7 +87,12 @@ class MipVideo extends CustomElement {
         this.videoElement = this.renderError()
       }
     }
-
+    window.addEventListener(CUSTOM_EVENT_SHOW_PAGE, () => {
+      this.videoElement.load && this.videoElement.load()
+    })
+    window.addEventListener(CUSTOM_EVENT_HIDE_PAGE, () => {
+      this.videoElement.pause && this.videoElement.pause()
+    })
     this.addEventAction('seekTo', (e, currentTime) => {
       this.videoElement.currentTime = currentTime
     })

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -46,7 +46,6 @@ let viewer = {
      * The initialise method of viewer
      */
   init () {
-
     /**
      * SF 创建的第一个页面的 window.name
      */
@@ -97,7 +96,6 @@ let viewer = {
 
     // proxy <a mip-link>
     setTimeout(() => this._proxyLink(this.page), 0)
-
   },
 
   /**
@@ -367,11 +365,11 @@ let viewer = {
         self.open(to, {isMipLink, replace, state, cacheFirst})
       } else {
         if (isMipLink) {
-          let message = self._getMessageData.call(this);
-          self.sendMessage(message.messageKey, message.messageData);
+          let message = self._getMessageData.call(this)
+          self.sendMessage(message.messageKey, message.messageData)
         } else {
           // other jump through '_top'
-          top.location.href = this.href;
+          top.location.href = this.href
         }
       }
 

--- a/packages/mip/test/specs/components/mip-video.spec.js
+++ b/packages/mip/test/specs/components/mip-video.spec.js
@@ -183,7 +183,7 @@ describe('mip-video', function () {
       let _mipVideo = new MipVideo()
       _mipVideo.attributes = getAttributeSet(div.attributes)
       _mipVideo.element = document.body
-      _mipVideo.sourceDoms = mipVideo.querySelectorAll('source')
+      _mipVideo.sourceDoms = [...mipVideo.querySelectorAll('source')]
       let videoEl = _mipVideo.renderPlayElsewhere()
 
       expect(videoEl.tagName).to.equal('DIV')


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/448

**1、升级点** 
 1. 视频播放时，通过链接打开新的 MIP 页面时（iframe），暂停视频播放
 2. 当通过 cache-first 链接跳回原页面时，重置视频状态到开头

**2、影响范围** （描述该需求上线会影响什么功能）
 - 所有使用 mip-video 的站点

**3、自测 Checklist**
 1. 暂停视频播放
   - video 页面 (rootPage) -> 其他页面 (iframe) -> video 页面 (iframe)
   - video 页面 (iframe) -> 其他页面 (iframe) -> video 页面 (iframe)
 2. 重置视频状态
   - video 页面 (iframe) -> 其他页面 (iframe) --(cache-first)-> video 页面 (iframe)
   - video 页面 (iframe) -> 其他页面 (iframe) --后退-> video 页面 (iframe)

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
