### PR TITLE
【免测】修复 mip-fixed 因为在搜索落地页环境额外定义了 position: fixed 被隐藏的问题

### DIFF
--- a/packages/mip/src/fixed-element.js
+++ b/packages/mip/src/fixed-element.js
@@ -266,8 +266,10 @@ class FixedElement {
                   */
                 // elements[j].parentElement.removeChild(elements[j])
                 let ele = elements[j]
-                ele.style.cssText = 'display: none!important'
-                console.warn(ele, '发现 position: fixed 样式, 请使用 mip-fixed 组件代替')
+                if (ele.tagName !== 'MIP-FIXED') {
+                  ele.style.cssText = 'display: none!important'
+                  console.warn(ele, '发现 position: fixed 样式, 请使用 mip-fixed 组件代替')
+                }
               }
             }
           } catch (e) {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#616  

**1、升级点** （清晰准确的描述升级的功能点）

- 修复 mip-fixed 因为在搜索落地页环境额外定义了 position: fixed 被隐藏的问题

**2、影响范围** （描述该需求上线会影响什么功能）

- 搜索落地页下的 mip cahce  页面中的 mip-fixed 组件

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
