### PR TITLE
feat: deprecate CustomElement v0

### DIFF
--- a/packages/mip/src/mip1-polyfill/element.js
+++ b/packages/mip/src/mip1-polyfill/element.js
@@ -239,9 +239,13 @@ function registerElement (name, elementClass, css) {
   }
 
   loadCss(css, name)
-  document.registerElement(name, {
-    prototype: mipElementProto
-  })
+  if (window.customElements) {
+    window.customElements.define(name, mipElementProto)
+  } else {
+    document.registerElement(name, {
+      prototype: mipElementProto
+    })
+  }
 
   return customElementInstances
 }


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/415

**1、升级点**
 - mip1Polyfill 优先使用 `window.customElements.define`

**2、影响范围** 
 - 所有含 mip1 组件的页面，可能需要回归头部站点
 - 功能期望无影响

**3、自测 Checklist**
 - 元尊
 - 美食天下

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
