### PR TITLE
修复 CLI 编译 BUG

### DIFF
--- a/packages/mip-cli/CHANGELOG.md
+++ b/packages/mip-cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- 1.5.12
+    1. 紧急修复 1.5.11 版本编译过程找不到 core-js 的 BUG
+
 - 1.5.11
     1. 升级 Babel 至 v7
     2. 优化 external 管理策略

--- a/packages/mip-cli/lib/builder/webpack/config/index.js
+++ b/packages/mip-cli/lib/builder/webpack/config/index.js
@@ -11,6 +11,7 @@ const path = require('path')
 const componentExternals = require('./component-externals')
 const webpack = require('webpack')
 const mipExternal = require('mip-components-webpack-helpers/lib/external')
+const {resolveModule} = require('../../../utils/helper')
 
 module.exports = function (options) {
   let config = {
@@ -81,7 +82,8 @@ module.exports = function (options) {
     resolve: {
       extensions: ['.js', '.json', '.vue'],
       alias: {
-        '@': path.resolve(options.context)
+        '@': path.resolve(options.context),
+        'core-js': resolveModule('core-js')
       }
     },
     plugins: [

--- a/packages/mip-cli/package-lock.json
+++ b/packages/mip-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4393,7 +4393,6 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-      "optional": true,
       "requires": {
         "nan": "2.13.2",
         "node-pre-gyp": "0.12.0"
@@ -4401,8 +4400,7 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -4410,13 +4408,11 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.6"
@@ -4436,8 +4432,7 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -4453,49 +4448,41 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "4.1.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ms": "2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -4510,7 +4497,6 @@
         "glob": {
           "version": "7.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -4522,13 +4508,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
@@ -4536,7 +4520,6 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimatch": "3.0.4"
           }
@@ -4544,7 +4527,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -4556,8 +4538,7 @@
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4568,8 +4549,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -4593,7 +4573,6 @@
         "minizlib": {
           "version": "1.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minipass": "2.3.5"
           }
@@ -4607,13 +4586,11 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
           "version": "2.3.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "debug": "4.1.1",
             "iconv-lite": "0.4.24",
@@ -4623,7 +4600,6 @@
         "node-pre-gyp": {
           "version": "0.12.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
             "mkdirp": "0.5.1",
@@ -4640,7 +4616,6 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -4648,13 +4623,11 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.6"
@@ -4663,7 +4636,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.5",
             "console-control-strings": "1.1.0",
@@ -4677,8 +4649,7 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
@@ -4689,18 +4660,15 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -4708,18 +4676,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "optional": true,
           "requires": {
             "deep-extend": "0.6.0",
             "ini": "1.3.5",
@@ -4729,15 +4694,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -4751,7 +4714,6 @@
         "rimraf": {
           "version": "2.6.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "glob": "7.1.3"
           }
@@ -4762,28 +4724,23 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -4797,7 +4754,6 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
           }
@@ -4811,13 +4767,11 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "4.4.8",
           "bundled": true,
-          "optional": true,
           "requires": {
             "chownr": "1.1.1",
             "fs-minipass": "1.2.5",
@@ -4830,13 +4784,11 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -6736,8 +6688,7 @@
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-      "optional": true
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#606 

**1、升级点** （清晰准确的描述升级的功能点）

1. 将 core-js 的路径到 CLI 的依赖里去找

**2、影响范围** （描述该需求上线会影响什么功能）

1. 后续上线组件和线下的组件开发

**3、自测 Checklist**

1. mip2-extensions 调试正常，编译正常
2. mip2-extensions-platform 编译正常

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
