### PR TITLE
增加 swanInvoke 白名单

### DIFF
--- a/packages/mip-cli/package-lock.json
+++ b/packages/mip-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1351,8 +1351,8 @@
     },
     "babel-core": {
       "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "resolved": "http://registry.npm.taobao.org/babel-core/download/babel-core-6.26.3.tgz",
+      "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-generator": "^6.26.0",
@@ -1377,28 +1377,28 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "resolved": "http://registry.npm.taobao.org/babel-generator/download/babel-generator-6.26.1.tgz",
+      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
         "babel-messages": "^6.23.0",
         "babel-runtime": "^6.26.0",
@@ -1412,14 +1412,14 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         }
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-builder-binary-assignment-operator-visitor/download/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
@@ -1429,7 +1429,7 @@
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-explode-assignable-expression/download/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -1439,7 +1439,7 @@
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-function-name/download/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
@@ -1451,7 +1451,7 @@
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-get-function-arity/download/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -1460,7 +1460,7 @@
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-remap-async-to-generator/download/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
         "babel-helper-function-name": "^6.24.1",
@@ -1472,7 +1472,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-helpers/download/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
         "babel-runtime": "^6.22.0",
@@ -1564,7 +1564,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -1572,32 +1572,32 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-functions/download/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-generators/download/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-exponentiation-operator/download/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-object-rest-spread/download/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-trailing-function-commas/download/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-generator-functions": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-generator-functions/download/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "requires": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
@@ -1607,7 +1607,7 @@
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-to-generator/download/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
@@ -1617,7 +1617,7 @@
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-exponentiation-operator/download/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
@@ -1627,7 +1627,7 @@
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.8.0",
@@ -1636,7 +1636,7 @@
     },
     "babel-preset-stage-3": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-stage-3/download/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "requires": {
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -1648,7 +1648,7 @@
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-register/download/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
         "babel-core": "^6.26.0",
@@ -1662,7 +1662,7 @@
       "dependencies": {
         "home-or-tmp": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+          "resolved": "http://registry.npm.taobao.org/home-or-tmp/download/home-or-tmp-2.0.0.tgz",
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -1671,8 +1671,8 @@
         },
         "source-map-support": {
           "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz?cache=0&sync_timestamp=1572389965235&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map-support%2Fdownload%2Fsource-map-support-0.4.18.tgz",
+          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
           "requires": {
             "source-map": "^0.5.6"
           }
@@ -1697,7 +1697,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-template/download/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -1709,7 +1709,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "^6.26.0",
@@ -1725,27 +1725,27 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "resolved": "https://registry.npm.taobao.org/globals/download/globals-9.18.0.tgz",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "http://registry.npm.taobao.org/babel-types/download/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -1756,15 +1756,15 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
       }
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "resolved": "http://registry.npm.taobao.org/babylon/download/babylon-6.18.0.tgz",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -3691,7 +3691,7 @@
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/detect-indent/download/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
         "repeating": "^2.0.0"
@@ -4421,8 +4421,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4440,13 +4439,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4459,18 +4456,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4573,8 +4567,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4584,7 +4577,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4597,20 +4589,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4627,7 +4616,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4700,8 +4688,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4711,7 +4698,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4787,8 +4773,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4818,7 +4803,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4836,7 +4820,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4875,13 +4858,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5546,7 +5527,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/is-finite/download/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -6549,9 +6530,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mip-component-validator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/mip-component-validator/-/mip-component-validator-1.1.7.tgz",
-      "integrity": "sha512-j60VneIFhSyE3BejhL9/3T/tqvhf2Pg6nbsEdltahj/mEsKmjUfn5Ve+DUunGBi8yvywPRIGkq8w6sHT0gZcCg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npm.taobao.org/mip-component-validator/download/mip-component-validator-1.1.8.tgz?cache=0&sync_timestamp=1573733333381&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmip-component-validator%2Fdownload%2Fmip-component-validator-1.1.8.tgz",
+      "integrity": "sha1-F0nnBJ05h0angjECqi3JQdpXNNE=",
       "requires": {
         "babel-core": "^6.26.3",
         "babel-preset-stage-3": "^6.24.1",
@@ -6567,8 +6548,8 @@
       "dependencies": {
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-7.0.1.tgz",
+          "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -6583,9 +6564,9 @@
       "integrity": "sha512-BEa0sUxMlqCwVLAu56zQhf+RhvcgCX4iu9wYXHmYr/8oPDAsl44vLoS9KQ/OkMRt9WeYZ1HgYtF9Qh43l3OBVA=="
     },
     "mip-sandbox": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/mip-sandbox/-/mip-sandbox-1.1.9.tgz",
-      "integrity": "sha512-Jb3UZ+peP2Vk26kWVAwa+NqscP7CAXMl1JgQjPaYh/bsc8eRh8CtFypjtIvzoz9cbYmB/THWvEqalq2er/Og0Q==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.1.13.tgz",
+      "integrity": "sha1-pQu3Gq4eGvlQzeFBtKV3kVe0aF8=",
       "requires": {
         "acorn": "^5.7.1",
         "acorn-dynamic-import": "^3.0.0",
@@ -6596,8 +6577,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },
@@ -6812,9 +6793,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npm.taobao.org/node-fetch/download/node-fetch-2.6.0.tgz",
+      "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
     },
     "node-libs-browser": {
       "version": "2.2.0",
@@ -6929,7 +6910,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
@@ -6971,7 +6952,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -8154,8 +8134,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -12153,7 +12132,7 @@
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "http://registry.npm.taobao.org/repeating/download/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "^1.0.0"
@@ -12436,7 +12415,7 @@
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/slash/download/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "snapdragon": {
@@ -13525,8 +13504,8 @@
     },
     "vue": {
       "version": "2.5.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
-      "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
+      "resolved": "http://registry.npm.taobao.org/vue/download/vue-2.5.16.tgz",
+      "integrity": "sha1-B+23XoQSqu7YceuvqZ9GclhKAIU="
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",

--- a/packages/mip-cli/package.json
+++ b/packages/mip-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip2",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "CLI for mip 2.0",
   "preferGlobal": true,
   "bin": {
@@ -65,9 +65,9 @@
     "livereload": "^0.7.0",
     "metalsmith": "^2.3.0",
     "minimatch": "^3.0.4",
-    "mip-component-validator": "^1.1.7",
+    "mip-component-validator": "^1.1.8",
     "mip-components-webpack-helpers": "^1.0.17",
-    "mip-sandbox": "^1.1.9",
+    "mip-sandbox": "^1.1.13",
     "mip-validator": "^1.5.15",
     "opn": "^5.3.0",
     "ora": "^2.1.0",

--- a/packages/mip-component-validator/package-lock.json
+++ b/packages/mip-component-validator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-component-validator",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mip-component-validator/package.json
+++ b/packages/mip-component-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-component-validator",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "MIP component validate",
   "main": "index.js",
   "scripts": {

--- a/packages/mip-component-validator/src/rules/component-npm-whitelist.js
+++ b/packages/mip-component-validator/src/rules/component-npm-whitelist.js
@@ -56,7 +56,7 @@ function getWhitelist () {
     return Promise.resolve(whitelist)
   }
 
-  const url = 'http://bos.nj.bpc.baidu.com/assets/mip-cli/whitelist.txt'
+  const url = 'http://mip-doc.bj.bcebos.com/mip-cli/whitelist.txt'
   const local = path.resolve(__dirname, 'lib/whitelist.txt')
 
   return fetch(url, {timeout: 1000})

--- a/packages/mip-component-validator/src/rules/lib/whitelist.txt
+++ b/packages/mip-component-validator/src/rules/lib/whitelist.txt
@@ -11,6 +11,9 @@ nib
 fe-siteopen-sdk
 @baidu/fe-siteopen-sdk
 @baidu/guid
+@baidu/m-antman
 web-animations-js
 vue-lottery
 mustache
+swiper
+clipboard

--- a/packages/mip-sandbox/lib/keywords-generate.js
+++ b/packages/mip-sandbox/lib/keywords-generate.js
@@ -350,6 +350,7 @@ module.exports = function () {
           'scrollbars',
           // https://github.com/mipengine/mip2/issues/563
           'swan',
+          'swanInvoke',
           {
             name: 'document',
             origin: function () {

--- a/packages/mip-sandbox/package-lock.json
+++ b/packages/mip-sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -236,7 +236,6 @@
       "resolved": "http://registry.npm.taobao.org/agent-base/download/agent-base-4.2.0.tgz",
       "integrity": "sha1-mDi1wzkrliutAx5qTF4QJKvsRc4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -264,7 +263,6 @@
       "resolved": "http://registry.npm.taobao.org/align-text/download/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -450,8 +448,7 @@
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -896,7 +893,6 @@
       "resolved": "http://registry.npm.taobao.org/boom/download/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -1025,8 +1021,7 @@
       "version": "0.0.2",
       "resolved": "http://registry.npm.taobao.org/buffer-more-ints/download/buffer-more-ints-0.0.2.tgz",
       "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1344,7 +1339,6 @@
       "resolved": "http://registry.npm.taobao.org/combined-stream/download/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1744,8 +1738,7 @@
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1992,15 +1985,13 @@
       "version": "4.2.4",
       "resolved": "http://registry.npm.taobao.org/es6-promise/download/es6-promise-4.2.4.tgz",
       "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "http://registry.npm.taobao.org/es6-promisify/download/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2209,8 +2200,7 @@
       "version": "1.3.0",
       "resolved": "http://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2433,8 +2423,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2455,14 +2444,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2477,20 +2464,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2607,8 +2591,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2620,7 +2603,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2635,7 +2617,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2643,14 +2624,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2669,7 +2648,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2750,8 +2728,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2763,7 +2740,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2849,8 +2825,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2886,7 +2861,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2906,7 +2880,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2950,14 +2923,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3367,8 +3338,7 @@
       "version": "2.16.3",
       "resolved": "http://registry.npm.taobao.org/hoek/download/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -3404,7 +3374,6 @@
       "resolved": "http://registry.npm.taobao.org/http-proxy-agent/download/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -3427,7 +3396,6 @@
       "resolved": "http://registry.npm.taobao.org/httpntlm/download/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -3437,8 +3405,7 @@
       "version": "0.4.24",
       "resolved": "http://registry.npm.taobao.org/httpreq/download/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -3451,7 +3418,6 @@
       "resolved": "http://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -3535,8 +3501,7 @@
       "version": "1.1.5",
       "resolved": "http://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3984,8 +3949,7 @@
       "version": "5.0.1",
       "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -4178,15 +4142,13 @@
       "version": "0.1.0",
       "resolved": "http://registry.npm.taobao.org/libbase64/download/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "http://registry.npm.taobao.org/libmime/download/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -4197,8 +4159,7 @@
           "version": "0.4.15",
           "resolved": "http://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4206,8 +4167,7 @@
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/libqp/download/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -4458,8 +4418,7 @@
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/longest/download/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4926,15 +4885,13 @@
       "version": "1.6.0",
       "resolved": "http://registry.npm.taobao.org/nodemailer-fetch/download/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/nodemailer-shared/download/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -4967,8 +4924,7 @@
       "version": "0.1.10",
       "resolved": "http://registry.npm.taobao.org/nodemailer-wellknown/download/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -6040,15 +5996,13 @@
       "version": "1.1.15",
       "resolved": "http://registry.npm.taobao.org/smart-buffer/download/smart-buffer-1.1.15.tgz",
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "http://registry.npm.taobao.org/smtp-connection/download/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -6274,7 +6228,6 @@
       "resolved": "http://registry.npm.taobao.org/socks/download/socks-1.1.10.tgz",
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ip": "^1.1.4",
         "smart-buffer": "^1.0.13"
@@ -6285,7 +6238,6 @@
       "resolved": "http://registry.npm.taobao.org/socks-proxy-agent/download/socks-proxy-agent-3.0.1.tgz",
       "integrity": "sha1-Lq58+OKoLTRWV2FTmn+XGMVhdlk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "socks": "^1.1.10"
@@ -6773,8 +6725,7 @@
       "version": "1.7.0",
       "resolved": "http://registry.npm.taobao.org/underscore/download/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/packages/mip-sandbox/package.json
+++ b/packages/mip-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip-sandbox",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "sandbox tools for MIP project",
   "main": "lib/sandbox.js",
   "scripts": {

--- a/packages/mip/package-lock.json
+++ b/packages/mip/package-lock.json
@@ -994,7 +994,6 @@
       "resolved": "http://registry.npm.taobao.org/agent-base/download/agent-base-4.2.1.tgz",
       "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1859,7 +1858,6 @@
       "resolved": "http://registry.npm.taobao.org/boom/download/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -2043,8 +2041,7 @@
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/buffer-more-ints/download/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha1-70+OLd261CntOCipxV1E8FxhFCI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3686,15 +3683,13 @@
       "version": "4.2.6",
       "resolved": "http://registry.npm.taobao.org/es6-promise/download/es6-promise-4.2.6.tgz",
       "integrity": "sha1-toXt2CWIhjZepitX0w3ij63Nl08=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "http://registry.npm.taobao.org/es6-promisify/download/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -4346,8 +4341,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4368,14 +4362,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4390,20 +4382,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4520,8 +4509,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4533,7 +4521,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4548,7 +4535,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4556,14 +4542,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4582,7 +4566,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4663,8 +4646,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4676,7 +4658,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4762,8 +4743,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4799,7 +4779,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4819,7 +4798,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4863,14 +4841,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5287,8 +5263,7 @@
       "version": "2.16.3",
       "resolved": "http://registry.npm.taobao.org/hoek/download/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -5335,7 +5310,6 @@
       "resolved": "http://registry.npm.taobao.org/http-proxy-agent/download/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -5346,7 +5320,6 @@
           "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz",
           "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5355,8 +5328,7 @@
           "version": "2.0.0",
           "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5387,7 +5359,6 @@
       "resolved": "http://registry.npm.taobao.org/httpntlm/download/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -5397,8 +5368,7 @@
       "version": "0.4.24",
       "resolved": "http://registry.npm.taobao.org/httpreq/download/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -5411,7 +5381,6 @@
       "resolved": "http://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -5422,7 +5391,6 @@
           "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5544,8 +5512,7 @@
       "version": "1.1.5",
       "resolved": "http://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -5772,8 +5739,7 @@
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/is-property/download/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -6344,15 +6310,13 @@
       "version": "0.1.0",
       "resolved": "http://registry.npm.taobao.org/libbase64/download/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "http://registry.npm.taobao.org/libmime/download/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -6363,8 +6327,7 @@
           "version": "0.4.15",
           "resolved": "http://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6372,8 +6335,7 @@
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/libqp/download/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lightercollective": {
       "version": "0.1.0",
@@ -7179,9 +7141,9 @@
       "integrity": "sha1-FBrZrRLYsvX8BOD8L5TbnozE9mA="
     },
     "mip-sandbox": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.1.12.tgz?cache=0&sync_timestamp=1568024420554&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmip-sandbox%2Fdownload%2Fmip-sandbox-1.1.12.tgz",
-      "integrity": "sha1-G+s8cK4GagEyR9z4zXcGb0hY0AM=",
+      "version": "1.1.13",
+      "resolved": "https://registry.npm.taobao.org/mip-sandbox/download/mip-sandbox-1.1.13.tgz",
+      "integrity": "sha1-pQu3Gq4eGvlQzeFBtKV3kVe0aF8=",
       "requires": {
         "acorn": "^5.7.1",
         "acorn-dynamic-import": "^3.0.0",
@@ -7813,15 +7775,13 @@
       "version": "1.6.0",
       "resolved": "http://registry.npm.taobao.org/nodemailer-fetch/download/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/nodemailer-shared/download/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -7854,8 +7814,7 @@
       "version": "0.1.10",
       "resolved": "http://registry.npm.taobao.org/nodemailer-wellknown/download/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -11076,15 +11035,13 @@
       "version": "4.0.2",
       "resolved": "http://registry.npm.taobao.org/smart-buffer/download/smart-buffer-4.0.2.tgz",
       "integrity": "sha1-UgeFjDgVzGkRBwPGuU5GwVY0OV0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "http://registry.npm.taobao.org/smtp-connection/download/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
-      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -11336,7 +11293,6 @@
       "resolved": "http://registry.npm.taobao.org/socks/download/socks-2.3.2.tgz",
       "integrity": "sha1-reOI6ebYf9sRZJwVdGxXiSKliD4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -11347,7 +11303,6 @@
       "resolved": "http://registry.npm.taobao.org/socks-proxy-agent/download/socks-proxy-agent-4.0.2.tgz",
       "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -12170,8 +12125,7 @@
       "version": "1.7.0",
       "resolved": "http://registry.npm.taobao.org/underscore/download/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/packages/mip/package.json
+++ b/packages/mip/package.json
@@ -71,7 +71,7 @@
     "he": "^1.1.1",
     "less": "^3.0.4",
     "mip-components-webpack-helpers": "^1.0.15",
-    "mip-sandbox": "^1.1.12",
+    "mip-sandbox": "^1.1.13",
     "ora": "^2.1.0",
     "postcss-csso": "^3.0.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#725 
**1、升级点** （清晰准确的描述升级的功能点）
- 增加白名单 swanInvoke
- 迁移 mip-component-validator 的 whitelist.txt bos 地址

**2、影响范围** （描述该需求上线会影响什么功能）
无

**3、自测 Checklist**
- mip-cli 可正常使用

**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
