### PR TITLE
统一 MIP 表达式的语法形式

### DIFF
--- a/docs/docs/interactive-mip/event-and-action.md
+++ b/docs/docs/interactive-mip/event-and-action.md
@@ -66,7 +66,7 @@ MIP 提供了 `on` 属性来定义对组件的事件绑定与事件触发时的�
 
 为了使得过长的 on 表达式更易于阅读，在分隔符前后允许存在换行符和空格进行表达式分段操作。
 
-[notice] 定义在同一个事件下面的多个行为当中，只允许存在 1 个 `MIP.setData()` 方法，以免造成
+[notice] 定义在同一个事件下面的多个行为当中，只允许存在 1 个 `MIP.setData()` 方法，以免造成数据执行顺序的混乱。
 
 ## 支持的事件
 
@@ -170,7 +170,6 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 |focus                                      |让元素获得焦点。<br>如：`element-id.focus`|
 
 [notice] 当 MIP 组件自定义方法与全局元素方法重名的情况下，比如 mip-toggle 具有自定义行为 `show` 和 `hide`，此时优先触发组件的自定义方法。
-
 
 下面是全局元素方法的一些例子：
 
@@ -366,6 +365,65 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 MIP 组件允许自定义方法，通过 `this.addEventAction` 进行自定义方法的注册。因此需要阅读对应 [MIP 组件文档](https://www.mipengine.org/v2/components/index.html)当中的 `行为` 或 `方法` 部分进行学习。
 
 
+## 行为封装与前置判断
+
+我们提供了 [mip-action-macro](https://www.mipengine.org/v2/components/dynamic-content/mip-action-macro.html) 来进一步增强 MIP on 表达式的功能。
+
+mip-action-macro 主要提供的功能包括：
+
+- 将单个或多个行为封装起来，提高行为复用率
+- 支持在执行方法前提供前置判断条件，只有当判断条件为真时才会执行方法
+- 支持对全部全局元素方法和特殊对象方法的参数进行有限能力的计算
+
+下面进行 mip-action-macro 的使用方法演示，更具体的组件说明，请点击链接查看 mip-action-macro 的组件文档。
+
+
+```html
+<mip-data>
+  <script type="application/json">
+  {
+    "protocol": "https://",
+    "baidu": "www.baidu.com",
+    "mipengine": "www.mipengine.org"
+  }
+  </script>
+</mip-data>
+
+<mip-action-macro
+  id="macro-id"
+  condition="event.url === baidu"
+  on="execute:MIP.navigateTo(url=protocol + event.url, target='_blank')"
+></mip-action-macro>
+
+<button on="tap:macro-id.execute(url=baidu)">点击跳转至百度首页</button>
+<button on="tap:macro-id.execute(url=mipengine)">点击不会发生任何跳转</button>
+```
+
+效果如下所示：
+
+<mip-data>
+  <script type="application/json">
+  {
+    "protocol": "https://",
+    "baidu": "www@baidu@com",
+    "mipengine": "ww@mipengine@org"
+  }
+  </script>
+</mip-data>
+
+<div class="example-wrapper">
+
+  <mip-action-macro
+    id="macro-id"
+    condition="event.url === baidu"
+    on="execute:MIP.navigateTo(url=protocol + event.url, target='_blank')"
+  ></mip-action-macro>
+
+  <button class="example-button" on="tap:macro-id.execute(url=baidu)">点击跳转至百度首页</button>
+  <button class="example-button" on="tap:macro-id.execute(url=mipengine)">点击不会发生任何跳转</button>
+
+</div>
+
 
 <div class="example-wrapper" id="bottom-example" hidden>
   <p>您已通过 bottom-button.scrollTo() 方法滚动到底部，请点击下方按钮返回原示例</p>
@@ -377,3 +435,4 @@ MIP 组件允许自定义方法，通过 `this.addEventAction` 进行自定义�
   >点击返回原示例</button>
 </div>
 
+<script src="https://c.mipcdn.com/static/v2/mip-action-macro/mip-action-macro.js"></script>

--- a/docs/docs/interactive-mip/event-and-action.md
+++ b/docs/docs/interactive-mip/event-and-action.md
@@ -10,7 +10,7 @@ MIP 提供了 `on` 属性来定义对组件的事件绑定与事件触发时的�
     class="example-button"
     on="tap:
       top-example.hide,
-      MIP.scrollTo(id='mip-scrollto-button', duration=500, position='center')"
+      MIP.scrollTo({id: 'mip-scrollto-button', duration: 500, position: 'center'})"
   >点击返回原示例</button>
 </div>
 
@@ -46,7 +46,7 @@ MIP 提供了 `on` 属性来定义对组件的事件绑定与事件触发时的�
 <div on="tap:header-element.show">点我</div>
 <!-- 调用 MIP 特殊对象上的方法 -->
 <div on="tap:MIP.setData({ a: 1 + 2 })"></div>
-<div on="tap:MIP.navigateTo(url='https://www.baidu.com', target='_blank')">
+<div on="tap:MIP.navigateTo({ url: 'https://www.baidu.com', target: '_blank' })">
 ```
 
 ### 多事件绑定与多行为触发
@@ -57,7 +57,7 @@ MIP 提供了 `on` 属性来定义对组件的事件绑定与事件触发时的�
 <input id="input-element"
   on="
     tap:
-      input-element.scrollTo(duration=500, position='center'),
+      input-element.scrollTo({ duration: 500, position: 'center' }),
       MIP.setData({ clicked: clicked + 1 });
     change:
       MIP.setData({ value: event.value })
@@ -165,11 +165,13 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 |hide |隐藏元素。<br>如：`element-id.hide` |
 |show |显示元素。<br>如：`element-id.show` |
 |toggleVisibility |切换显示和隐藏元素。|
-|toggleClass(<br>&nbsp;&nbsp;class=STRING,<br>&nbsp;&nbsp;force=BOOLEAN<br>) |切换元素类名。<br>参数 `force` 可选，如果为 true，则只添加类名。如果为 false，则只移除类名。<br> 如：`element-id.toggleClass(class='active')`|
-|scrollTo(<br>&nbsp;&nbsp;duration=INTEGER,<br>&nbsp;&nbsp;position=STRING<br>)|视口滚动到元素所在位置。<br>参数 `duration` 可选，用于指定动画时间，单位 ms，默认是 0。<br>参数 `position` 可选，只可取 `top`，`center` 或者 `bottom`，用于指定滚动后元素在视口的位置，默认是 `top`。<br>如：`element-id.scrollTo(duration=500, position='center')`|
+|toggleClass({<br>&nbsp;&nbsp;class: STRING,<br>&nbsp;&nbsp;force: BOOLEAN<br>}) |切换元素类名。<br>参数 `force` 可选，如果为 true，则只添加类名。如果为 false，则只移除类名。<br> 如：`element-id.toggleClass({class: 'active'})`|
+|scrollTo({<br>&nbsp;&nbsp;duration: INTEGER,<br>&nbsp;&nbsp;position: STRING<br>})|视口滚动到元素所在位置。<br>参数 `duration` 可选，用于指定动画时间，单位 ms，默认是 0。<br>参数 `position` 可选，只可取 `top`，`center` 或者 `bottom`，用于指定滚动后元素在视口的位置，默认是 `top`。<br>如：`element-id.scrollTo({duration: 500, position: 'center'})`|
 |focus                                      |让元素获得焦点。<br>如：`element-id.focus`|
 
 [notice] 当 MIP 组件自定义方法与全局元素方法重名的情况下，比如 mip-toggle 具有自定义行为 `show` 和 `hide`，此时优先触发组件的自定义方法。
+
+[info] 在参数写法上，我们兼容了 AMP 的语法，因此也可以使用类似 AMP 的书写方式传入参数：`element-id.toggleClass(class='active', force=false)`
 
 下面是全局元素方法的一些例子：
 
@@ -207,7 +209,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 <!-- 无法通过 text2.show 方法显示通过 display: none 定义样式的元素 -->
 <button on="tap:text2.show">无法显示文字</button>
 <!-- 通过 toggleClass 添加或移除 .hide 实现元素的隐藏或显示 -->
-<button on="tap:text2.toggleClass(class='hide')">添加/移除 hidden class</button>
+<button on="tap:text2.toggleClass({class: 'hide'})">添加/移除 hidden class</button>
 <!-- .hide { display: none; } -->
 <p id="text2" class="hide">文字2</p>
 ```
@@ -223,7 +225,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
   <!-- 无法通过 text2.show 方法显示通过 display: none 定义样式的元素 -->
   <button on="tap:text2.show" class="example-button">无法显示文字</button>
   <!-- 通过 toggleClass 添加或移除 .hide 实现元素的隐藏或显示 -->
-  <button on="tap:text2.toggleClass(class='hide')" class="example-button">添加/移除 hidden class</button>
+  <button on="tap:text2.toggleClass({class: 'hide'})" class="example-button">添加/移除 hidden class</button>
   <!-- .hide { display: none; } -->
   <p id="text2" class="hide">文字2</p>
 </div>
@@ -232,7 +234,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 
 ```html
 <!-- 点击滚动到页面底部 -->
-<button on="tap:bootm-button.scrollTo(duration=500, position='center')">点击滚动到底部</button>
+<button on="tap:bootm-button.scrollTo({ duration: 500, position: 'center' })">点击滚动到底部</button>
 ```
 效果如下所示：
 
@@ -240,7 +242,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
   <button id="scroll-button"
     on="tap:
       bottom-example.show,
-      bottom-button.scrollTo(duration=500, position='center')"
+      bottom-button.scrollTo({ duration: 500, position: 'center' })"
     class="example-button">点击滚动到底部</button>
 </div>
 
@@ -271,11 +273,13 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 |行为|描述|
 |---|---|
 |setData({<br>&nbsp;&nbsp;[name]: Expression<br>}) |将数据合并到到全局状态树中，结合数据绑定，写入数据时允许写有限的计算表达式进行运算。<br>更多内容请参考[数据绑定](./data-binding/mip-bind.md)<br>如：`MIP.setData({ a: 1 + 1, b: 'hello' })`|
-|navigateTo(<br>&nbsp;&nbsp;url=STRING,<br>&nbsp;&nbsp;target=STRING,<br>&nbsp;&nbsp;opener=BOOLEAN<br>) |跳转到指定 `url` 页面。<br>参数 `url` 为必填参数，要跳转到的目标页面 URL<br>参数 `target` 为必填参数，只可取 `_top` 或 `_blank`。<br>`opener` 为可选参数，用于指定在 `target=_blank` 时新打开的页面能否访问到 `window.opener`。<br>如：`MIP.navigateTo(url='https://www.baidu.com', target='_blank')`|
-|closeOrNavigateTo(<br>&nbsp;&nbsp;url=STRING, <br>&nbsp;&nbsp;target=STRING,<br>&nbsp;&nbsp;opener=BOOLEAN<br>)|关闭当前页面，如果失败则如 `navigateTo` 跳转。一般用作新打开页面的后退操作。<br>参数说明与示例用法同上。|
-|scrollTo(<br>&nbsp;&nbsp;id=STRING,<br>&nbsp;&nbsp;duration=INTEGER,<br>&nbsp;&nbsp;position=STRING<br>) |视口滚动到 `id` 元素的位置，类似于全局元素方法 `element-id.scrollTo`。<br>参数 `id` 为必填参数，用于指定要滚动到的元素<br>参数 `duration` 为可选参数<br>参数 `position` 为可选参数。|
+|navigateTo({<br>&nbsp;&nbsp;url: STRING,<br>&nbsp;&nbsp;target: STRING,<br>&nbsp;&nbsp;opener: BOOLEAN<br>}) |跳转到指定 `url` 页面。<br>参数 `url` 为必填参数，要跳转到的目标页面 URL<br>参数 `target` 为必填参数，只可取 `_top` 或 `_blank`。<br>`opener` 为可选参数，用于指定在 `target=_blank` 时新打开的页面能否访问到 `window.opener`。<br>如：`MIP.navigateTo({ url: 'https://www.baidu.com', target: '_blank' })`|
+|closeOrNavigateTo({<br>&nbsp;&nbsp;url: STRING, <br>&nbsp;&nbsp;target: STRING,<br>&nbsp;&nbsp;opener: BOOLEAN<br>})|关闭当前页面，如果失败则如 `navigateTo` 跳转。一般用作新打开页面的后退操作。<br>参数说明与示例用法同上。|
+|scrollTo({<br>&nbsp;&nbsp;id: STRING,<br>&nbsp;&nbsp;duration: INTEGER,<br>&nbsp;&nbsp;position: STRING<br>}) |视口滚动到 `id` 元素的位置，类似于全局元素方法 `element-id.scrollTo`。<br>参数 `id` 为必填参数，用于指定要滚动到的元素<br>参数 `duration` 为可选参数<br>参数 `position` 为可选参数。|
 |goBack                                                      |返回上一个页面，效果等同于 `window.history.back()`<br>如：`MIP.goBack`|
 |print                                                       |打开当前页面的打印对话框<br>如：`MIP.print`|
+
+[info] 在参数写法上，我们兼容了 AMP 的语法，因此也可以使用类似 AMP 的书写方式传入参数：`MIP.navigateTo(url='https://www.baidu.com', target='_blank')`
 
 下面是一些 MIP 方法的一些使用示例：
 
@@ -316,14 +320,14 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 需要说明的是，在通常情况下，应优先使用 `<a href="xxx"></a>` 的形式实现页面跳转，因为 a 链的形式更有利于搜索引擎的抓取和分析。
 
 ```html
-<button on="tap:MIP.navigateTo(url='https://www.mipengine.org', target='_blank', opener=true)">在新页面打开 mip 官网</button>
-<button on="tap:MIP.closeOrNavigateTo(url='https://www.mipengine.org', target='_blank', opener=true)">关闭页面或者打开 mip 官网</button>
+<button on="tap:MIP.navigateTo({ url: 'https://www.mipengine.org', target: '_blank', opener: true })">在新页面打开 mip 官网</button>
+<button on="tap:MIP.closeOrNavigateTo({ url: 'https://www.mipengine.org', target: '_blank', opener: true })">关闭页面或者打开 mip 官网</button>
 ```
 效果如下所示：
 
 <div class="example-wrapper">
-  <button class="example-button" on="tap:MIP.navigateTo(url='https://www.mipengine.org', target='_blank', opener=true)">在新页面打开 mip 官网</button>
-  <button class="example-button" on="tap:MIP.closeOrNavigateTo(url='https://www.mipengine.org', target='_blank', opener=true)">关闭页面或者打开 mip 官网</button>
+  <button class="example-button" on="tap:MIP.navigateTo({ url: 'https://www.mipengine.org', target: '_blank', opener: true })">在新页面打开 mip 官网</button>
+  <button class="example-button" on="tap:MIP.closeOrNavigateTo({ url: 'https://www.mipengine.org', target: '_blank', opener: true })">关闭页面或者打开 mip 官网</button>
 
 </div>
 
@@ -331,7 +335,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
 
 
 ```html
-<button on="tap:MIP.scrollTo(id='top-example', duration=500, position='center')">滚动到顶部 id 为 top-button 的按钮处</button>
+<button on="tap:MIP.scrollTo({ id: 'top-example', duration: 500, position: 'center' })">滚动到顶部 id 为 top-button 的按钮处</button>
 ```
 
 效果如下所示：
@@ -342,7 +346,7 @@ MIP 为所有元素（包括普通 HTML 和 MIP 元素）都提供了一些默�
     id="mip-scrollto-button"
     on="tap:
       top-example.show,
-      MIP.scrollTo(id='top-button', duration=500, position='center')"
+      MIP.scrollTo({ id: 'top-button', duration: 500, position: 'center' })"
   >滚动到顶部 id 为 top-button 的按钮处</button>
 </div>
 
@@ -392,11 +396,11 @@ mip-action-macro 主要提供的功能包括：
 <mip-action-macro
   id="macro-id"
   condition="event.url === baidu"
-  on="execute:MIP.navigateTo(url=protocol + event.url, target='_blank')"
+  on="execute:MIP.navigateTo({ url: protocol + event.url, target: '_blank' })"
 ></mip-action-macro>
 
-<button on="tap:macro-id.execute(url=baidu)">点击跳转至百度首页</button>
-<button on="tap:macro-id.execute(url=mipengine)">点击不会发生任何跳转</button>
+<button on="tap:macro-id.execute({ url: baidu })">点击跳转至百度首页</button>
+<button on="tap:macro-id.execute({ url: mipengine })">点击不会发生任何跳转</button>
 ```
 
 效果如下所示：
@@ -416,11 +420,11 @@ mip-action-macro 主要提供的功能包括：
   <mip-action-macro
     id="macro-id"
     condition="event.url === baidu"
-    on="execute:MIP.navigateTo(url=protocol + event.url, target='_blank')"
+    on="execute:MIP.navigateTo({ url: protocol + event.url, target: '_blank' })"
   ></mip-action-macro>
 
-  <button class="example-button" on="tap:macro-id.execute(url=baidu)">点击跳转至百度首页</button>
-  <button class="example-button" on="tap:macro-id.execute(url=mipengine)">点击不会发生任何跳转</button>
+  <button class="example-button" on="tap:macro-id.execute({ url: baidu })">点击跳转至百度首页</button>
+  <button class="example-button" on="tap:macro-id.execute({ url: mipengine })">点击不会发生任何跳转</button>
 
 </div>
 
@@ -431,7 +435,7 @@ mip-action-macro 主要提供的功能包括：
     class="example-button"
     on="tap:
       bottom-example.hide,
-      scroll-button.scrollTo(duration=500, position='center')"
+      scroll-button.scrollTo({ duration: 500, position: 'center' })"
   >点击返回原示例</button>
 </div>
 

--- a/docs/docs/interactive-mip/expression.md
+++ b/docs/docs/interactive-mip/expression.md
@@ -77,7 +77,8 @@ MIP 支持有限的运算符，利用这些运算符的相互组合，基本能�
 |类型|说明|示例|
 |---|----|---|
 |`( expr )`| 分组运算符（小括号） | `1 + (2 - 3)` |
-| `{ attr: vaue }` | 字面量对象 | `{a: 1, b: 2, c: 3 + 4}` |
+| `{ attr: value }` | 字面量对象 | `{a: 1, b: 2, c: 3 + 4}` |
+| `{ [ expr ]: value }` | 可计算属性名的字面量对象 | `{ ['a' + 'bc']: 3 + 4}` |
 | `[ item, item ]` | 字面量数组 | `[2, 1, 3]` |
 |`expr . attr`| 属性运算符（点运算符） | `userInfo.name` |
 |`expr[ expr ]`| 计算属性 | `userInfo['name']` |
@@ -118,7 +119,7 @@ MIP 还支持使用部分原型链方法，比如下面举例的一些常见的�
 |----|----|----|
 |Array|concat <br>filter <br>indexOf <br>join <br>lastIndexOf <br>map <br>reduce <br>slice <br>some <br>every <br>find <br>sort（修改） <br>splice（修改）| 为了提升 MIP 表达式中的数组操作体验，我们修改了 sort 和 splice 方法，这两个方法将不会对原数组造成影响。<br>其中 sort 将返回排序后的新数组；<br>同时 splice 返回进行插入或删除操作之后的新数组。 <br> `// 返回新的对象 [1, 2, 3]` <br> `[2, 1, 3].sort()`<br> `// 返回新的对象 [1, 3]` <br> `[1, 2, 3].splice(1, 1)` <br> `// false` <br> `[1, 2, 3].some(num => num > 4)` <br> |
 |Number|toExponential<br>toFixed<br>toPrecision<br>toString| `// 返回 1.2` <br> `(1.23).toFixed(1)`|
-|String|charAt <br>charCodeAt <br>concat <br>indexOf <br>lastIndexOf <br>slice <br>split <br>substr <br>substring <br>toLowerCase <br>toUpperCase | `// 返回 ['1', '2', '3']` <br> `'123'.split()` |
+|String|charAt <br>charCodeAt <br>concat <br>indexOf <br>lastIndexOf <br>slice <br>split <br>substr <br>substring <br>toLowerCase <br>toUpperCase <br>trim| `// 返回 ['1', '2', '3']` <br> `'123'.split()` |
 
 ## 函数表达式
 
@@ -169,19 +170,4 @@ MIP 还支持使用部分原型链方法，比如下面举例的一些常见的�
 // 错误，MIP 表达式不支持 ++ 运算符
 [1, 2, 3].map(item => item++)
 ```
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/docs/docs/interactive-mip/introduction.md
+++ b/docs/docs/interactive-mip/introduction.md
@@ -41,11 +41,11 @@ MIP 提供了为数众多的官方组件来满足开发者的需求。这些组�
 
 ```html
 <button
-  on="tap:MIP.navigateTo(url='https://www.baidu.com', target='_blank')"
+  on="tap:MIP.navigateTo({url: 'https://www.baidu.com', target: '_blank'})"
 >点击打开百度首页</button>
 
 <button
-  on="tap:bottom-item.scrollTo(duration=500, position='center')"
+  on="tap:bottom-item.scrollTo({duration: 500, position: 'center'})"
 >点击跳转到页面底部</button>
 ```
 
@@ -54,13 +54,13 @@ MIP 提供了为数众多的官方组件来满足开发者的需求。这些组�
 <div class="example-wrapper">
   <button
     class="example-button"
-    on="tap:MIP.navigateTo(url='https://www.baidu.com', target='_blank')"
+    on="tap:MIP.navigateTo({url: 'https://www.baidu.com', target: '_blank'})"
   >点击打开百度首页</button>
 
   <button
     id="scroll-button"
     class="example-button"
-    on="tap:bottom-button.scrollTo(duration=500, position='center')"
+    on="tap:bottom-button.scrollTo({duration: 500, position: 'center'})"
   >点击跳转到页面底部</button>
 </div>
 
@@ -205,10 +205,7 @@ MIP 交互机制旨在提升 MIP 页面的可交互性，在 MIP 核心机制和
   <p>您已滚动至页面底部</p>
   <button class="example-button"
     id="bottom-button"
-    on="tap:scroll-button.scrollTo(duration=1000, position='center')"
+    on="tap:scroll-button.scrollTo({duration: 1000, position: 'center'})"
   >点击滚回原示例</button>
 </div>
-
-
-
 

--- a/packages/mip/src/util/event-action/grammar/basic.js
+++ b/packages/mip/src/util/event-action/grammar/basic.js
@@ -223,10 +223,29 @@ export const $variable = lex.set({
   }
 })
 
+export const $computedProperty = lex.set({
+  type: 'ComputedProperty',
+  rule: () => [
+    $leftBracket,
+    _,
+    $conditional,
+    _,
+    $rightBracket
+  ],
+  match (args) {
+    return {
+      type: 'Member',
+      computed: true,
+      property: args[2]
+    }
+  }
+})
+
 export const $property = lex.set({
   type: 'Property',
   rule: () => [
     [or, [
+      $computedProperty,
       $identifier,
       $string,
       $number
@@ -237,10 +256,23 @@ export const $property = lex.set({
     $conditional
   ],
   match (args) {
-    return {
-      key: args[0],
+    let key = args[0]
+    let result = {
       value: args[4]
     }
+
+    if (key.computed) {
+      result.computed = true
+      result.key = key.property
+    } else {
+      result.key = key
+    }
+
+    return result
+    // return {
+    //   key: args[0],
+    //   value: args[4]
+    // }
   }
 })
 
@@ -308,24 +340,6 @@ export const $primary = lex.set({
     $object,
     $grouping
   ]]
-})
-
-export const $computedProperty = lex.set({
-  type: 'ComputedProperty',
-  rule: () => [
-    $leftBracket,
-    _,
-    $conditional,
-    _,
-    $rightBracket
-  ],
-  match (args) {
-    return {
-      type: 'Member',
-      computed: true,
-      property: args[2]
-    }
-  }
 })
 
 export const $identifierProperty = lex.set({

--- a/packages/mip/src/util/event-action/grammar/event-argument.js
+++ b/packages/mip/src/util/event-action/grammar/event-argument.js
@@ -8,8 +8,6 @@ import {
   or,
   any,
   opt
-  // ,
-  // def
 } from '../../parser/lexer'
 
 import {
@@ -20,6 +18,7 @@ import {
 
 import {
   $conditional,
+  $object,
   $number,
   $literal,
   $variable,
@@ -162,12 +161,23 @@ export const $mipActionOldArguments = lex.set({
   }
 })
 
+export const $mipActionObjectArguments = lex.set({
+  type: 'MIPActionObjectArguments',
+  rule: $object,
+  match (args) {
+    return {
+      arguments: [args]
+    }
+  }
+})
+
 export const $mipActionArguments = lex.set({
   type: 'MIPActionArguments',
   rule: [
     _,
     [opt,
       [or, [
+        $mipActionObjectArguments,
         $mipActionOldArguments,
         $mipActionNewArguments
       ]]

--- a/packages/mip/src/util/event-action/whitelist/basic.js
+++ b/packages/mip/src/util/event-action/whitelist/basic.js
@@ -77,7 +77,8 @@ export const PROTOTYPE = {
     substr: String.prototype.substr,
     substring: String.prototype.substring,
     toLowerCase: String.prototype.toLowerCase,
-    toUpperCase: String.prototype.toUpperCase
+    toUpperCase: String.prototype.toUpperCase,
+    trim: String.prototype.trim
   }
 }
 

--- a/packages/mip/test/specs/util/parser/basic.spec.js
+++ b/packages/mip/test/specs/util/parser/basic.spec.js
@@ -207,7 +207,7 @@ describe('Test Grammar', function () {
   describe('Test Object', function () {
     let fn = (walker) => run(walker, lexer.$object)
 
-    it('should be equal', function () {
+    it('Computed Value', function () {
       let str = `{
         a: 1,
         '$asdf'   : 1 + (2 - 3) * 4
@@ -219,11 +219,24 @@ describe('Test Grammar', function () {
       expect(result.properties[1].key.value).to.be.equal('$asdf')
     })
 
-    it('should be equal', function () {
+    it('Empty Value', function () {
       let str = `{}`
       let walker = new Walker(str)
       let result = fn(walker)
       expect(result.properties).to.be.deep.equal([])
+    })
+
+    it('Computed Key', function () {
+      let str = `{
+        abc: 123,
+        ['a' + 'cd']: true ? 2 : 3,
+        [3 -2]: 12345
+      }`
+      let walker = new Walker(str)
+      let result = fn(walker)
+      expect(result.properties.length).to.be.equal(3)
+      expect(result.properties[1].key.type).to.be.equal('Binary')
+      expect(result.properties[2].key.type).to.be.equal('Binary')
     })
   })
 

--- a/packages/mip/test/specs/util/parser/event-argument.spec.js
+++ b/packages/mip/test/specs/util/parser/event-argument.spec.js
@@ -29,6 +29,20 @@ describe('MIP Argument', () => {
       expect(ast.arguments[0].properties[2].value.value).to.be.equal('this is a string with \" and \'\' ')
     })
 
+    it('Object Argument Expression', () => {
+      let str = `{
+        abc: 1,
+        def: null,
+        someStr: \"this is a string with \\\" and '' \",
+        useEvent: event.a
+      }`
+      let ast = fn(str)
+      expect(ast.arguments[0].properties.length).to.be.equal(4)
+      expect(ast.arguments[0].properties[3].value.type).to.be.equal('Member')
+      expect(ast.arguments[0].properties[2].value.value).to.be.equal('this is a string with \" and \'\' ')
+    })
+
+
     it('Old Argument Expression', () => {
       let str = `123,
         null,

--- a/packages/mip/test/specs/util/parser/parse.spec.js
+++ b/packages/mip/test/specs/util/parser/parse.spec.js
@@ -33,6 +33,12 @@ describe('parser', () => {
       expect(result).to.be.equal(false)
     })
 
+    it('Computed Object Name', function () {
+      const str = `{[1 + 2]: 3 + 4, [1 + '2']: 5 + 6, '7': 8}`
+      let fn = parser.transform(str, 'ObjectLiteral')
+      let result = fn()
+      expect(result).to.be.deep.equal({'3': 7, '12': 11, '7': 8})
+    })
     it('Sort Array', function () {
       const str = `[3,1,4,1,5].sort()`
       let fn = parser.transform(str, 'Conditional')
@@ -221,6 +227,43 @@ describe('parser', () => {
   })
 
   describe('MIPAction', () => {
+    it('Object style', () => {
+      const str = `{a : -12345.6,b : event.data,c : DOM.dataset.value}`
+      let fn = parser.transform(str, 'MIPActionArguments')
+      let result = fn({
+        event: {
+          data: '\'"'
+        },
+        target: {
+          dataset: {
+            value: -3456.7
+          }
+        }
+      })
+      // console.log(result)
+      expect(result[0].a).to.be.equal(-12345.6)
+      expect(result[0].b).to.be.equal('\'"')
+      expect(result[0].c).to.be.equal(-3456.7)
+    })
+
+    it('Object Style With Expression', () => {
+      const str = `{a: 1 + 2 + 3, b:( 2 *event.data), c:((DOM.dataset.value/event.data))}`
+      let fn = parser.transform(str, 'MIPActionArguments')
+      let result = fn({
+        event: {
+          data: 100
+        },
+        target: {
+          dataset: {
+            value: -10
+          }
+        }
+      })
+      expect(result[0].a).to.be.equal(6)
+      expect(result[0].b).to.be.equal(200)
+      expect(result[0].c).to.be.equal(-0.1)
+    })
+
     it('new style', () => {
       const str = `a = -12345.6,b = event.data,c = DOM.dataset.value`
       let fn = parser.transform(str, 'MIPActionArguments')
@@ -257,6 +300,7 @@ describe('parser', () => {
       expect(result[0].b).to.be.equal(200)
       expect(result[0].c).to.be.equal(-0.1)
     })
+
 
     it('old style', () => {
 


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#679 
**1、升级点** （清晰准确的描述升级的功能点）
1. MIP.scrollTo/ MIP.navigateTo 等方法参数支持 Plain Object 的形式，并修改文档优先推荐这种写法，即从 `MIP.navigateTo(url='xxx', target='_blank')` 的写法优先推荐采用 `MIP.navigateTo({ url: 'xxx', target: '_blank' })`；
2. 新增 String.prototype.trim；
3. 新增 Plain Object 计算属性 `{[1 + '2']: 3}`；

**2、影响范围** （描述该需求上线会影响什么功能）
新增逻辑，对线上无影响

**3、自测 Checklist**

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
