### PR TITLE
【免测】bugfix: 修复 slot 在 v-for 中失效问题

### DIFF
--- a/packages/mip/examples/mip2/mip-test-slot.html
+++ b/packages/mip/examples/mip2/mip-test-slot.html
@@ -1,0 +1,22 @@
+<!--htmlcs-disable-->
+<!DOCTYPE html>
+<html mip>
+<head>
+  <meta charset="utf-8">
+  <title>MIP tree demo</title>
+  <meta name="apple-touch-fullscreen" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="stylesheet" href="../../dist/mip.css">
+  <style mip-custom>
+  </style>
+</head>
+
+<body>
+  <mip-test-slot><span>hello</span></mip-test-slot>
+  <script src="../../dist/mip.js"></script>
+  <script src="../../dist/mip-vue.js"></script>
+  <script src="./mip-test-slot.js"></script>
+</body>
+</html>

--- a/packages/mip/examples/mip2/mip-test-slot.js
+++ b/packages/mip/examples/mip2/mip-test-slot.js
@@ -1,0 +1,17 @@
+/**
+ * @file mip-tree
+ * @author sfe
+ */
+
+/* global MIP */
+
+MIP.registerVueCustomElement('mip-test-slot', {
+  template: `
+    <div>
+      <div v-for="i in [1, 2, 3, 4, 5, 6,7]" :key="i">
+        {{ i }}
+        <slot></slot>
+      </div>
+    </div>
+  `
+})

--- a/packages/mip/src/vue/core/instance/render-helpers/render-slot.js
+++ b/packages/mip/src/vue/core/instance/render-helpers/render-slot.js
@@ -19,6 +19,7 @@ export function renderSlot (
   bindObject
 ) {
   const scopedSlotFn = this.$scopedSlots[name]
+  let nodes
   if (scopedSlotFn) { // scoped slot
     props = props || {}
     if (bindObject) {
@@ -32,18 +33,15 @@ export function renderSlot (
       props = extend(extend({}, bindObject), props)
     }
 
-    return scopedSlotFn(props) || fallback
-  }
-  const slotNodes = this.$slots[name]
-  // warn duplicate slot usage
-  if (slotNodes && process.env.NODE_ENV !== 'production') {
-    slotNodes._rendered && warn(
-      `Duplicate presence of slot "${name}" found in the same render tree ` +
-      '- this will likely cause render errors.',
-      this
-    )
-    slotNodes._rendered = true
+    nodes = scopedSlotFn(props) || fallback
+  } else {
+    nodes = this.$slots[name] || fallback
   }
 
-  return slotNodes || fallback
+  const target = props && props.slot
+  if (target) {
+    return this.$createElement('template', { slot: target }, nodes)
+  }
+
+  return nodes
 }

--- a/packages/mip/src/vue/core/instance/render.js
+++ b/packages/mip/src/vue/core/instance/render.js
@@ -65,20 +65,9 @@ export function renderMixin (Vue) {
     const vm = this
     const {render, _parentVnode} = vm.$options
 
-    if (vm._isMounted) {
-      // if the parent didn't update, the slot nodes will be the ones from
-      // last render. They need to be cloned to ensure "freshness" for this render.
-      for (const key in vm.$slots) {
-        const slot = vm.$slots[key]
-        if (slot._rendered) {
-          vm.$slots[key] = cloneVNodes(slot, true
-            // deep
-          )
-        }
-      }
+    if (_parentVnode) {
+      vm.$scopedSlots = _parentVnode.data.scopedSlots || emptyObject
     }
-
-    vm.$scopedSlots = (_parentVnode && _parentVnode.data.scopedSlots) || emptyObject
 
     // set parent vnode. this allows render functions to have access
     // to the data on the placeholder node.


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#613 

**1、升级点** （清晰准确的描述升级的功能点）

修复 v-for 配合 slot 使用导致的渲染 slot 缺失问题， 见 #613 

**2、影响范围** （描述该需求上线会影响什么功能）

- mip 的 vue 组件的 slot  用法

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
