### PR TITLE
feat: 允许独立站禁用 mip-shell

### DIFF
--- a/packages/mip/src/components/index.js
+++ b/packages/mip/src/components/index.js
@@ -17,6 +17,7 @@ import MipShell from './mip-shell/index'
 import MipFixed from './mip-fixed/index'
 import MipLayout from './mip-layout'
 import registerElement from '../register-element'
+import {isMIPShellDisabled} from '../page/util/dom'
 
 export default {
 
@@ -34,6 +35,6 @@ export default {
     registerElement('mip-fixed', MipFixed)
     new MipBind()
     registerElement('mip-data', MipData)
-    registerElement('mip-shell', MipShell)
+    isMIPShellDisabled() || registerElement('mip-shell', MipShell)
   }
 }

--- a/packages/mip/src/page/util/dom.js
+++ b/packages/mip/src/page/util/dom.js
@@ -328,6 +328,15 @@ export function ensureMIPShell () {
   }
 }
 
+/**
+ * Returns whether mip-shell needs to be disabled.
+ *
+ * @returns {boolean}
+ */
+export function isMIPShellDisabled () {
+  return !!(window.MIP.standalone && document.querySelector('mip-shell[disabled]'))
+}
+
 export function nextFrame (fn) {
   raf(() => {
     raf(fn)

--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -13,7 +13,6 @@ import EventAction from './util/event-action'
 import EventEmitter from './util/event-emitter'
 import {fn, makeCacheUrl, parseCacheUrl} from './util'
 import {supportsPassive} from './page/util/feature-detect'
-import {resolvePath} from './page/util/path'
 import viewport from './viewport'
 import Page from './page/index'
 import {
@@ -22,6 +21,8 @@ import {
   OUTER_MESSAGE_PUSH_STATE,
   OUTER_MESSAGE_REPLACE_STATE
 } from './page/const'
+import {isMIPShellDisabled} from './page/util/dom'
+import {resolvePath} from './page/util/path'
 import Messager from './messager'
 import fixedElement from './fixed-element'
 import clientPrerender from './client-prerender'
@@ -205,9 +206,9 @@ let viewer = {
     }
 
     // Jump in top window directly
-    // 1. Cross origin and NOT in SF
+    // 1. ( Cross origin or MIP Shell is disabled ) and NOT in SF
     // 2. Not MIP page and not only hash change
-    if ((this._isCrossOrigin(to) && window.MIP.standalone) ||
+    if (((this._isCrossOrigin(to) || isMIPShellDisabled()) && window.MIP.standalone) ||
       (!isMipLink && !isHashInCurrentPage)) {
       if (replace) {
         window.top.location.replace(to)


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** 
 - 允许独立站通过 `<mip-shell disabled></mip-shell>` 禁用 `mip-shell`

**2、影响范围** （描述该需求上线会影响什么功能）
 - 无影响

**3、自测 Checklist**
 - https://mip.64365.com 禁用功能生效
 - 搜索结果页无影响

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
