### PR TITLE
feat: Call the corresponding handlers when attributes changed

### DIFF
--- a/packages/mip/build/config.js
+++ b/packages/mip/build/config.js
@@ -23,7 +23,7 @@ const resolve = p => {
 }
 
 const builds = {
-  'mip-prod': {
+  'mip': {
     entry: resolve('mip'),
     dest: resolve('dist/mip.js'),
     format: 'umd',

--- a/packages/mip/src/base-element.js
+++ b/packages/mip/src/base-element.js
@@ -329,7 +329,7 @@ class BaseElement extends HTMLElement {
     } catch (e) {
       this.error = e
       customEmit(this, 'build-error', e)
-      console.warn('build error:', e)
+      console.error(e)
     }
   }
 

--- a/packages/mip/src/base-element.js
+++ b/packages/mip/src/base-element.js
@@ -132,7 +132,7 @@ class BaseElement extends HTMLElement {
   attributeChangedCallback (name, oldValue, newValue) {
     const propName = camelize(name)
 
-    if (hasOwn(this.propTypes, propName) && oldValue !== newValue) {
+    if (this.isBuilt() && hasOwn(this.propTypes, propName) && oldValue !== newValue) {
       const prevProps = this.customElement.props[propName]
       const nextProps = this.vueCompat.parseAttribute(newValue, this.propTypes[propName])
       const handler = `handle${capitalize(propName)}Change`

--- a/packages/mip/src/base-element.js
+++ b/packages/mip/src/base-element.js
@@ -9,7 +9,7 @@ import {hasOwn} from './util'
 import {customEmit} from './util/custom-event'
 import dom from './util/dom/dom'
 import css from './util/dom/css'
-import {camelize} from './util/string'
+import {camelize, capitalize} from './util/string'
 import {parseSizeList} from './size-list'
 
 /** @param {!Element} element */
@@ -104,7 +104,7 @@ class BaseElement extends HTMLElement {
 
     this.propTypes = this.vueCompat.getPropTypes(this.name, CustomElementImpl)
 
-    this.defaultValues = this.vueCompat.getDefaultValues(this.name, CustomElementImpl)
+    this.defaultProps = this.vueCompat.getDefaultProps(this.name, CustomElementImpl)
 
     this.customElement.props = {}
 
@@ -130,8 +130,18 @@ class BaseElement extends HTMLElement {
   }
 
   attributeChangedCallback (name, oldValue, newValue) {
-    const propName = camelize(name)
-    this.customElement.props[propName] = this.vueCompat.parseAttribute(newValue, this.propTypes[propName])
+    if (oldValue !== newValue) {
+      const propName = camelize(name)
+      const prevProps = this.customElement.props[propName]
+      const nextProps = this.vueCompat.parseAttribute(newValue, this.propTypes[propName])
+      const handler = `handle${capitalize(propName)}Change`
+
+      this.customElement.props[propName] = nextProps
+      if (typeof this.customElement[handler] === 'function' &&
+        !(oldValue === null && nextProps === this.defaultProps[propName])) {
+        this.customElement[handler](prevProps, nextProps)
+      }
+    }
     this.customElement.attributeChangedCallback(name, oldValue, newValue)
   }
 
@@ -332,18 +342,18 @@ class BaseElement extends HTMLElement {
    */
   getProps () {
     const propTypes = this.propTypes
-    const defaultValues = this.defaultValues
+    const defaultProps = this.defaultProps
     const props = this.vueCompat.getProps(this, propTypes)
     const names = Object.keys(propTypes)
 
     for (let i = 0; i < names.length; i++) {
       const name = names[i]
 
-      if (typeof props[name] !== 'undefined' || !hasOwn(defaultValues, name)) {
+      if (typeof props[name] !== 'undefined' || !hasOwn(defaultProps, name)) {
         continue
       }
 
-      const def = defaultValues[name]
+      const def = defaultProps[name]
 
       props[name] = typeof def === 'function' ? def() : def
     }

--- a/packages/mip/src/base-element.js
+++ b/packages/mip/src/base-element.js
@@ -130,8 +130,9 @@ class BaseElement extends HTMLElement {
   }
 
   attributeChangedCallback (name, oldValue, newValue) {
-    if (oldValue !== newValue) {
-      const propName = camelize(name)
+    const propName = camelize(name)
+
+    if (hasOwn(this.propTypes, propName) && oldValue !== newValue) {
       const prevProps = this.customElement.props[propName]
       const nextProps = this.vueCompat.parseAttribute(newValue, this.propTypes[propName])
       const handler = `handle${capitalize(propName)}Change`

--- a/packages/mip/src/custom-element.js
+++ b/packages/mip/src/custom-element.js
@@ -78,8 +78,17 @@ class CustomElement {
 
   /**
    * Called when the MIPElement is first inserted into the document.
+   *
+   * @deprecated
    */
-  build () {}
+  build () {
+    this.buildCallback()
+  }
+
+  /**
+   * Executes after the element attached to DOM.
+   */
+  buildCallback () {}
 
   /**
    * Requests the element to unload any expensive resources when the element

--- a/packages/mip/src/mip1-polyfill/element.js
+++ b/packages/mip/src/mip1-polyfill/element.js
@@ -161,7 +161,7 @@ function createBaseElementProto () {
       customEmit(this, 'build')
     } catch (e) {
       customEmit(this, 'build-error', e)
-      console.warn('build error:', e)
+      console.error(e)
     }
   }
 

--- a/packages/mip/src/services/extensions.js
+++ b/packages/mip/src/services/extensions.js
@@ -10,6 +10,24 @@ const UNKNOWN_EXTENSION_ID = 'unknown'
 
 // const LATEST_MIP_VERSION = '2'
 
+/**
+ * Inserts a script element in `<head>` with specified url. Returns that script element.
+ *
+ * @param {string} url of script.
+ * @returns {!HTMLScriptElement}
+ * @private
+ */
+function insertScript (url) {
+  const script = document.createElement('script')
+
+  script.async = true
+  script.src = url
+
+  document.head.appendChild(script)
+
+  return script
+}
+
 export class Extensions {
   constructor () {
     /**
@@ -81,24 +99,6 @@ export class Extensions {
   }
 
   /**
-   * Inserts a script element in `<head>` with specified url. Returns that script element.
-   *
-   * @param {string} url of script.
-   * @returns {!HTMLScriptElement}
-   * @private
-   */
-  insertScript (url) {
-    const script = document.createElement('script')
-
-    script.async = true
-    script.src = url
-
-    document.head.appendChild(script)
-
-    return script
-  }
-
-  /**
    * Returns the script url of extension.
    *
    * @param {string} extensionId of extension.
@@ -151,7 +151,7 @@ export class Extensions {
       return
     }
 
-    holder.script = this.insertScript(this.getExtensionScriptUrl(extensionId, version))
+    holder.script = insertScript(this.getExtensionScriptUrl(extensionId, version))
   }
   */
 
@@ -258,7 +258,7 @@ export class Extensions {
         if (!document.querySelector('script[src*="mip-vue.js"]')) {
           const baseUrl = document.querySelector('script[src*="mip.js"]').src.replace(/\/[^/]+$/, '')
 
-          this.insertScript(`${baseUrl}/mip-vue.js`)
+          insertScript(`${baseUrl}/mip-vue.js`)
         }
 
         /**

--- a/packages/mip/src/services/vue-compat.js
+++ b/packages/mip/src/services/vue-compat.js
@@ -56,7 +56,7 @@ export class VueCompat {
 
   /**
    * Returns metadata computed from a definition of custom element or Vue component,
-   * which contains `propTypes` and `defaultValues`.
+   * which contains `propTypes` and `defaultProps`.
    *
    * @param {string} name of custom element.
    * @param {?Object} definition of custom element or Vue component.
@@ -66,7 +66,7 @@ export class VueCompat {
   getPropsMetadata (name, definition) {
     const metadata = {
       propTypes: {},
-      defaultValues: {}
+      defaultProps: {}
     }
 
     if (!name || !definition) {
@@ -100,7 +100,7 @@ export class VueCompat {
       metadata.propTypes[name] = this.getPropType(prop)
 
       if (prop && typeof prop === 'object' && hasOwn(prop, 'default')) {
-        metadata.defaultValues[name] = prop.default
+        metadata.defaultProps[name] = prop.default
       }
     }
 
@@ -119,14 +119,14 @@ export class VueCompat {
   }
 
   /**
-   * Returns default values of custom element or Vue component.
+   * Returns default props of custom element or Vue component.
    *
    * @param {string} name of custom element.
    * @param {?Object} definition of custom element.
    * @returns {!Object}
    */
-  getDefaultValues (name, definition) {
-    return this.getPropsMetadata(name, definition).defaultValues
+  getDefaultProps (name, definition) {
+    return this.getPropsMetadata(name, definition).defaultProps
   }
 
   /**

--- a/packages/mip/src/util/string.js
+++ b/packages/mip/src/util/string.js
@@ -4,4 +4,7 @@ import {memoize} from './fn'
 export const camelize = memoize(name => name.replace(/-[a-z]/g, s => s[1].toUpperCase()))
 
 /** @type {(name: string) => string} */
+export const capitalize = memoize(name => name.replace(/^[a-z]/, s => s.toUpperCase()))
+
+/** @type {(name: string) => string} */
 export const hyphenate = memoize(name => name.replace(/\B[A-Z]/g, s => `-${s.toLowerCase()}`))

--- a/packages/mip/src/vue-custom-element/index.js
+++ b/packages/mip/src/vue-custom-element/index.js
@@ -13,7 +13,7 @@ const {
   util: {string: {camelize, hyphenate}}
 } = window.MIP
 
-export class MIPVue {
+class MIPVue {
   constructor () {
     this.vueCompat = Services.vueCompat()
 
@@ -125,8 +125,4 @@ export class MIPVue {
   }
 }
 
-export function installMIPVueService () {
-  Services.registerService('mip-vue', MIPVue)
-}
-
-installMIPVueService()
+Services.registerService('mip-vue', MIPVue)

--- a/packages/mip/test/specs/base-element.spec.js
+++ b/packages/mip/test/specs/base-element.spec.js
@@ -63,7 +63,7 @@ describe('base-element', () => {
 
   it('should warn if lifecycle build throws an error', function (done) {
     let name = prefix + '-build-error'
-    let warn = sinon.stub(console, 'warn')
+    let warn = sinon.stub(console, 'error')
 
     registerElement(name, class extends CustomElement {
       build () {

--- a/packages/mip/test/specs/services/extensions.spec.js
+++ b/packages/mip/test/specs/services/extensions.spec.js
@@ -6,7 +6,6 @@ import CustomElement from 'src/custom-element'
 import customElement from 'src/mip1-polyfill/customElement'
 import templates from 'src/util/templates'
 import resources from 'src/resources'
-import {installMIPVueService} from 'src/vue-custom-element'
 
 describe('extensions', () => {
   /** @type {sinon.SinonSandbox} */
@@ -410,9 +409,11 @@ describe('extensions', () => {
     const css = 'mip-vue-custom{display:block}'
     const baseUrl = 'https://c.mipcdn.com/static/v2'
 
-    extensions.insertScript(`${baseUrl}/mip.js`)
+    const script = document.createElement('script')
 
-    extensions.insertScript = sandbox.spy()
+    script.src = `${baseUrl}/mip.js`
+    script.async = true
+    document.head.appendChild(script)
 
     extensions.registerExtension('mip-ext', () => {
       extensions.registerElement('mip-vue-custom', implementation, css)
@@ -436,7 +437,8 @@ describe('extensions', () => {
 
     document.body.appendChild(ele)
 
-    installMIPVueService()
+    delete require.cache[require.resolve('src/vue-custom-element')]
+    require('src/vue-custom-element')
 
     await Services.getServicePromise('mip-vue')
 

--- a/packages/mip/test/specs/services/vue-compat.spec.js
+++ b/packages/mip/test/specs/services/vue-compat.spec.js
@@ -149,13 +149,13 @@ describe('vue-compat', () => {
 
   describe('getDefaultValues', () => {
     it('should return an empty object if name or definition is not present', () => {
-      expect(vueCompat.getDefaultValues()).to.deep.equal({})
-      expect(vueCompat.getDefaultValues('', MIPCustom)).to.deep.equal({})
-      expect(vueCompat.getDefaultValues('mip-empty')).to.deep.equal({})
+      expect(vueCompat.getDefaultProps()).to.deep.equal({})
+      expect(vueCompat.getDefaultProps('', MIPCustom)).to.deep.equal({})
+      expect(vueCompat.getDefaultProps('mip-empty')).to.deep.equal({})
     })
 
     it('should return custom element default values', () => {
-      expect(vueCompat.getDefaultValues('mip-custom', MIPCustom)).to.deep.equal({
+      expect(vueCompat.getDefaultProps('mip-custom', MIPCustom)).to.deep.equal({
         bool: true,
         obj: defaultObj,
         mixed: 0
@@ -163,8 +163,8 @@ describe('vue-compat', () => {
     })
 
     it('should cache default values for the same elements', () => {
-      expect(vueCompat.getDefaultValues('mip-custom', MIPCustom))
-        .to.equal(vueCompat.getDefaultValues('mip-custom', MIPCustom))
+      expect(vueCompat.getDefaultProps('mip-custom', MIPCustom))
+        .to.equal(vueCompat.getDefaultProps('mip-custom', MIPCustom))
     })
   })
 

--- a/packages/mip/test/specs/util/string.spec.js
+++ b/packages/mip/test/specs/util/string.spec.js
@@ -1,10 +1,18 @@
-import {camelize, hyphenate} from 'src/util/string'
+import {camelize, capitalize, hyphenate} from 'src/util/string'
 
 describe('camelize', () => {
   it('should transform dash-case string to camelCase', () => {
     expect(camelize('foo')).to.equal('foo')
     expect(camelize('foo-bar')).to.equal('fooBar')
     expect(camelize('foo-bar-baz')).to.equal('fooBarBaz')
+  })
+})
+
+describe('capitalize', () => {
+  it('should transform camelCase string to PascalCase', () => {
+    expect(capitalize('foo')).to.equal('Foo')
+    expect(capitalize('fooBar')).to.equal('FooBar')
+    expect(capitalize('fooBarBaz')).to.equal('FooBarBaz')
   })
 })
 

--- a/packages/mip/test/specs/vue-custom-element/index.spec.js
+++ b/packages/mip/test/specs/vue-custom-element/index.spec.js
@@ -4,7 +4,6 @@
  */
 
 import Services from 'src/services'
-import {installMIPVueService} from 'src/vue-custom-element'
 import Vue from 'vue'
 
 let prefix = 'vue-custom-element-index-'
@@ -23,7 +22,8 @@ describe('vue custom element', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     window.services['mip-vue'] = null
-    installMIPVueService()
+    delete require.cache[require.resolve('src/vue-custom-element')]
+    require('src/vue-custom-element')
     vue = Services.getService('mip-vue')
   })
 


### PR DESCRIPTION
**相关 ISSUE:** https://github.com/mipengine/mip2/issues/584

**1、升级点** 
 - 在被监听的属性变更时，自动调用 `handle${propName}Change` 回调

**2、影响范围** 
 - 新功能，无影响

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
