### PR TITLE
修改 mip-img 手百调起逻辑

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -258,7 +258,7 @@ function bindPopup (element, img) {
 /**
  * 调起手百图片浏览器
  *
- * @param  {HTMLElement} ele mip-img
+ * @param  {HTMLElement} ele     mip-img
  * @param  {HTMLElement} img     mip-img下的img
  * @return {void}         无
  */

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -256,14 +256,32 @@ function bindPopup (element, img) {
 }
 
 /**
- * 点击图片调起手百图片浏览器
+ * 调起手百图片浏览器
  *
+ * @param  {HTMLElement} element mip-img
  * @param  {HTMLElement} img     mip-img下的img
  * @return {void}         无
  */
-function bindInvocation (img) {
-  img.addEventListener('click', e => {
-    e.stopPropagation()
+function bindInvocation (ele, img) {
+  //有 popup 属性的图片点击调起
+  if (ele.hasAttribute('popup')) {
+    img.addEventListener('click', e => {
+      e.stopPropagation()
+      invoke()
+    })
+  }
+  //iframe 中长按调起
+  if (viewer.isIframed) {
+    let timeout
+    img.addEventListener('touchstart', () => {
+      timeout = setTimeout(invoke, 300)
+    })
+    img.addEventListener('touchend', () => {
+      clearTimeout(timeout)
+    })
+  }
+
+  function invoke () {
     // 图片未加载则不调起
     /* istanbul ignore if */
     if (img.width + img.naturalWidth === 0) {
@@ -280,7 +298,7 @@ function bindInvocation (img) {
       body.removeChild(iframe)
       iframe = null
     }, 0)
-  })
+  }
 }
 
 class MipImg extends CustomElement {
@@ -364,9 +382,8 @@ class MipImg extends CustomElement {
     ele.appendChild(img)
     // 在手百中，点击非跳转图片应调起图片查看器
     if (platform.isBaiduApp() && !dom.closest(img, 'a')) {
-      bindInvocation(img)
-    }
-    else if (ele.hasAttribute('popup')) {
+      bindInvocation(ele, img)
+    } else if (ele.hasAttribute('popup')) {
       bindPopup(ele, img)
     }
     this.element.classList.add('mip-img-loading')

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -263,14 +263,7 @@ function bindPopup (element, img) {
  * @return {void}         无
  */
 function bindInvocation (ele, img) {
-  //有 popup 属性的图片点击调起
-  if (ele.hasAttribute('popup')) {
-    img.addEventListener('click', e => {
-      e.stopPropagation()
-      invoke()
-    })
-  }
-  //iframe 中长按调起
+  // iframe 中长按调起
   if (viewer.isIframed) {
     let timeout
     img.addEventListener('touchstart', () => {
@@ -280,7 +273,14 @@ function bindInvocation (ele, img) {
       clearTimeout(timeout)
     })
   }
-
+  // 有 popup 属性的图片点击调起
+  if (ele.hasAttribute('popup')) {
+    img.addEventListener('click', e => {
+      e.stopPropagation()
+      invoke()
+    })
+  }
+  
   function invoke () {
     // 图片未加载则不调起
     /* istanbul ignore if */
@@ -380,7 +380,7 @@ class MipImg extends CustomElement {
     }
 
     ele.appendChild(img)
-    // 在手百中，点击非跳转图片应调起图片查看器
+    // 在手百中，点击非跳转图片可调起图片查看器
     if (platform.isBaiduApp() && !dom.closest(img, 'a')) {
       bindInvocation(ele, img)
     } else if (ele.hasAttribute('popup')) {

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -258,7 +258,7 @@ function bindPopup (element, img) {
 /**
  * 调起手百图片浏览器
  *
- * @param  {HTMLElement} element mip-img
+ * @param  {HTMLElement} ele mip-img
  * @param  {HTMLElement} img     mip-img下的img
  * @return {void}         无
  */

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -290,6 +290,9 @@ describe('mip-img', function () {
 
     appStub.restore()
     iframeStub.restore()
-    return waitForChild(document.body, body => body.querySelector('iframe'))
+    await waitForChild(document.body, body => body.querySelector('iframe')).then(() => {
+      let event = new Event('touchend')
+      img.dispatchEvent(event)
+    })
   })
 })

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -5,6 +5,7 @@
 
 import dom, {waitForChild} from 'src/util/dom/dom'
 import util from 'src/util'
+import viewer from 'src/viewer';
 
 /* eslint-disable no-unused-expressions */
 /* globals describe, before, it, expect, after, Event */
@@ -250,9 +251,9 @@ describe('mip-img', function () {
     expect(mipPopWrap.querySelector('mip-carousel')).to.be.exist
     expect(mipPopWrap.querySelector('mip-carousel').getAttribute('index')).to.equal('1')
   })
-  it('should invoke image browser in BaiduApp when the image is clicked', () => {
-    let stub = sinon.stub(platform, 'isBaiduApp')
-    stub.callsFake(() => true)
+  it('should invoke image browser in BaiduApp when the popup image is clicked', () => {
+    let appStub = sinon.stub(platform, 'isBaiduApp')
+    appStub.callsFake(() => true)
 
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
@@ -267,7 +268,28 @@ describe('mip-img', function () {
     event.initEvent('click', true, true)
     img.dispatchEvent(event)
 
-    stub.restore()
+    appStub.restore()
+    return waitForChild(document.body, body => body.querySelector('iframe'))
+  })
+  it('should invoke image browser in BaiduApp when the image is long pressed', async () => {
+    let appStub = sinon.stub(platform, 'isBaiduApp')
+    let iframeStub = sinon.stub(viewer, 'isIframed')
+    appStub.callsFake(() => true)
+    iframeStub.callsFake(() => true)
+
+    let mipImg = document.createElement('mip-img')
+    mipImg.setAttribute('width', '100px')
+    mipImg.setAttribute('height', '100px')
+    mipImg.setAttribute('src', 'https://boscdn.baidu.com/v1/assets/mip/mip2-component-lifecycle.png')
+    mipImgWrapper.appendChild(mipImg)
+
+    mipImg.viewportCallback(true)
+    let img = mipImg.querySelector('img')
+    let event = new Event('touchstart')
+    img.dispatchEvent(event)
+
+    appStub.restore()
+    iframeStub.restore()
     return waitForChild(document.body, body => body.querySelector('iframe'))
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）
在手百中，popup 属性的图片点击调起大图，iframe 下所有图片长按调起大图

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
