### PR TITLE
【免测】bugfix: 修复事件 event 数据丢失问题

### DIFF
--- a/packages/mip/src/util/event-action.js
+++ b/packages/mip/src/util/event-action.js
@@ -96,7 +96,7 @@ class EventAction {
     }) : {}
 
     let fn = new Function('DOM', `with(this){return ${action.arg}}`) // eslint-disable-line
-    let data = fn.call(proxy)
+    let data = fn.call(Object.assign(proxy, action))
 
     if (action.handler === 'setData') {
       MIP.setData(data)


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#608 

**1、升级点** （清晰准确的描述升级的功能点）

- 在 on 事件的 setData 函数中，可以通过 event 获取事件暴露的数据

**2、影响范围** （描述该需求上线会影响什么功能）

无

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
