### PR TITLE
[免测]build 异常处理，便于编译脚本捕获异常

### DIFF
--- a/packages/mip-cli/CHANGELOG.md
+++ b/packages/mip-cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- 1.5.4
+    1. build 异常时，中断程序，便于外部脚本捕获错误
+
 - 1.5.3
     1. 锁死 webpack-dev-middleware 版本至 3.6.0
 

--- a/packages/mip-cli/bin/mip2-build
+++ b/packages/mip-cli/bin/mip2-build
@@ -51,6 +51,9 @@ if (conf.ignore === true) {
 }
 
 build(conf)
+.catch(() => {
+  process.exit(1)
+})
 
 // 白名单校验没必要阻塞 dev 启动
 if (!conf.ignore || !/(^|,)whitelist(,|$)/.test(conf.ignore)) {

--- a/packages/mip-cli/package-lock.json
+++ b/packages/mip-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）

在 mip-cli build 出错时，中断 node 进程，编译脚本能捕获错误

**2、影响范围** （描述该需求上线会影响什么功能）

mip-cli 编译异常的情况

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
