### PR TITLE
修改 helper 插入组件 css 的位置

### DIFF
--- a/packages/mip/deps/mip-components-webpack-helpers.js
+++ b/packages/mip/deps/mip-components-webpack-helpers.js
@@ -4079,11 +4079,14 @@ function addStylesToDom (styles /* Array<StyleObject> */) {
   }
 }
 
+var mipCssLink = head.querySelector('link[rel=stylesheet][href*="/mip.css"]');
+var mipCssLinkNext = mipCssLink && mipCssLink.nextSibling;
+
 function createStyleElement () {
   var styleElement = document.createElement('style');
   styleElement.type = 'text/css';
   // head.appendChild(styleElement)
-  head.insertBefore(styleElement, head.firstChild);
+  head.insertBefore(styleElement, mipCssLinkNext || head.firstChild);
   return styleElement
 }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#491 
**1、升级点** （清晰准确的描述升级的功能点）
1. 组件 css 插入位置从 insertBefore(style, head.firstChild) 改成 insertBefore(style, cssLinkNext || head.firstChild)
**2、影响范围** （描述该需求上线会影响什么功能）
1. mip-shell-xiaoshuo 等会覆盖 mip.css 样式的组件
**3、自测 Checklist**
1. 线上小说样式正常
**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
