### PR TITLE
[免测]去掉 QQ 浏览器下的特殊处理

### DIFF
--- a/packages/mip/src/polyfill.js
+++ b/packages/mip/src/polyfill.js
@@ -15,22 +15,22 @@ import 'document-register-element/build/document-register-element.esm'
 // import 'deps/document-register-element'
 
 import 'deps/fetch-jsonp'
-import {
-  fetch as polyfillFetch,
-  Headers as polyfillHeaders,
-  Request as polyfillRequest,
-  Response as polyfillResponse
-} from 'whatwg-fetch/fetch'
+// import {
+//   fetch as polyfillFetch,
+//   Headers as polyfillHeaders,
+//   Request as polyfillRequest,
+//   Response as polyfillResponse
+// } from 'whatwg-fetch/fetch'
 
-import platform from './util/platform'
+// import platform from './util/platform'
 
 // 增加 QQ 浏览器的判断，
 // 因为 QQ 浏览器的早起版本 fetch 实现有问题，
 // 发送请求会漏掉 cookie，
 // 因为在 QQ 浏览器中也通过 polyfill 的方式覆盖 fetch
-if (platform.isQQ) {
-  window.fetch = polyfillFetch
-  window.Headers = polyfillHeaders
-  window.Request = polyfillRequest
-  window.Response = polyfillResponse
-}
+// if (platform.isQQ()) {
+//   window.fetch = polyfillFetch
+//   window.Headers = polyfillHeaders
+//   window.Request = polyfillRequest
+//   window.Response = polyfillResponse
+// }


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

#638 

**1、升级点** （清晰准确的描述升级的功能点）

去掉 QQ 浏览器下对 `fetch` 的处理

**2、影响范围** （描述该需求上线会影响什么功能）

低版本 QQ 浏览器下，对 fetch 支持不好的浏览器下，xhr 请求没带 cookie

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
