### PR TITLE
迁移 BOS 图片地址

### DIFF
--- a/docs/api/global/mip-shell.md
+++ b/docs/api/global/mip-shell.md
@@ -8,7 +8,7 @@
 
 * 除了头部，还有底部栏或者侧边栏需要额外渲染和绑定事件。例如下图：
 
-    ![Bottom Shell](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/bottom-shell-2.png)
+    ![Bottom Shell](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/bottom-shell-2.png)
 
 * 开发者需要控制站点的 Shell 配置，修改/禁用/忽略某些选项。
 
@@ -28,7 +28,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
 
 个性化 Shell 的编写规范和普通组件相同，同样在 mip2-extensions 项目中编写，如下：
 
-![MIP Shell Folder](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/page/mip-shell-folder.PNG)
+![MIP Shell Folder](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/page/mip-shell-folder.PNG)
 
 ## 使用个性化 Shell
 
@@ -45,7 +45,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
                        "header": {
                             "show": true,
                             "title": "MIP Index",
-                            "logo": "https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg"
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg"
                         },
                     }
                 }
@@ -90,7 +90,7 @@ constructor (...args) {
 
 MIP Shell 的头部标题栏右侧的按钮区域会根据 MIP 页面当前所处的状态来决定是否展示关闭按钮。当处于百度搜索结果页中（即拥有 SuperFrame 环境时）会额外渲染一个关闭按钮，点击效果用以通知 SuperFrame 关闭自身，如下图所示：
 
-![Close Button](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/close-button.png)
+![Close Button](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/close-button.png)
 
 MIP 页面判断当前是否处于 SuperFrame 环境的判断依据是 `window.MIP.standalone` 值等于 `false`。
 
@@ -180,7 +180,7 @@ MIP Shell 进行的所谓“初步处理”包括：
     setTimeout(() => {
       // 通过 exampleUserId 获取到目标用户的标题和 LOGO，并固定按钮
       shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-      shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+      shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
       shellConfig.routes[0].meta.header.buttonGroup = [
         {
           name: 'share',
@@ -343,7 +343,7 @@ afterSwitchPage(options) {
         console.log('Simulate async request with isId:', isId)
         setTimeout(() => {
           shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-          shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+          shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
           shellConfig.routes[0].meta.header.buttonGroup = [
             {
               name: 'share',

--- a/docs/codelabs/all-sites-mip/create-a-link.md
+++ b/docs/codelabs/all-sites-mip/create-a-link.md
@@ -64,4 +64,4 @@ MIP 页面的链接采用和标准 HTML 相同的 `<a>` 标签，但进行了一
 
 点击 `index.html` 的下一页按钮，我们可以看到 `second.html` 以动画的形式流畅地侧滑进入屏幕，页面并没有常规的白屏，体验和单页应用完全相同。
 
-![切换效果](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/transition-forward.png)
+![切换效果](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/transition-forward.png)

--- a/docs/codelabs/all-sites-mip/create-a-page.md
+++ b/docs/codelabs/all-sites-mip/create-a-page.md
@@ -38,7 +38,7 @@ MIP 提供了一些很常用的组件，称为 “内置组件”，常用的如
 <body>
   <h2>这是我的第一个 MIP 页面</h2>
 
-  <mip-img src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
+  <mip-img src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
 
   <p>MIP 全称为 Mobile Instant Pages，因此是以页面 (Page) 为单位来运行的。开发者通过改造/提交一个个页面，继而被百度收录并展示。 </p>
   <p>但以页面为单位会带来一个问题：当一个 MIP 页面中存在往其他页面跳转的链接时，就会使浏览器使用加载页面的默认行为来加载新页面。这“第二跳”的体验比起从搜索结果页到 MIP 页面的“第一跳”来说相去甚远。 </p>
@@ -96,4 +96,4 @@ __注意__： `<style mip-custom>` 整个页面只能使用一次，不要遗漏
 
 至此一个独立的 MIP 页面已经完成了。我们可以使用一个静态服务器 (例如 [static-server](https://www.npmjs.com/package/static-server)) 来启动并通过浏览器访问这个 HTML 文件。预览效果如下：
 
-![use-shell](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/use-shell.png)
+![use-shell](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/use-shell.png)

--- a/docs/codelabs/all-sites-mip/create-shell.md
+++ b/docs/codelabs/all-sites-mip/create-shell.md
@@ -75,18 +75,18 @@
 
 我们已经成功地为我们的两个页面添加了头部标题栏。打开 `index.html` 可以看到效果（虽然样式颇为简陋）：
 
-![带 Shell 的示例](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/use-shell-2.png)
+![带 Shell 的示例](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/use-shell-2.png)
 
 注意到右上角的三个点，点击之后可以展现更多按钮，即我们配置过的“关注”和“发消息”（还包含一个动画效果）：
 
-![带 Shell 的示例下拉](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/use-shell-3.png)
+![带 Shell 的示例下拉](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/use-shell-3.png)
 
 最后我们看一下页面的切换效果。在切换到第二页时，因为 Shell 独立于页面之外且配置完整，因此头部标题可以直接出现在目标页面加载之前，大大提升了体验：
 
-![带 Shell 的前进切换](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/transition-forward-2.png)
+![带 Shell 的前进切换](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/transition-forward-2.png)
 
 页面后退和前进时的动画略有不同：前进时需要载入目标页面，因此需要 loading；而后退的目标页面已经存在，因此可以直接展现，效果更好：
 
-![带 Shell 的后退切换](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/transition-backward.png)
+![带 Shell 的后退切换](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/transition-backward.png)
 
 您可以启动静态服务器自己体验一下动态的效果，和普通的浏览器切换页面相比在体验上可以说是天壤之别！

--- a/docs/codelabs/all-sites-mip/sample-code.md
+++ b/docs/codelabs/all-sites-mip/sample-code.md
@@ -44,7 +44,7 @@
   <body>
     <h2>这是我的第一个 MIP 页面</h2>
 
-    <mip-img src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
+    <mip-img src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
 
     <p>MIP 全称为 Mobile Instant Pages，因此是以页面 (Page) 为单位来运行的。开发者通过改造/提交一个个页面，继而被百度收录并展示。 </p>
     <p>但以页面为单位会带来一个问题：当一个 MIP 页面中存在往其他页面跳转的链接时，就会使浏览器使用加载页面的默认行为来加载新页面。这“第二跳”的体验比起从搜索结果页到 MIP 页面的“第一跳”来说相去甚远。 </p>

--- a/docs/codelabs/customize-shell/introduction.md
+++ b/docs/codelabs/customize-shell/introduction.md
@@ -8,7 +8,7 @@ MIP Shell 可以帮助开发者把多个单独的 MIP 页面串联起来，形�
 
 * 除了头部，还有底部栏或者侧边栏需要额外渲染和绑定事件。例如下图：
 
-    ![Bottom Shell](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/bottom-shell-2.png)
+    ![Bottom Shell](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/bottom-shell-2.png)
 
 * 开发者需要控制站点的 Shell 配置，修改/禁用/忽略某些选项。
 

--- a/docs/codelabs/mip-started/prepare.md
+++ b/docs/codelabs/mip-started/prepare.md
@@ -20,7 +20,7 @@
     mip2 init
     ```
 
-    ![mip2 init](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/mip-init0.jpg)
+    ![mip2 init](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/mip-init0.jpg)
 
 3. 进入目录并启动开发服务器
 
@@ -28,10 +28,10 @@
     mip2 dev
     ```
 
-    ![mip2 dev](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/mip-dev0.jpg)
+    ![mip2 dev](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/mip-dev0.jpg)
 
 4. 访问 `http://127.0.0.1:8111/example/index.html` 将看到初始 `example` 示例页面
 
-    ![example Page](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/home-init.png)
+    ![example Page](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/home-init.png)
 
 > 下一节我们会学习初始化的项目的文件结构及 MIP 页面的内容结构及开发方式。

--- a/docs/codelabs/mip-started/project.md
+++ b/docs/codelabs/mip-started/project.md
@@ -4,7 +4,7 @@
 
 1. 初始化项目结构
 
-    ![myproject](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/project.jpg)
+    ![myproject](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/project.jpg)
 
 
 2. 如下图所示，初始化项目的预览页面 `example/index.html` 中给出了 MIP 页面的一个最基本的格式。

--- a/docs/codelabs/mip-started/validate.md
+++ b/docs/codelabs/mip-started/validate.md
@@ -8,7 +8,7 @@ MIP 开发工具还提供了页面规范的校验工具，来帮助开发者快�
 	$ mip2 validate -p example/index.html
 	```
 
-    ![validate0](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/validate0.png)
+    ![validate0](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/validate0.png)
 
 	> 可以看到，出现了校验失败的结果，它提示我们需要将带有 canonical 属性的 link 指向原页面，并且将 mip-example.js 的引用地址替换成线上CDN（前提是已经提交上线了），诸如此类，只需按照提示进行相应的微调即可。
 
@@ -19,7 +19,7 @@ MIP 开发工具还提供了页面规范的校验工具，来帮助开发者快�
 	$ mip2 validate -c ./componets
 	```
 
-	![validate1](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/validate1.jpg)
+	![validate1](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/validate1.jpg)
 
 3. 代码格式校验，安装依赖，代码必须遵守 JavaScript Standard Style [[CN](https://standardjs.com/rules-zhcn.html)/[EN](https://standardjs.com/rules-en.html)] 规范
 

--- a/docs/components/builtin/mip-carousel.md
+++ b/docs/components/builtin/mip-carousel.md
@@ -21,19 +21,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 </mip-carousel>
 ```
@@ -50,19 +50,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 
 </mip-carousel>
@@ -81,19 +81,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 
 </mip-carousel>
@@ -114,19 +114,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 
 </mip-carousel>
@@ -148,19 +148,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 
 </mip-carousel>
@@ -188,19 +188,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 
 </mip-carousel>
@@ -220,7 +220,7 @@
     >
     <a target="_blank" href="http://wenda.tianya.cn/m/question/1almfj0foas94gc7vtoq6ejbfbmdk3e78ehaa">
         <mip-img
-            src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg" layout="responsive"
+            src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg" layout="responsive"
         width="720"
         height="405">
         </mip-img>
@@ -230,13 +230,13 @@
         layout="responsive"
         width=720
         height=405
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         layput="responsive"
         width=720
         height=405
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 </mip-carousel>
 ```
@@ -256,18 +256,18 @@
         layout="responsive"
         width=720
         height=405
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <a target="_blank" href="http://wenda.tianya.cn/m/question/1almfj0foas94gc7vtoq6ejbfbmdk3e78ehaa">
         <mip-img
-            src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg" width="720" height="405" layout="responsive">
+            src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg" width="720" height="405" layout="responsive">
         </mip-img>
     </a>
     <mip-img
         layout="responsive"
         width=720
         height=405
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 </mip-carousel>
 ```
@@ -284,19 +284,19 @@
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg">
     </mip-img>
     <mip-img
         width="720"
         height="405"
         layout="responsive"
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 </mip-carousel>
 <div>
@@ -322,15 +322,15 @@
     on="switchCompleted:MIP.setData({ index: event.currIndex })"
     >
     <mip-img
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-01.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-01.jpg">
     </mip-img>
     <a target="_blank" href="http://wenda.tianya.cn/m/question/1almfj0foas94gc7vtoq6ejbfbmdk3e78ehaa">
         <mip-img
-            src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-02.jpg" width="720" height="405" layout="responsive">
+            src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-02.jpg" width="720" height="405" layout="responsive">
         </mip-img>
     </a>
     <mip-img
-        src="http://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/static/example-03.jpg">
+        src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/static/example-03.jpg">
     </mip-img>
 </mip-carousel>
 <div m-text="'当前显示的图片 index: ' + index"></div>

--- a/docs/components/builtin/mip-shell.md
+++ b/docs/components/builtin/mip-shell.md
@@ -6,7 +6,7 @@
 
 一个最典型的 Shell 的例子就是头部标题栏：
 
-![头部标题栏](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/mip-shell.png)
+![头部标题栏](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/mip-shell.png)
 
 ## 内置 MIP Shell
 
@@ -123,14 +123,14 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
 
     配置头部中间的标题，这部分将显示在头部标题栏中，超长会自动截断。
 
-    ![MIP Shell header title](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-title-2.png)
+    ![MIP Shell header title](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-title-2.png)
 
 * header.logo
     __string__, 默认值：无
 
     配置头部左侧的 LOGO 的 URL，建议是一个正方形的图片，长宽不小于 64px。如果不配置则不显示 LOGO。
 
-    ![MIP Shell header logo](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-logo-2.png)
+    ![MIP Shell header logo](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-logo-2.png)
 
 * header.color
     __string__, 默认值：'#000000'
@@ -154,11 +154,11 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
 
     右侧的关闭按钮在百度搜索结果页中会自动展现，单独打开时不展现，不需要额外配置。
 
-    ![MIP Shell header button](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-button-2.png)
+    ![MIP Shell header button](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-button-2.png)
 
     点开“更多”按钮，会出现浮层展现 `buttonGroup` 中配置的按钮，效果如下：
 
-    ![Drop Down](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/dropdown-2.png)
+    ![Drop Down](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/dropdown-2.png)
 
     每一个配置对象由 3 个属性构成，分别是 `name`, `text` 和 `link`。这三个配置项均 __没有__ 默认值，如果缺少某个则被认为非法配置，__会被跳过而不进行渲染__。
 
@@ -195,7 +195,7 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
                        "header": {
                             "show": true,
                             "title": "MIP Index",
-                            "logo": "https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg",
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg",
                             "buttonGroup": [
                                 {
                                     "name": "subscribe",
@@ -302,7 +302,7 @@ MIP 页面总共有 4 处可以配置头部标题，它们的生效顺序依次�
 
 * 除了头部，还有底部栏或者侧边栏需要额外渲染和绑定事件。例如下图：
 
-    ![Bottom Shell](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/bottom-shell-2.png)
+    ![Bottom Shell](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/bottom-shell-2.png)
 
 * 开发者需要控制站点的 Shell 配置，修改/禁用/忽略某些选项。
 
@@ -322,7 +322,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
 
 个性化 Shell 的编写规范和普通组件相同，同样在 mip2-extensions 项目中编写，如下：
 
-![MIP Shell Folder](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/page/mip-shell-folder.PNG)
+![MIP Shell Folder](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/page/mip-shell-folder.PNG)
 
 ### 使用个性化 Shell
 
@@ -339,7 +339,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
                        "header": {
                             "show": true,
                             "title": "MIP Index",
-                            "logo": "https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg"
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg"
                         },
                     }
                 }
@@ -384,7 +384,7 @@ constructor (...args) {
 
 MIP Shell 的头部标题栏右侧的按钮区域会根据 MIP 页面当前所处的状态来决定是否展示关闭按钮。当处于百度搜索结果页中（即拥有 SuperFrame 环境时）会额外渲染一个关闭按钮，点击效果用以通知 SuperFrame 关闭自身，如下图所示：
 
-![Close Button](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/close-button.png)
+![Close Button](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/close-button.png)
 
 MIP 页面判断当前是否处于 SuperFrame 环境的判断依据是 `window.MIP.standalone` 值等于 `false`。
 
@@ -474,7 +474,7 @@ MIP Shell 进行的所谓“初步处理”包括：
     setTimeout(() => {
       // 通过 exampleUserId 获取到目标用户的标题和 LOGO，并固定按钮
       shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-      shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+      shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
       shellConfig.routes[0].meta.header.buttonGroup = [
         {
           name: 'share',
@@ -680,7 +680,7 @@ MIP Shell 基类的动画切换逻辑实现方法。但子类如有需要也可�
         console.log('Simulate async request with isId:', isId)
         setTimeout(() => {
           shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-          shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+          shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
           shellConfig.routes[0].meta.header.buttonGroup = [
             {
               name: 'share',

--- a/docs/contribute/debug/mip-dev.md
+++ b/docs/contribute/debug/mip-dev.md
@@ -18,21 +18,21 @@ mip2 dev
 
 在启动调试服务器前，首先会检查当前最新的 MIP CLI 版本，当前版本过老时，会在命令行窗口打印如下提示：
 
-![版本过低提示](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/docs/too-old-a9fcbcba.png)
+![版本过低提示](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/docs/too-old-a9fcbcba.png)
 
 开发者在看到这个版本过低的提示时，建议最好顺手将 CLI 工具升级一下，因为组件在提交上线的时候会拉最新版本的 MIP CLI 进行代码编译，保持 CLI 工具为最新版本能够保证开发与编译上线时组件代码的一致性。
 
 调试服务器启动完成，命令行窗口会打印如下提示：
 
-![命令行启动完毕](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/docs/mip2-dev-start-6b55f270.png)
+![命令行启动完毕](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/docs/mip2-dev-start-6b55f270.png)
 
 默认参数条件下启动调试服务器，默认监听的 8111 端口，在浏览器访问 `127.0.0.1:8111` 可以直接在页面上访问到组件仓库目录，如下图所示：
 
-![组件目录预览](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/docs/localhost-look-26156466.png)
+![组件目录预览](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/docs/localhost-look-26156466.png)
 
 可以通过点击对应的目录打开组件示例进行功能预览和调试，比如点击 components - mip-accordion - example - mip-accordion1.html，就可以打开对应的示例页面：
 
-![组件示例](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/docs/accordion-example-621d3e09.png)
+![组件示例](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/docs/accordion-example-621d3e09.png)
 
 如果组件开发者需要在实际的网站项目里面调试 MIP 组件，那么只需要在网站项目生成的 HTML 页面底部通过增加以下 script 标签引入：
 

--- a/docs/contribute/development/component-syntax.md
+++ b/docs/contribute/development/component-syntax.md
@@ -60,7 +60,7 @@ export default class MIPExample extends MIP.CustomElement {
 
 接下来，在命令行通过 `mip2 dev` 启动调试服务器（启动前可能需要在组件仓库根目录执行 `npm install` 安装依赖），启动完成后访问 `http://127.0.0.1:8111/components/mip-example/example/index.html` 即可查看对应的网页：
 
-![hello world](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-hello-world-ac8ff645.png)
+![hello world](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-hello-world-ac8ff645.png)
 
 可以看到页面显示了 "Hello World" 这样的单词，这正是 `mip-example` 这个组件所生成显示的。
 
@@ -89,7 +89,7 @@ export default class MIPExample extends MIP.CustomElement {
 
 刷新网页，可以看到 "Hello World" 显示为红色，并且居中显示了：
 
-![add style](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-hello-word-red-841deef3.png)
+![add style](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-hello-word-red-841deef3.png)
 
 需要注意的是，在进行样式开发的时候，要求以 mip 组件标签名作为样式的作用域限制条件，比如使用 css 开发，上面的样式需要写成：
 
@@ -144,7 +144,7 @@ export default class MIPExample extends MIP.CustomElement {
 
 刷新页面可以看到页面上显示了 "Hello lilei"：
 
-![Hello LiLei](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-hello-lilei-78527e0f.png)
+![Hello LiLei](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-hello-lilei-78527e0f.png)
 
 我们可以在 example/index.html 将属性值修改成别的内容进行调试。需要注意的是，通过 `this.element.getAttribute()` 方法拿到的属性类型都是字符串，开发者需要根据实际要求的数据类型手动进行转换。
 
@@ -281,7 +281,7 @@ export default class MIPExample extends MIP.CustomElement {
 
 这样在点击了页面上的按钮之后，页面上将显示 "你好"。
 
-![nihao](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-nihao-a51cc751.png)
+![nihao](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-nihao-a51cc751.png)
 
 如果 `on="tap:example.say('你', '好')"`，那么点击按钮后页面上显示的则是 `'你', '好'`，即括号内的全部字符串内容，开发者可以根据实际组件的需求对这个字符串进行手动解析。
 
@@ -321,7 +321,7 @@ export default class MIPExample extends MIP.CustomElement {
 
 在 `mip-example` 的标签对内部手动添加了一个 `class` 为 content 的 div 标签。刷新网页可以看到页面显示效果如下：
 
-![](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-slot-22ec5732.png)
+![](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-slot-22ec5732.png)
 
 可以看到无论是 div 还是 p 标签里面的内容都被添加上了序号，因此开发者可以采用类似的方法来对组件内容进行调整操作。
 

--- a/docs/contribute/development/resources-management.md
+++ b/docs/contribute/development/resources-management.md
@@ -70,7 +70,7 @@ import _ from 'lodash'
 
 MIP 必须严格把控组件编写质量，因此也需要对第三方库的使用采用白名单的方式进行限制，只有经过 MIP 认可的第三方库才能够安装使用。在通过 MIP CLI 启动开发模式的情况下，CLI 工具会动态监听 package.json 文件的改动并且判断当前使用的第三方库是否在白名单中，如果不存在，则会在控制台打印 WARNING 进行提示，如下图所示（假设开发者安装了一个名叫 `the-answer` 的第三方库）：
 
-![npm whitelist warning](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/docs/the-answer-a29a059f.png)
+![npm whitelist warning](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/docs/the-answer-a29a059f.png)
 
 这时组件开发者需要考虑更换符合要求的第三方库或者是向 MIP 工作组提交 npm 白名单申请，申请的地址为：[https://github.com/mipengine/mip2/issues/new?template=npm_whiltelist_request.md](https://github.com/mipengine/mip2/issues/new?template=npm_whiltelist_request.md)，开发者需要按照格式填写相应内容并且说明清楚该 npm 包的必要性。
 

--- a/docs/contribute/development/writing-mip-component-in-vue-style.md
+++ b/docs/contribute/development/writing-mip-component-in-vue-style.md
@@ -34,7 +34,7 @@ export default {
 
 使用 Vue 单文件写法开发 MIP 组件与普通的 Vue 组件存在着一定区别，区别之一就是组件的生命周期。MIP 组件扩展了 Vue 组件的生命周期钩子，同时限制了部分 CustomElement 生命周期钩子，生命周期示意图如下所示：
 
-![mip2 组件生命周期](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/mip2-component-lifecycle.png)
+![mip2 组件生命周期](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png)
 
 > 由于 vue 组件实例化比较消耗性能，所以 mip 对 vue 组件做了延迟实例化，只有组件执行 firstInviewCallback 后才会执行组件的实例化。如果需要强制组件在初始化时执行 vue 组件实例化，需要通过声明 prerenderAllowed() 为 true 实现。
 

--- a/docs/contribute/getting-start/contribute-with-mip-platform.md
+++ b/docs/contribute/getting-start/contribute-with-mip-platform.md
@@ -58,7 +58,7 @@ zip -r test.a.com.zip test.a.com/
 
 提交代码跟原来步骤一样，打开 [MIP 组件审核平台 - 我的组件](https://www.mipengine.org/platform/mip)，点击“上传组件”按钮，将上一步打包好的文件进行上传即可。
 
-![上传组件](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/docs/contribute/mip-upload-code.png)
+![上传组件](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/contribute/mip-upload-code.png)
 
 上传完成之后会在“我的组件”条目多出当前提交的站点，点击提交审核，站长平台会自动发起 GitHub 的 PR，接下来就能够点击查看相应的 PR 查看代码审核意见了。与原先一样，当 PR 要求修改或者被打回时，站长组件平台的站点条目会显示“需修改”或者已打回，站长需要根据修改意见重新修改代码并重新打包提交。在组件状态为“需修改”的情况下，如果对审核意见有异议的话，可以点击链接到相应的评论下面添加留言（这步要求站长有 GitHub 账号）。
 

--- a/docs/contribute/getting-start/how-to-contribute-mip-extensions.md
+++ b/docs/contribute/getting-start/how-to-contribute-mip-extensions.md
@@ -28,7 +28,7 @@ $ git clone https://github.com/your-username/mip2-extensions.git
 
 `git clone` 出来的项目结构与 `mip2 init` 命令初始化的项目结构类似，我们可以在根目录使用 `mip2 add` 命令新增组件。
 
-![](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-add-3eef75e8.png)
+![](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-add-3eef75e8.png)
 
 根据 `mip2 add` 的命令提示，我们可以通过以下命令来增加一个叫 `mip-example` 的组件开发目录：
 

--- a/docs/contribute/getting-start/how-to-contribute.md
+++ b/docs/contribute/getting-start/how-to-contribute.md
@@ -68,7 +68,7 @@ $ mip2 init
 
 按照提示输入项目名称，如 `test.a.com`，新增了一个站点项目。
 
-![init 示例](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-init-a81dcd37.png)
+![init 示例](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-init-a81dcd37.png)
 
 ```bash
 $ cd test.a.com

--- a/docs/contribute/getting-start/mip-cli-usage.md
+++ b/docs/contribute/getting-start/mip-cli-usage.md
@@ -19,7 +19,7 @@ $ npm install -g mip2
 
 输入 `mip2 -V`，若能正常显示版本号，说明已经安装成功。在使用 mip2 CLI 工具输入命令时，比如 `mip2 dev`、`mip2 build` 等等，会首先检查当前安装的 CLI 版本，如果存在新版本，则会在命令行提示升级：
 
-![mip2 update toast](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/cli/mip2-update-58f7edba.png)
+![mip2 update toast](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/cli/mip2-update-58f7edba.png)
 
 建议开发者保持本地安装的 CLI 为最新版本，因为线上的 MIP 组件总是会拿最新版本的 CLI 工具进行编译，因此最好能够保持开发编译环境和线上编译环境的一致性。
 

--- a/docs/contribute/principle/instance-life-cycle.md
+++ b/docs/contribute/principle/instance-life-cycle.md
@@ -74,4 +74,4 @@
 
 下图是 MIP 组件实例的生命周期的示意图，展示了每个生命周期钩子的执行时机。
 
-![MIP 组件生命周期](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/docs/lifecycle-d543b674.png)
+![MIP 组件生命周期](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/docs/lifecycle-d543b674.png)

--- a/docs/docs/all-sites-mip/mip-shell.md
+++ b/docs/docs/all-sites-mip/mip-shell.md
@@ -6,7 +6,7 @@
 
 一个最典型的 Shell 的例子就是头部标题栏：
 
-![头部标题栏](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/mip-shell.png)
+![头部标题栏](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/mip-shell.png)
 
 ## 内置 MIP Shell
 
@@ -123,14 +123,14 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
 
     配置头部中间的标题，这部分将显示在头部标题栏中，超长会自动截断。
 
-    ![MIP Shell header title](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-title-2.png)
+    ![MIP Shell header title](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-title-2.png)
 
 * header.logo
     __string__, 默认值：无
 
     配置头部左侧的 LOGO 的 URL，建议是一个正方形的图片，长宽不小于 64px。如果不配置则不显示 LOGO。
 
-    ![MIP Shell header logo](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-logo-2.png)
+    ![MIP Shell header logo](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-logo-2.png)
 
 * header.color
     __string__, 默认值：'#000000'
@@ -154,11 +154,11 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
 
     右侧的关闭按钮在百度搜索结果页中会自动展现，单独打开时不展现，不需要额外配置。
 
-    ![MIP Shell header button](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/mip-button-2.png)
+    ![MIP Shell header button](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/mip-button-2.png)
 
     点开“更多”按钮，会出现浮层展现 `buttonGroup` 中配置的按钮，效果如下：
 
-    ![Drop Down](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/dropdown-2.png)
+    ![Drop Down](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/dropdown-2.png)
 
     每一个配置对象由 3 个属性构成，分别是 `name`, `text` 和 `link`。这三个配置项均 __没有__ 默认值，如果缺少某个则被认为非法配置，__会被跳过而不进行渲染__。
 
@@ -195,7 +195,7 @@ Shell 最基本的配置中必须包含 `routes` 数组。其中的每个元素�
                        "header": {
                             "show": true,
                             "title": "MIP Index",
-                            "logo": "https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg",
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg",
                             "buttonGroup": [
                                 {
                                     "name": "subscribe",
@@ -302,7 +302,7 @@ MIP 页面总共有 4 处可以配置头部标题，它们的生效顺序依次�
 
 * 除了头部，还有底部栏或者侧边栏需要额外渲染和绑定事件。例如下图：
 
-    ![Bottom Shell](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/bottom-shell-2.png)
+    ![Bottom Shell](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/bottom-shell-2.png)
 
 * 开发者需要控制站点的 Shell 配置，修改/禁用/忽略某些选项。
 
@@ -322,7 +322,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
 
 个性化 Shell 的编写规范和普通组件相同，同样在 mip2-extensions 项目中编写，如下：
 
-![MIP Shell Folder](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/page/mip-shell-folder.PNG)
+![MIP Shell Folder](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/page/mip-shell-folder.PNG)
 
 ### 使用个性化 Shell
 
@@ -339,7 +339,7 @@ export default class MIPShellExample extends window.MIP.builtinComponents.MIPShe
                        "header": {
                             "show": true,
                             "title": "MIP Index",
-                            "logo": "https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/codelab/shell/mashroom.jpg"
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg"
                         },
                     }
                 }
@@ -395,7 +395,7 @@ constructor (...args) {
 
 MIP Shell 的头部标题栏右侧的按钮区域会根据 MIP 页面当前所处的状态来决定是否展示关闭按钮。当处于百度搜索结果页中（即拥有 SuperFrame 环境时）会额外渲染一个关闭按钮，点击效果用以通知 SuperFrame 关闭自身，如下图所示：
 
-![Close Button](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/close-button.png)
+![Close Button](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/close-button.png)
 
 MIP 页面判断当前是否处于 SuperFrame 环境的判断依据是 `window.MIP.standalone` 值等于 `false`。
 
@@ -485,7 +485,7 @@ MIP Shell 进行的所谓“初步处理”包括：
     setTimeout(() => {
       // 通过 exampleUserId 获取到目标用户的标题和 LOGO，并固定按钮
       shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-      shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+      shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
       shellConfig.routes[0].meta.header.buttonGroup = [
         {
           name: 'share',
@@ -679,7 +679,7 @@ afterSwitchPage(options) {
         console.log('Simulate async request with isId:', isId)
         setTimeout(() => {
           shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-          shellConfig.routes[0].meta.header.logo = 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/lanxiniu/logo.png'
+          shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
           shellConfig.routes[0].meta.header.buttonGroup = [
             {
               name: 'share',

--- a/docs/docs/all-sites-mip/page-api.md
+++ b/docs/docs/all-sites-mip/page-api.md
@@ -25,7 +25,7 @@ if (isRootPage) {
 
 如果页面需要展现全页面级别的遮罩层（如弹出对话框时），因为 iframe 的关系，并不能遮挡头部，如下图左边所示。
 
-![Page Mask](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/page-mask-2.png)
+![Page Mask](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/page-mask-2.png)
 
 而调用 `togglePageMask` 方法可以就通知 Page 把头部也进行遮挡，从而完成全页面的遮罩，如上图右边所示。
 
@@ -47,7 +47,7 @@ window.MIP.viewer.page.togglePageMask(true, {skipTransition: true})
 
 展现/隐藏“更多”按钮的浮层。效果如图：
 
-![Drop Down](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip2/page/dropdown-2.png)
+![Drop Down](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/page/dropdown-2.png)
 
 这个方法接收一个参数，具体如下：
 

--- a/docs/docs/assistant-development-tools/mip-sf.md
+++ b/docs/docs/assistant-development-tools/mip-sf.md
@@ -22,7 +22,7 @@ MIP 页面在上线到搜索结果页之后，需要嵌入在 SuperFrame (简称
 
     `http://localhost:8210/sf`
 
-    ![](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/tools/mip-sf.png)
+    ![](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/tools/mip-sf.png)
 
 4. 在 URL 输入框 (第一个) 输入目标页面的 URL。__切记带上协议头，即 `http` 或者 `https`__
 
@@ -32,7 +32,7 @@ MIP 页面在上线到搜索结果页之后，需要嵌入在 SuperFrame (简称
 
     浏览器地址栏会变成 `http://localhost:8210/wishwing/c/xxxx`，而页面如下：
 
-    ![](https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mip/tools/mip-sf-view.png)
+    ![](https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/tools/mip-sf-view.png)
 
     从地址栏和页面右上角的更多（三个点）按钮都可以发现，页面已经位于 SuperFrame 环境内了。之后的页面跳转操作也可以正常进行。
 

--- a/docs/docs/interactive-mip/data-driven.md
+++ b/docs/docs/interactive-mip/data-driven.md
@@ -383,7 +383,7 @@ MIP 提供了 `MIP.setData` 方法进行数据修改。`MIP.setData` 传入的�
 
 <mip-img m-bind:src="imgSrc" src="https://www.mipengine.org/static/img/sample_01.jpg"></mip-img>
 
-<button on="tap:MIP.setData({ imgSrc: 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg' })">点击更换图片</button>
+<button on="tap:MIP.setData({ imgSrc: 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg' })">点击更换图片</button>
 ```
 
 效果如下所示：
@@ -402,7 +402,7 @@ MIP 提供了 `MIP.setData` 方法进行数据修改。`MIP.setData` 传入的�
     layout="fixed-height"
     m-bind:src="imgSrc" src="https://www.mipengine.org/static/img/sample_01.jpg"></mip-img>
   <div class="example-button-wrapper">
-    <button class="example-button" on="tap:MIP.setData({ imgSrc: 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg' })">点击更换图片</button>
+    <button class="example-button" on="tap:MIP.setData({ imgSrc: 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg' })">点击更换图片</button>
   </div>
 </div>
 

--- a/packages/mip/examples/builtin-components/mip-img.html
+++ b/packages/mip/examples/builtin-components/mip-img.html
@@ -148,7 +148,7 @@
   height="500"
   popup
   alt="baidu mip img"
-  src="http://bos.nj.bpc.baidu.com/v1/assets/mip/mip2-component-lifecycle.png"&gt;
+  src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png"&gt;
 &lt;/mip-img&gt;</pre>
 
 <mip-img
@@ -157,7 +157,7 @@
   height="500"
   popup
   alt="baidu mip img"
-  src="http://bos.nj.bpc.baidu.com/v1/assets/mip/mip2-component-lifecycle.png">
+  src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png">
 </mip-img>
 
 <h2>使用 source 标签</h2>

--- a/packages/mip/examples/mip2/mip-interact.html
+++ b/packages/mip/examples/mip2/mip-interact.html
@@ -345,7 +345,7 @@
       width="400"
       height="250"
       popup
-      src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg">
+      src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg">
     </mip-img>
     <div style="height:1000px;background-color: gray">
     </div>

--- a/packages/mip/examples/page/async-script.html
+++ b/packages/mip/examples/page/async-script.html
@@ -312,7 +312,7 @@
               "header": {
                 "show": true,
                 "title": "MIP",
-                "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+                "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
                 "buttonGroup": [{
                     "name": "subscribe",
                     "text": "关注",

--- a/packages/mip/examples/page/codelab/use-shell.html
+++ b/packages/mip/examples/page/codelab/use-shell.html
@@ -37,7 +37,7 @@
   <body>
       <h2>这是我的第一个 MIP 页面</h2>
 
-      <mip-img src="http://boscdn.bpc.baidu.com/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
+      <mip-img src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="main-image"></mip-img>
 
       <p>MIP 全称为 Mobile Instant Pages，因此是以页面 (Page) 为单位来运行的。开发者通过改造/提交一个个页面，继而被百度收录并展示。 </p>
       <p>但以页面为单位会带来一个问题：当一个 MIP 页面中存在往其他页面跳转的链接时，就会使浏览器使用加载页面的默认行为来加载新页面。这“第二跳”的体验比起从搜索结果页到 MIP 页面的“第一跳”来说相去甚远。 </p>

--- a/packages/mip/examples/page/components/mip-shell-is.js
+++ b/packages/mip/examples/page/components/mip-shell-is.js
@@ -23,7 +23,7 @@ class MipShellIS extends window.MIP.builtinComponents.MipShell {
     console.log('Simulate async request with isId:', isId)
     setTimeout(() => {
       shellConfig.routes[0].meta.header.title = '蓝犀牛搬家'
-      shellConfig.routes[0].meta.header.logo = 'http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png'
+      shellConfig.routes[0].meta.header.logo = 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png'
       shellConfig.routes[0].meta.header.buttonGroup = [
         {
           name: 'share',

--- a/packages/mip/examples/page/data.html
+++ b/packages/mip/examples/page/data.html
@@ -298,7 +298,7 @@
                         "header": {
                             "show": true,
                             "title": "MIP",
-                            "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
                             "buttonGroup": [
                                 {
                                     "name": "subscribe",

--- a/packages/mip/examples/page/index.html
+++ b/packages/mip/examples/page/index.html
@@ -75,7 +75,7 @@
 </head>
 <body>
     <div class="main-image">
-        <mip-img popup src="http://boscdn.bpc.baidu.com/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300"></mip-img>
+        <mip-img popup src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300"></mip-img>
     </div>
     <br><br>
     <mip-data>
@@ -163,7 +163,7 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
                         "header": {
                             "show": true,
                             "title": "MIP",
-                            "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+                            "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
                             "buttonGroup": [
                                 {
                                     "name": "subscribe",

--- a/packages/mip/examples/page/tree.html
+++ b/packages/mip/examples/page/tree.html
@@ -76,7 +76,7 @@
                             "header": {
                                 "show": true,
                                 "title": "MIP",
-                                "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+                                "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
                                 "buttonGroup": [
                                     {
                                         "name": "subscribe",

--- a/packages/mip/examples/ssr/index.html
+++ b/packages/mip/examples/ssr/index.html
@@ -33,9 +33,9 @@
         </div>
       </custom-volume>
 
-      <mip-img src="http://boscdn.bpc.baidu.com/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="mip-layout-fixed mip-layout-size-defined" style="width: 300px; height: 300px;">
+      <mip-img src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg" width="300" height="300" class="mip-layout-fixed mip-layout-size-defined" style="width: 300px; height: 300px;">
         <div data-server-rendered data-v-2fc858b0="" class="mip-img mip-fill-content mip-replaced-content" style="width: 300px;">
-          <img data-v-2fc858b0="" src="http://boscdn.bpc.baidu.com/assets/mip/codelab/shell/mashroom.jpg">
+          <img data-v-2fc858b0="" src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/codelab/shell/mashroom.jpg">
         </div>
       </mip-img>
     </div>

--- a/packages/mip/test/e2e/cases/api.html
+++ b/packages/mip/test/e2e/cases/api.html
@@ -34,7 +34,7 @@
             "header": {
               "show": true,
               "title": "MIP",
-              "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+              "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
               "buttonGroup": [
                 {
                   "name": "subscribe",

--- a/packages/mip/test/e2e/cases/data.html
+++ b/packages/mip/test/e2e/cases/data.html
@@ -35,7 +35,7 @@
             "header": {
               "show": true,
               "title": "MIP",
-              "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+              "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
               "buttonGroup": [
                 {
                   "name": "subscribe",

--- a/packages/mip/test/e2e/cases/index.html
+++ b/packages/mip/test/e2e/cases/index.html
@@ -49,7 +49,7 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
             "header": {
               "show": true,
               "title": "MIP",
-              "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+              "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
               "buttonGroup": [
                 {
                   "name": "subscribe",

--- a/packages/mip/test/e2e/cases/scroll-to-anchor.html
+++ b/packages/mip/test/e2e/cases/scroll-to-anchor.html
@@ -77,7 +77,7 @@ Fast - Respond quickly to user interactions with silky smooth animations and no 
             "header": {
               "show": true,
               "title": "MIP",
-              "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+              "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
               "buttonGroup": [
                 {
                   "name": "subscribe",

--- a/packages/mip/test/e2e/cases/tree.html
+++ b/packages/mip/test/e2e/cases/tree.html
@@ -26,7 +26,7 @@
                             "header": {
                                 "show": true,
                                 "title": "MIP",
-                                "logo": "http://boscdn.bpc.baidu.com/assets/mip2/lanxiniu/logo.png",
+                                "logo": "https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip2/lanxiniu/logo.png",
                                 "buttonGroup": [
                                     {
                                         "name": "subscribe",

--- a/packages/mip/test/specs/components/mip-carousel.spec.js
+++ b/packages/mip/test/specs/components/mip-carousel.spec.js
@@ -62,10 +62,10 @@ describe('mip-carousel', function () {
               <div class="mip-carousle-subtitle">这里是title2</div>
           </a>
           <mip-img popup
-              src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg">
+              src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg">
           </mip-img>
           <mip-img popup
-              src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mipengine/wide.jpg">
+              src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/wide.jpg">
           </mip-img>
         </mip-carousel>
       `
@@ -82,7 +82,7 @@ describe('mip-carousel', function () {
       expect(wrapBox).to.be.exist
       expect(wrapBox.parentNode.classList.contains('mip-carousel-container')).to.be.true
       expect(slideBoxs.length).to.equal(5)
-      expect(slideBoxs[0].querySelector('img').getAttribute('src')).to.equal('https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mipengine/wide.jpg')
+      expect(slideBoxs[0].querySelector('img').getAttribute('src')).to.equal('https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/wide.jpg')
       expect(slideBoxs[4].querySelector('img').getAttribute('src')).to.equal('https://www.mipengine.org/static/img/sample_01.jpg')
     })
 

--- a/packages/mip/test/specs/components/mip-img.spec.js
+++ b/packages/mip/test/specs/components/mip-img.spec.js
@@ -43,7 +43,7 @@ describe('mip-img', function () {
   })
 
   it('should be loading with placeholder', async () => {
-    let mipImg = dom.create('<mip-img popup src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg"></mip-img>')
+    let mipImg = dom.create('<mip-img popup src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg"></mip-img>')
     mipImgWrapper.appendChild(mipImg)
     document.body.appendChild(mipImgWrapper)
     mipImg.viewportCallback(true)
@@ -99,14 +99,14 @@ describe('mip-img', function () {
 
   it('should load img with normal src', function () {
     mipImgWrapper.innerHTML = `
-      <mip-img src="https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg"></mip-img>
+      <mip-img src="https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg"></mip-img>
     `
     let mipImg = mipImgWrapper.querySelector('mip-img')
     mipImg.viewportCallback(true)
     let img = mipImg.querySelector('img')
     let loading = new Promise(resolve => event.listen(img, 'load', resolve))
     expect(img.classList.contains('mip-replaced-content')).to.equal(true)
-    expect(img.getAttribute('src')).to.equal('https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg')
+    expect(img.getAttribute('src')).to.equal('https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg')
     return loading
   })
 
@@ -165,7 +165,7 @@ describe('mip-img', function () {
     let carou = document.createElement('mip-carousel')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/assets/mipengine/wide.jpg')
+    mipImg.setAttribute('src', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/wide.jpg')
     mipImg.setAttribute('popup', 'true')
     // carousel for triggering open-popup and close-popup event
     carou.appendChild(mipImg)
@@ -230,7 +230,7 @@ describe('mip-img', function () {
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/mip2-component-lifecycle.png')
+    mipImg.setAttribute('src', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png')
     mipImg.setAttribute('popup', 'true')
     mipImgWrapper.appendChild(mipImg)
 
@@ -271,7 +271,7 @@ describe('mip-img', function () {
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/mip2-component-lifecycle.png')
+    mipImg.setAttribute('src', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png')
     mipImg.setAttribute('popup', 'true')
     mipImgWrapper.appendChild(mipImg)
 
@@ -297,7 +297,7 @@ describe('mip-img', function () {
     let mipImg = document.createElement('mip-img')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/mip2-component-lifecycle.png')
+    mipImg.setAttribute('src', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png')
     mipImgWrapper.appendChild(mipImg)
 
     mipImg.viewportCallback(true)
@@ -320,10 +320,10 @@ describe('mip-img', function () {
   it('should work with source tag', async () => {
     let mipImg = document.createElement('mip-img')
     let source = document.createElement('source')
-    source.setAttribute('srcset', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg')
+    source.setAttribute('srcset', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg')
     mipImg.setAttribute('width', '100px')
     mipImg.setAttribute('height', '100px')
-    mipImg.setAttribute('src', 'https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mip/mip2-component-lifecycle.png')
+    mipImg.setAttribute('src', 'https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mip/mip2-component-lifecycle.png')
     mipImg.setAttribute('popup', 'true')
     mipImg.appendChild(source)
     mipImgWrapper.appendChild(mipImg)
@@ -333,6 +333,6 @@ describe('mip-img', function () {
     let loading = new Promise(resolve => event.listen(img, 'load', resolve))
     expect(mipImg.querySelector('picture')).to.be.exist
     await loading
-    expect(img.currentSrc).to.equal('https://gss0.baidu.com/9rkZbzqaKgQUohGko9WTAnF6hhy/v1/assets/mipengine/logo.jpeg')
+    expect(img.currentSrc).to.equal('https://mip-doc.cdn.bcebos.com/mipengine-org/assets/mipengine/logo.jpeg')
   })
 })


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#710 
**1、升级点** （清晰准确的描述升级的功能点）
1. 将原先的 assets bucket 的图片迁移到 mip-doc 上

**2、影响范围** （描述该需求上线会影响什么功能）
无
**3、自测 Checklist**
单测不受影响，无代码改动

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
