### PR TITLE
mip-img 支持调起手百图片浏览器

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -257,12 +257,11 @@ function bindPopup (element, img) {
 
 /**
  * 点击图片调起手百图片浏览器
- * 协议link：http://wiki.baidu.com/pages/viewpage.action?pageId=686806027
  *
  * @param  {HTMLElement} img     mip-img下的img
  * @return {void}         无
  */
-function bindInvoke (img) {
+function bindInvocation (img) {
   img.addEventListener('click', () => {
     let url = 'baiduboxapp://v19/utils/previewImage?params=' + encodeURIComponent(JSON.stringify({urls: [img.src]}))
     let iframe = document.createElement('iframe')
@@ -359,7 +358,7 @@ class MipImg extends CustomElement {
     ele.appendChild(img)
     // 在手百中，点击非跳转图片应调起图片查看器
     if (platform.isBaiduApp() && !dom.closest(img, 'a')) {
-      bindInvoke(img)
+      bindInvocation(img)
     }
     else if (ele.hasAttribute('popup')) {
       bindPopup(ele, img)

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -262,7 +262,13 @@ function bindPopup (element, img) {
  * @return {void}         无
  */
 function bindInvocation (img) {
-  img.addEventListener('click', () => {
+  img.addEventListener('click', e => {
+    e.stopPropagation()
+    // 图片未加载则不调起
+    /* istanbul ignore if */
+    if (img.width + img.naturalWidth === 0) {
+      return
+    }
     let scheme = 'baiduboxapp://v19/utils/previewImage?params=' + encodeURIComponent(JSON.stringify({urls: [img.src]}))
     let iframe = document.createElement('iframe')
     iframe.style.display = 'none'

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -12,7 +12,7 @@ import CustomElement from '../custom-element'
 import viewport from '../viewport'
 import viewer from '../viewer'
 
-const {css, rect, event, naboo} = util
+const {css, rect, event, naboo, platform, dom} = util
 
 // 取值根据 https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement
 let imgAttributes = [
@@ -255,6 +255,29 @@ function bindPopup (element, img) {
   }, false)
 }
 
+/**
+ * 点击图片调起手百图片浏览器
+ * 协议link：http://wiki.baidu.com/pages/viewpage.action?pageId=686806027
+ *
+ * @param  {HTMLElement} img     mip-img下的img
+ * @return {void}         无
+ */
+function bindInvoke (img) {
+  img.addEventListener('click', () => {
+    let url = 'baiduboxapp://v19/utils/previewImage?params=' + encodeURIComponent(JSON.stringify({urls: [img.src]}))
+    let iframe = document.createElement('iframe')
+    iframe.style.display = 'none'
+    iframe.src = url
+    let body = document.body
+    body.appendChild(iframe)
+    // 销毁 iframe
+    setTimeout(() => {
+      body.removeChild(iframe)
+      iframe = null
+    }, 0)
+  })
+}
+
 class MipImg extends CustomElement {
   static get observedAttributes () {
     return imgAttributes
@@ -334,7 +357,11 @@ class MipImg extends CustomElement {
     }
 
     ele.appendChild(img)
-    if (ele.hasAttribute('popup')) {
+    // 在手百中，点击非跳转图片应调起图片查看器
+    if (platform.isBaiduApp() && !dom.closest(img, 'a')) {
+      bindInvoke(img)
+    }
+    else if (ele.hasAttribute('popup')) {
       bindPopup(ele, img)
     }
     this.element.classList.add('mip-img-loading')

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -263,10 +263,10 @@ function bindPopup (element, img) {
  */
 function bindInvocation (img) {
   img.addEventListener('click', () => {
-    let url = 'baiduboxapp://v19/utils/previewImage?params=' + encodeURIComponent(JSON.stringify({urls: [img.src]}))
+    let scheme = 'baiduboxapp://v19/utils/previewImage?params=' + encodeURIComponent(JSON.stringify({urls: [img.src]}))
     let iframe = document.createElement('iframe')
     iframe.style.display = 'none'
-    iframe.src = url
+    iframe.src = scheme
     let body = document.body
     body.appendChild(iframe)
     // 销毁 iframe

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -256,7 +256,7 @@ describe('mip-img', function () {
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_02.jpg')
+    mipImg.setAttribute('src', 'https://boscdn.baidu.com/v1/assets/mip/mip2-component-lifecycle.png')
     mipImg.setAttribute('popup', 'true')
     mipImgWrapper.appendChild(mipImg)
 

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -3,11 +3,13 @@
  * @author qiusiqi(qiusiqi@baidu.com)
  */
 
-import dom from 'src/util/dom/dom'
-import {event} from 'src/util'
+import dom, {waitForChild} from 'src/util/dom/dom'
+import util from 'src/util'
 
 /* eslint-disable no-unused-expressions */
 /* globals describe, before, it, expect, after, Event */
+
+const {event, platform} = util
 
 describe('mip-img', function () {
   let mipImgWrapper
@@ -247,5 +249,24 @@ describe('mip-img', function () {
     expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
     expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
     expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
+  })
+  it('should invoke image browser in BaiduApp when the image is clicked', () => {
+    let stub = sinon.stub(platform, 'isBaiduApp').callsFake(() => true)
+
+    let mipImg = document.createElement('mip-img')
+    mipImg.setAttribute('width', '100px')
+    mipImg.setAttribute('height', '100px')
+    mipImg.setAttribute('src', 'https://www.mipengine.org/static/img/sample_02.jpg')
+    mipImg.setAttribute('popup', 'true')
+    mipImgWrapper.appendChild(mipImg)
+
+    mipImg.viewportCallback(true)
+
+    let img = mipImg.querySelector('img')
+    let event = document.createEvent('MouseEvents')
+    event.initEvent('click', true, true)
+    img.dispatchEvent(event)
+    
+    return waitForChild(document.body, body => body.querySelector('iframe'))
   })
 })

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -251,7 +251,8 @@ describe('mip-img', function () {
     expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
   })
   it('should invoke image browser in BaiduApp when the image is clicked', () => {
-    let stub = sinon.stub(platform, 'isBaiduApp').callsFake(() => true)
+    let stub = sinon.stub(platform, 'isBaiduApp')
+    stub.callsFake(() => true)
 
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
@@ -261,12 +262,12 @@ describe('mip-img', function () {
     mipImgWrapper.appendChild(mipImg)
 
     mipImg.viewportCallback(true)
-
     let img = mipImg.querySelector('img')
     let event = document.createEvent('MouseEvents')
     event.initEvent('click', true, true)
     img.dispatchEvent(event)
-    
+
+    stub.restore()
     return waitForChild(document.body, body => body.querySelector('iframe'))
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#582 
#517 

**1、升级点** （清晰准确的描述升级的功能点）

- 查看图片支持缩放

- 图片长按可以下载

**2、影响范围** （描述该需求上线会影响什么功能）
在手百点击非跳转的图片，会通过手百浏览器打开，图片可缩放与下载

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
