### PR TITLE
fix: 自动轮播支持 popup

### DIFF
--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -415,13 +415,13 @@ class MIPCarousel extends CustomElement {
     }, false)
 
     // 打开 popup 时暂停轮播
-    wrapBox.addEventListener('openPopup', e => {
+    ele.addEventListener('open-popup', e => {
       e.stopPropagation()
       clearInterval(moveInterval)
     })
 
     // 关闭 popup 时继续轮播
-    wrapBox.addEventListener('closePopup', e => {
+    ele.addEventListener('close-popup', e => {
       e.stopPropagation()
       if (isAutoPlay) {
         autoPlay()

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -167,6 +167,8 @@ function getChildNodes (element) {
     // 拷贝第一个和最后一个节点拼接dom
     let firstCard = childList[0].cloneNode(true)
     let endCard = childList[childList.length - 1].cloneNode(true)
+    firstCard.classList.add('mip-carousel-extra-img')
+    endCard.classList.add('mip-carousel-extra-img')
     childList.unshift(endCard)
     childList.push(firstCard)
   }
@@ -423,6 +425,7 @@ class MIPCarousel extends CustomElement {
     // 关闭 popup 时继续轮播
     ele.addEventListener('close-popup', e => {
       e.stopPropagation()
+      /* istanbul ignore if */
       if (isAutoPlay) {
         autoPlay()
       }

--- a/packages/mip/src/components/mip-carousel.js
+++ b/packages/mip/src/components/mip-carousel.js
@@ -159,12 +159,6 @@ function getChildNodes (element) {
 
   arrNode.map(function (ele, i) {
     if (ele.tagName.toLowerCase() !== 'mip-i-space') {
-      // 如果是 autoplay，则不允许有 popup 功能
-      if (element.hasAttribute('autoplay')) {
-        if (ele.hasAttribute('popup')) {
-          ele.removeAttribute('popup')
-        }
-      }
       childList.push(ele)
       element.removeChild(ele)
     }
@@ -419,6 +413,20 @@ class MIPCarousel extends CustomElement {
         autoPlay()
       }
     }, false)
+
+    // 打开 popup 时暂停轮播
+    wrapBox.addEventListener('openPopup', e => {
+      e.stopPropagation()
+      clearInterval(moveInterval)
+    })
+
+    // 关闭 popup 时继续轮播
+    wrapBox.addEventListener('closePopup', e => {
+      e.stopPropagation()
+      if (isAutoPlay) {
+        autoPlay()
+      }
+    })
 
     // 自动轮播
     if (isAutoPlay) {

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -96,10 +96,9 @@ function getImgsSrcIndex (ele) {
   // 取已渲染的 popup 图片
   const mipImgs = [...document.querySelectorAll('mip-img[popup].mip-img-loaded')]
   let index = mipImgs.indexOf(ele)
-  // just check
   /* istanbul ignore if */
   if (index === -1) {
-    index = 0
+    return {imgsSrcArray: [], index}
   }
   const imgsSrcArray = mipImgs.map(mipImg => {
     let img = mipImg.querySelector('img')
@@ -136,7 +135,7 @@ function getCurrentImg (carouselWrapper, mipCarousel) {
 function createPopup (element) {
   const {imgsSrcArray, index} = getImgsSrcIndex(element)
   /* istanbul ignore if */
-  if (imgsSrcArray.length === 0) {
+  if (imgsSrcArray.length === 0 || index === -1) {
     return
   }
   let popup = document.createElement('div')
@@ -214,6 +213,10 @@ function bindPopup (element, img) {
     if (!popup) {
       return
     }
+
+    let openEvent = new Event('openPopup', {bubbles: true})
+    element.dispatchEvent(openEvent)
+
     let popupBg = popup.querySelector('.mip-img-popUp-bg')
     let mipCarousel = popup.querySelector('mip-carousel')
     let popupImg = new Image()
@@ -257,6 +260,9 @@ function bindPopup (element, img) {
         popup.removeEventListener('click', imagePop, false)
         popup.remove()
       })
+
+      let closeEvent = new Event('closePopup', {bubbles: true})
+      element.dispatchEvent(closeEvent)
     }
 
     let onResize = function () {

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -12,7 +12,7 @@ import CustomElement from '../custom-element'
 import viewport from '../viewport'
 import viewer from '../viewer'
 
-const {css, rect, event, naboo, platform} = util
+const {css, rect, event, naboo, platform, dom} = util
 
 // 取值根据 https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement
 let imgAttributes = [
@@ -193,6 +193,8 @@ function createPopup (element) {
  * @return {void}         无
  */
 function bindPopup (element, img) {
+  // 是否在 mip-carousel 中
+  let carousel = dom.closest(element, 'mip-carousel')
   // 图片点击时展现图片
   img.addEventListener('click', function (event) {
     event.stopPropagation()
@@ -214,8 +216,9 @@ function bindPopup (element, img) {
       return
     }
 
-    let openEvent = new Event('openPopup', {bubbles: true})
-    element.dispatchEvent(openEvent)
+    if (carousel) {
+      customEmit(carousel, 'open-popup')
+    }
 
     let popupBg = popup.querySelector('.mip-img-popUp-bg')
     let mipCarousel = popup.querySelector('mip-carousel')
@@ -261,8 +264,11 @@ function bindPopup (element, img) {
         popup.remove()
       })
 
-      let closeEvent = new Event('closePopup', {bubbles: true})
-      element.dispatchEvent(closeEvent)
+      // let closeEvent = new Event('close-popup', {bubbles: true})
+      // element.dispatchEvent(closeEvent)
+      if (carousel) {
+        customEmit(carousel, 'close-popup')
+      }
     }
 
     let onResize = function () {

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -193,14 +193,11 @@ function createPopup (element) {
  * @return {void}         无
  */
 function bindPopup (element, img) {
-  let carousel
+  // 是否在 mip-carousel 中
+  let carousel = dom.closest(element, 'mip-carousel')
   // 图片点击时展现图片
   img.addEventListener('click', function (event) {
     event.stopPropagation()
-    // 是否在 mip-carousel 中
-    if (!carousel) {
-      carousel = dom.closest(element, 'mip-carousel')
-    }
     let current = img.currentSrc || img.src
     // 图片未加载则不弹层
     /* istanbul ignore if */

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -193,11 +193,14 @@ function createPopup (element) {
  * @return {void}         无
  */
 function bindPopup (element, img) {
-  // 是否在 mip-carousel 中
-  let carousel = dom.closest(element, 'mip-carousel')
+  let carousel
   // 图片点击时展现图片
   img.addEventListener('click', function (event) {
     event.stopPropagation()
+    // 是否在 mip-carousel 中
+    if (!carousel) {
+      carousel = dom.closest(element, 'mip-carousel')
+    }
     let current = img.currentSrc || img.src
     // 图片未加载则不弹层
     /* istanbul ignore if */
@@ -264,8 +267,6 @@ function bindPopup (element, img) {
         popup.remove()
       })
 
-      // let closeEvent = new Event('close-popup', {bubbles: true})
-      // element.dispatchEvent(closeEvent)
       if (carousel) {
         customEmit(carousel, 'close-popup')
       }

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -93,8 +93,9 @@ function getImgOffset (img) {
  * @return {Object} 保存 src 数组和 index
  */
 function getImgsSrcIndex (ele) {
-  // 取已渲染的 popup 图片
+  // 取已渲染的 popup 图片，不包括 carousel 中头尾的两个图片
   const mipImgs = [...document.querySelectorAll('mip-img[popup].mip-img-loaded')]
+                    .filter(mipImg => !mipImg.classList.contains('mip-carousel-extra-img'))
   let index = mipImgs.indexOf(ele)
   /* istanbul ignore if */
   if (index === -1) {
@@ -182,7 +183,6 @@ function createPopup (element) {
   popup.appendChild(popUpBg)
   popup.appendChild(carouselWrapper)
   document.body.appendChild(popup)
-
   return popup
 }
 /**
@@ -225,6 +225,11 @@ function bindPopup (element, img) {
     let popupImg = new Image()
     popupImg.setAttribute('src', current)
     popup.appendChild(popupImg)
+    
+    // 背景 fade in
+    naboo.animate(popupBg, {
+      opacity: 1
+    }).start()
 
     let imgOffset = getImgOffset(img)
 

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -194,7 +194,7 @@ function createPopup (element) {
  */
 function bindPopup (element, img) {
   // 是否在 mip-carousel 中
-  let carousel = dom.closest(element, 'mip-carousel')
+  let carouselOutside = element.customElement.carouselOutside
   // 图片点击时展现图片
   img.addEventListener('click', function (event) {
     event.stopPropagation()
@@ -216,8 +216,8 @@ function bindPopup (element, img) {
       return
     }
 
-    if (carousel) {
-      customEmit(carousel, 'open-popup')
+    if (carouselOutside) {
+      customEmit(carouselOutside, 'open-popup')
     }
 
     let popupBg = popup.querySelector('.mip-img-popUp-bg')
@@ -269,8 +269,8 @@ function bindPopup (element, img) {
         popup.remove()
       })
 
-      if (carousel) {
-        customEmit(carousel, 'close-popup')
+      if (carouselOutside) {
+        customEmit(carouselOutside, 'close-popup')
       }
     }
 
@@ -376,6 +376,8 @@ class MipImg extends CustomElement {
 
   /** @overwrite */
   build () {
+    // 在 build 中判断，在 layoutCallback 可能不对（与执行顺序有关）
+    this.carouselOutside = dom.closest(this.element, 'mip-carousel')
     this.createPlaceholder()
   }
 

--- a/packages/mip/src/styles/mip-img.less
+++ b/packages/mip/src/styles/mip-img.less
@@ -97,7 +97,7 @@
   }
   &-popUp-bg {
     height: 100%;
-    opacity: 1;
+    opacity: 0;
     background: #000;
   }
 }

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -135,7 +135,7 @@ describe('mip-carousel', function () {
       // 等待 popup 完全关闭
       await sleep(500)
       expect(carousel.style.display).to.equal('none')
-    }).timeout(4000)
+    }).timeout(6000)
 
     after(function () {
       document.body.removeChild(div)

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -135,7 +135,7 @@ describe('mip-carousel', function () {
       // 等待 popup 完全关闭
       await sleep(500)
       expect(carousel.style.display).to.equal('none')
-    }).timeout(3000)
+    }).timeout(4000)
 
     after(function () {
       document.body.removeChild(div)

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -122,20 +122,18 @@ describe('mip-carousel', function () {
       expect(mipImg.hasAttribute('popup')).to.be.true
       let img = mipImg.querySelector('img')
       let evt = document.createEvent('MouseEvents')
+      // 图片可能未加载
       await sleep(500)
       evt.initEvent('click', true, true)
       img.dispatchEvent(evt)
-      // await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))
-      await sleep(500)
+      await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))
       let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
       expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
-      // await waitForChild(mipPopWrap, mipPopWrap => mipPopWrap.querySelector('mip-carousel'))
-      await sleep(500)
+      await waitForChild(mipPopWrap, mipPopWrap => mipPopWrap.querySelector('mip-carousel'))
       let carousel = mipPopWrap.querySelector('mip-carousel')
       expect(carousel).to.be.exist
       carousel.viewportCallback(true)
-      // await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
-      await sleep(500)
+      await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
       mipPopWrap.dispatchEvent(evt)
       // 等待 popup 完全关闭
       await sleep(500)

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -122,6 +122,7 @@ describe('mip-carousel', function () {
       expect(mipImg.hasAttribute('popup')).to.be.true
       let img = mipImg.querySelector('img')
       let evt = document.createEvent('MouseEvents')
+      await sleep(500)
       evt.initEvent('click', true, true)
       img.dispatchEvent(evt)
       // await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -121,21 +121,25 @@ describe('mip-carousel', function () {
       let mipImg = slideBoxs[2].querySelector('mip-img')
       expect(mipImg.hasAttribute('popup')).to.be.true
       let img = mipImg.querySelector('img')
-      let evt = new Event('click')
+      let evt = document.createEvent('MouseEvents')
+      evt.initEvent('click', true, true)
       img.dispatchEvent(evt)
-      await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))
+      // await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))
+      await sleep(500)
       let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
       expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
-      await waitForChild(mipPopWrap, mipPopWrap => mipPopWrap.querySelector('mip-carousel'))
+      // await waitForChild(mipPopWrap, mipPopWrap => mipPopWrap.querySelector('mip-carousel'))
+      await sleep(500)
       let carousel = mipPopWrap.querySelector('mip-carousel')
       expect(carousel).to.be.exist
       carousel.viewportCallback(true)
-      await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
+      // await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
+      await sleep(500)
       mipPopWrap.dispatchEvent(evt)
       // 等待 popup 完全关闭
       await sleep(500)
       expect(carousel.style.display).to.equal('none')
-    }).timeout(6000)
+    }).timeout(4000)
 
     after(function () {
       document.body.removeChild(div)

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -6,6 +6,8 @@
 /* eslint-disable no-unused-expressions */
 /* globals describe, before, it, expect, after */
 
+import {waitForChild} from 'src/util/dom/dom'
+
 let sleep = t => new Promise(resolve => setTimeout(resolve, t))
 
 describe('mip-carousel', function () {
@@ -60,10 +62,10 @@ describe('mip-carousel', function () {
               <div class="mip-carousle-subtitle">这里是title2</div>
           </a>
           <mip-img popup
-              src="https://www.mipengine.org/static/img/sample_02.jpg">
+              src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg">
           </mip-img>
-          <mip-img
-              src="https://www.mipengine.org/static/img/sample_03.jpg">
+          <mip-img popup
+              src="https://boscdn.baidu.com/assets/mipengine/wide.jpg">
           </mip-img>
         </mip-carousel>
       `
@@ -80,7 +82,7 @@ describe('mip-carousel', function () {
       expect(wrapBox).to.be.exist
       expect(wrapBox.parentNode.classList.contains('mip-carousel-container')).to.be.true
       expect(slideBoxs.length).to.equal(5)
-      expect(slideBoxs[0].querySelector('img').getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_03.jpg')
+      expect(slideBoxs[0].querySelector('img').getAttribute('src')).to.equal('https://boscdn.baidu.com/assets/mipengine/wide.jpg')
       expect(slideBoxs[4].querySelector('img').getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
     })
 
@@ -88,10 +90,6 @@ describe('mip-carousel', function () {
       // 定时播放，所以使用 setTimeout 定时检查 400 + 100
       await sleep(500)
       expect(wrapBox.style.transform).to.equal('translate3d(-200px, 0px, 0px)')
-    })
-
-    it('should not popup when autoplay', function () {
-      expect(slideBoxs[2].getAttribute('popup')).to.be.null
     })
 
     it('should move to next img when touch', async function () {
@@ -118,6 +116,26 @@ describe('mip-carousel', function () {
       await sleep(100)
       expect(wrapBox.style.transform).to.be.oneOf(['translate3d(-100px, 0px, 0px)', 'translate3d(-400px, 0px, 0px)'])
     })
+
+    it('should popup and close popup', async () => {
+      let mipImg = slideBoxs[2].querySelector('mip-img')
+      expect(mipImg.hasAttribute('popup')).to.be.true
+      let img = mipImg.querySelector('img')
+      let evt = new Event('click')
+      img.dispatchEvent(evt)
+      await waitForChild(document.body, body => body.querySelector('.mip-img-popUp-wrapper'))
+      let mipPopWrap = document.querySelector('.mip-img-popUp-wrapper')
+      expect(mipPopWrap.getAttribute('data-name')).to.equal('mip-img-popUp-name')
+      await waitForChild(mipPopWrap, mipPopWrap => mipPopWrap.querySelector('mip-carousel'))
+      let carousel = mipPopWrap.querySelector('mip-carousel')
+      expect(carousel).to.be.exist
+      carousel.viewportCallback(true)
+      await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
+      mipPopWrap.dispatchEvent(evt)
+      // 等待 popup 完全关闭
+      await sleep(500)
+      expect(carousel.style.display).to.equal('none')
+    }).timeout(3000)
 
     after(function () {
       document.body.removeChild(div)

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -43,7 +43,7 @@ describe('mip-img', function () {
   })
 
   it('should be loading with placeholder', async () => {
-    let mipImg = dom.create('<mip-img popup src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>')
+    let mipImg = dom.create('<mip-img popup src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>')
     mipImgWrapper.appendChild(mipImg)
     document.body.appendChild(mipImgWrapper)
     mipImg.viewportCallback(true)
@@ -99,14 +99,14 @@ describe('mip-img', function () {
 
   it('should load img with normal src', function () {
     mipImgWrapper.innerHTML = `
-      <mip-img src="http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
+      <mip-img src="https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg"></mip-img>
     `
     let mipImg = mipImgWrapper.querySelector('mip-img')
     mipImg.viewportCallback(true)
     let img = mipImg.querySelector('img')
     let loading = new Promise(resolve => event.listen(img, 'load', resolve))
     expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-    expect(img.getAttribute('src')).to.equal('http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
+    expect(img.getAttribute('src')).to.equal('https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
     return loading
   })
 
@@ -164,7 +164,7 @@ describe('mip-img', function () {
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'http://boscdn.bpc.baidu.com/assets/mipengine/wide.jpg')
+    mipImg.setAttribute('src', 'https://boscdn.baidu.com/assets/mipengine/wide.jpg')
     mipImg.setAttribute('popup', 'true')
     mipImgWrapper.appendChild(mipImg)
 
@@ -316,7 +316,7 @@ describe('mip-img', function () {
   it('should work with source tag', async () => {
     let mipImg = document.createElement('mip-img')
     let source = document.createElement('source')
-    source.setAttribute('srcset', 'http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
+    source.setAttribute('srcset', 'https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
     mipImg.setAttribute('src', 'https://boscdn.baidu.com/v1/assets/mip/mip2-component-lifecycle.png')
@@ -329,6 +329,6 @@ describe('mip-img', function () {
     let loading = new Promise(resolve => event.listen(img, 'load', resolve))
     expect(mipImg.querySelector('picture')).to.be.exist
     await loading
-    expect(img.currentSrc).to.equal('http://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
+    expect(img.currentSrc).to.equal('https://boscdn.baidu.com/v1/assets/mipengine/logo.jpeg')
   })
 })

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -162,11 +162,14 @@ describe('mip-img', function () {
 
   it('should popup and close the popup', async () => {
     let mipImg = document.createElement('mip-img')
+    let carou = document.createElement('mip-carousel')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
     mipImg.setAttribute('src', 'https://boscdn.baidu.com/assets/mipengine/wide.jpg')
     mipImg.setAttribute('popup', 'true')
-    mipImgWrapper.appendChild(mipImg)
+    // carousel for triggering open-popup and close-popup event
+    carou.appendChild(mipImg)
+    mipImgWrapper.appendChild(carou)
 
     mipImg.viewportCallback(true)
 
@@ -185,7 +188,6 @@ describe('mip-img', function () {
     expect(mipPopWrap.querySelector('.mip-img-popUp-bg')).to.be.exist
     let carousel = mipPopWrap.querySelector('mip-carousel')
     expect(carousel).to.be.exist
-    expect(carousel.getAttribute('index')).to.equal('1')
 
     // 等待 carousel 生成
     await waitForChild(carousel, carousel => carousel.querySelector('.mip-carousel-wrapper'))
@@ -193,6 +195,7 @@ describe('mip-img', function () {
     // 等待 popup 完全关闭
     await timer.sleep(500)
     expect(mipPopWrap.style.display).to.equal('none')
+    mipImgWrapper.removeChild(carou)
   }).timeout(4000)
   it('should not popup if the image is not loaded', async () => {
     mipImgWrapper.innerHTML = `<mip-img popup src="https://www.wrong.org?test=1"></mip-img>`


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）

根据手百站点检测要求，自动轮播也能够打开大图，popup 时暂停轮播，关闭 popup 后继续轮播

**2、影响范围** （描述该需求上线会影响什么功能）

使用 mip-carousel 的站点

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
