### PR TITLE
fix: Fix mip-shell display

### DIFF
--- a/packages/mip/src/components/mip-shell/index.js
+++ b/packages/mip/src/components/mip-shell/index.js
@@ -284,7 +284,7 @@ class MipShell extends CustomElement {
     this.$wrapper.setAttribute('type', 'top')
     this.$wrapper.classList.add('mip-shell-header-wrapper')
     if (!showHeader) {
-      this.$wrapper.classList.add('hide')
+      css(this.$wrapper, 'display', 'none')
     }
 
     // Header
@@ -488,7 +488,7 @@ class MipShell extends CustomElement {
     this.currentPageMeta = pageMeta
 
     if (!(pageMeta.header && pageMeta.header.show)) {
-      this.$wrapper.classList.add('hide')
+      css(this.$wrapper, 'display', 'none')
       css(this.$loading, 'display', 'none')
       if (!this.transitionContainsHeader) {
         let headerLogoTitle = this.$el.querySelector('.mip-shell-header-logo-title')
@@ -532,7 +532,7 @@ class MipShell extends CustomElement {
     this.$buttonMask = mask
     this.$buttonWrapper = buttonWrapper
 
-    this.$wrapper.classList.remove('hide')
+    css(this.$wrapper, 'display', null)
 
     if (!asyncRefresh) {
       if (!this.transitionContainsHeader) {

--- a/packages/mip/src/styles/mip-shell.less
+++ b/packages/mip/src/styles/mip-shell.less
@@ -11,9 +11,6 @@ mip-shell * {
 .mip-shell-header-wrapper {
   z-index: 20000 !important;
   height: @shell-header-height;
-  &.hide {
-    display: none !important;
-  }
 }
 
 .mip-shell-header {


### PR DESCRIPTION
**相关 ISSUE:** 

**1、升级点**
 - 页面没有 mip.css 时，页面出现大箭头，现在去掉了

**2、影响范围** 
 - 无

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
