### PR TITLE
mip cdn链接可以通过mip-shell跳转

### DIFF
--- a/packages/mip/src/viewer.js
+++ b/packages/mip/src/viewer.js
@@ -240,7 +240,7 @@ let viewer = {
     // Jump in top window directly
     // 1. ( Cross origin or MIP Shell is disabled ) and NOT in SF
     // 2. Not MIP page and not only hash change
-    if (((this._isCrossOrigin(to) || isMIPShellDisabled()) && window.MIP.standalone) ||
+    if (((this._isCrossOrigin(to) || isMIPShellDisabled()) && (window.MIP.standalone && !window.MIP.util.isCacheUrl(location.href))) ||
       (!isMipLink && !isHashInCurrentPage)) {
       if (replace) {
         window.top.location.replace(to)
@@ -268,7 +268,7 @@ let viewer = {
 
     // Create target route
     let targetRoute = {
-      path: window.MIP.standalone ? to : makeCacheUrl(to)
+      path: (window.MIP.standalone && !window.MIP.util.isCacheUrl(location.href)) ? to : makeCacheUrl(to)
     }
 
     if (isMipLink) {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#643 

**1、升级点** （清晰准确的描述升级的功能点）
mip cdn链接里的 a 标签 data-type=mip 可以通过mip-shell的方式跳转

**2、影响范围** （描述该需求上线会影响什么功能）
所有 a 标签 data-type=mip  的 mip cdn 链接  

**3、自测 Checklist**
https://www-xmkanshu-com.mipcdn.com/c/www.xmkanshu.com/book/mip/read?bkid=685640121&crid=916&fr=bdgfh&mip=1&pg=4
代理测试，点击下一页，url一直都是这种 mip cdn 的链接

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
