### PR TITLE
仅针对安卓手百将播放器的播放模式切换回 h5

### DIFF
--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -92,7 +92,7 @@ class MipVideo extends CustomElement {
     videoEl.setAttribute('x5-playsinline', 'x5-playsinline')
     videoEl.setAttribute('webkit-playsinline', 'webkit-playsinline')
     // @2019.12.04 安卓手百在 t7-video-player-type=inline 的情况下，先锁屏再解锁之后，浏览器会自动播放。由于问题仅出现在安卓手百环境，因此仅针对安卓手百环境，将 t7-video-player-type 设置为 h5
-    if (util.platform.isAndroid && util.platform.isBaiduApp) {
+    if (util.platform.isAndroid() && util.platform.isBaiduApp()) {
       videoEl.setAttribute('t7-video-player-type', 'h5')
 
     }

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -91,7 +91,14 @@ class MipVideo extends CustomElement {
     // 兼容qq浏览器
     videoEl.setAttribute('x5-playsinline', 'x5-playsinline')
     videoEl.setAttribute('webkit-playsinline', 'webkit-playsinline')
-    videoEl.setAttribute('t7-video-player-type', 'inline')
+    // @2019.12.04 安卓手百在 t7-video-player-type=inline 的情况下，先锁屏再解锁之后，浏览器会自动播放。由于问题仅出现在安卓手百环境，因此仅针对安卓手百环境，将 t7-video-player-type 设置为 h5
+    if (util.platform.isAndroid && util.platform.isBaiduApp) {
+      videoEl.setAttribute('t7-video-player-type', 'h5')
+
+    }
+    else {
+      videoEl.setAttribute('t7-video-player-type', 'inline')
+    }
     Array.prototype.slice.apply(this.element.childNodes).forEach(function (node) {
       // FIXME: mip layout related, remove this!
       if (node.nodeName.toLowerCase() === 'mip-i-space') {


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#729 
**1、升级点** （清晰准确的描述升级的功能点）
1. 针对 android 手百环境，将 t7-video-player-type 从 inline 改成 h5
**2、影响范围** （描述该需求上线会影响什么功能）
1. video 在安卓手百环境下打开的情况
**3、自测 Checklist**
1. android 普通浏览器页面测试 examples/builtin-components/mip-video.html 各个 case 正常
2. android 手百浏览上述页面，已修复锁屏后打开自动播放问题
3. ios 普通浏览器测试上述页面正常
4. ios 手百浏览上述测试页面正常

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
