### PR TITLE
 移除 mip-img popup 对 loaded 的筛选

### DIFF
--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -93,7 +93,7 @@ function getImgOffset (img) {
  * @return {Object} 保存 src 数组和 index
  */
 function getImgsSrcIndex (ele) {
-  // 取已渲染的 popup 图片，不包括 carousel 中头尾的两个图片
+  // 取 popup 图片，不包括 carousel 中头尾的两个图片
   const mipImgs = [...document.querySelectorAll('mip-img[popup]')]
                     .filter(mipImg => !mipImg.classList.contains('mip-carousel-extra-img'))
   let index = mipImgs.indexOf(ele)

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -94,7 +94,7 @@ function getImgOffset (img) {
  */
 function getImgsSrcIndex (ele) {
   // 取已渲染的 popup 图片，不包括 carousel 中头尾的两个图片
-  const mipImgs = [...document.querySelectorAll('mip-img[popup].mip-img-loaded')]
+  const mipImgs = [...document.querySelectorAll('mip-img[popup]')]
                     .filter(mipImg => !mipImg.classList.contains('mip-carousel-extra-img'))
   let index = mipImgs.indexOf(ele)
   /* istanbul ignore if */
@@ -108,7 +108,7 @@ function getImgsSrcIndex (ele) {
     if (!img) {
       return mipImg.getAttribute('src')
     }
-    return img.currentSrc || img.src
+    return img.src
   })
   return {imgsSrcArray, index}
 }

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -87,7 +87,7 @@ function getImgOffset (img) {
   return imgOffset
 }
 /**
- * 获取所有已渲染的 popup 属性的 mip-img src 和本元素在数组中对应的 index
+ * 获取有 popup 属性的 mip-img src 和本元素在数组中对应的 index
  *
  * @param {HTMLElement} ele mip-img 组件元素
  * @return {Object} 保存 src 数组和 index

--- a/packages/mip/src/components/mip-img.js
+++ b/packages/mip/src/components/mip-img.js
@@ -103,7 +103,6 @@ function getImgsSrcIndex (ele) {
   }
   const imgsSrcArray = mipImgs.map(mipImg => {
     let img = mipImg.querySelector('img')
-    // just check
     /* istanbul ignore if */
     if (!img) {
       return mipImg.getAttribute('src')


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#651 

**1、升级点** （清晰准确的描述升级的功能点）

之前的改动是为了保持和 picture 实际加载图片一致，popup 会过滤没有加载完成的图片

现在改为 popup 应包括未加载的图片，没有必要只显示已加载图片

**2、影响范围** （描述该需求上线会影响什么功能）

mip-img popup 功能

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
