### PR TITLE
【免测】修复 mip-custom 动态引入的组件中包含 mip-img 会导致图片的 src 被错误修改成 mip cache url 的问题

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -12,7 +12,7 @@ import CustomElement from '../custom-element'
 import viewport from '../viewport'
 import viewer from '../viewer'
 
-const {css, rect, event, naboo, makeCacheUrl} = util
+const {css, rect, event, naboo} = util
 
 // 取值根据 https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement
 let imgAttributes = [
@@ -329,20 +329,7 @@ class MipImg extends CustomElement {
     this.attributes = getAttributeSet(this.element.attributes)
     for (let k in this.attributes) {
       if (this.attributes.hasOwnProperty(k) && imgAttributes.indexOf(k) > -1) {
-        if (k === 'src') {
-          // src attribute needs to be mip-cached
-          let imgsrc = makeCacheUrl(this.attributes.src, 'img')
-          img.setAttribute(k, imgsrc)
-        } else if (k === 'srcset') {
-          let imgSrcset = this.attributes.srcset
-          let reg = /[\w-/]+\.(jpg|jpeg|png|gif|webp|bmp|tiff) /g
-          let srcArr = imgSrcset.replace(reg, function (url) {
-            return makeCacheUrl(url, 'img')
-          })
-          img.setAttribute('srcset', srcArr)
-        } else {
-          img.setAttribute(k, this.attributes[k])
-        }
+        img.setAttribute(k, this.attributes[k])
       }
     }
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#573 

**1、升级点** （清晰准确的描述升级的功能点）
- 去除 mip-img 中用 js 修改 img src 指向 mip cache url 的逻辑

**2、影响范围** （描述该需求上线会影响什么功能）
- mip-img 组件

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
