### PR TITLE
【BUGFIX】消除自定义样式 min-width/min-height 对 MIP 固定顶部栏样式所造成的影响

### DIFF
--- a/packages/mip/src/styles/mip-shell.less
+++ b/packages/mip/src/styles/mip-shell.less
@@ -64,6 +64,10 @@ mip-shell * {
     .mip-shell-header-logo {
       height: 32px;
       width: 32px;
+      min-width: 32px;
+      max-width: 32px;
+      min-height: 32px;
+      max-height: 32px;
       margin: 5px 8px 0 0;
       border: 1px solid #e1e1e1;
       border-radius: 50%;


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
#731 
**1、升级点** （清晰准确的描述升级的功能点）
1. 增加 mip-shell-header-logo 的样式，防止被 min-width/min-height/max-width/max-height 的站点自定义样式污染；
**2、影响范围** （描述该需求上线会影响什么功能）
1. 医疗 MIP 页；
**3、自测 Checklist**
1. 普通 MIP 页不受影响；
2. 目前正常显示的医疗 MIP 页也不受影响；
3. logo 被拉伸的医疗 MIP 页 logo 显示正常；

**4、需要覆盖的场景和 Case**
- [x] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [x] 是否覆盖了 iOS 系统手机
- [x] 是否覆盖了 Android 系统手机
- [x] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [x] 是否覆盖了手百
