### PR TITLE
update cli to 1.5.15

### DIFF
--- a/packages/mip-cli/CHANGELOG.md
+++ b/packages/mip-cli/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- 1.5.15
+    1. 紧急修复 less 版本升级引起的 bug
+
 - 1.5.14 
     1. 修复 typescript 文件没经过 babel 编译的 BUG
 

--- a/packages/mip-cli/package-lock.json
+++ b/packages/mip-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {
@@ -60,7 +60,7 @@
     "koa-router": "^7.4.0",
     "koa-static": "^4.0.3",
     "koa-webpack": "^4.0.0",
-    "less": "^3.0.4",
+    "less": "3.9.0",
     "less-loader": "^4.1.0",
     "livereload": "^0.7.0",
     "metalsmith": "^2.3.0",


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）

**1、升级点** （清晰准确的描述升级的功能点）

less 升级至 3.10.0 导致和 less-loader 同时使用时编译出错，见：

https://github.com/less/less.js/issues/3414

先锁定版本，不影响正常编译。

**2、影响范围** （描述该需求上线会影响什么功能）

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
