### PR TITLE
开放video的针对浏览器的属性的自定义#733

### DIFF
--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -25,6 +25,16 @@ let videoAttributes = [
   'currenttime'
 ]
 
+const videoExtAttributes = [
+  'playsinline',
+  'x5-playsinline',
+  'webkit-playsinline',
+  'webkit-playsinline',
+  't7-video-player-type',
+  'x5-video-player-type',
+  'x-webkit-airplay'
+] 
+
 /**
  * Get attribute Set from attribute List
  *
@@ -81,11 +91,6 @@ class MipVideo extends CustomElement {
   // Render the `<video>` element, and append to `this.element`
   renderInView () {
     let videoEl = document.createElement('video')
-    for (let k in this.attributes) {
-      if (this.attributes.hasOwnProperty(k) && videoAttributes.indexOf(k) > -1) {
-        videoEl.setAttribute(k, this.attributes[k])
-      }
-    }
     let currentTime = this.attributes.currenttime
     videoEl.setAttribute('playsinline', 'playsinline')
     // 兼容qq浏览器
@@ -98,6 +103,12 @@ class MipVideo extends CustomElement {
     }
     else {
       videoEl.setAttribute('t7-video-player-type', 'inline')
+    }
+    const attributes = videoAttributes.concat(videoExtAttributes);
+    for (let k in this.attributes) {
+      if (this.attributes.hasOwnProperty(k) && attributes.indexOf(k) > -1) {
+        videoEl.setAttribute(k, this.attributes[k])
+      }
     }
     Array.prototype.slice.apply(this.element.childNodes).forEach(function (node) {
       // FIXME: mip layout related, remove this!

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -34,6 +34,8 @@ const videoExtAttributes = [
   'x-webkit-airplay'
 ] 
 
+const videoAttributesName = videoAttributes.concat(videoExtAttributes)
+
 /**
  * Get attribute Set from attribute List
  *
@@ -103,9 +105,8 @@ class MipVideo extends CustomElement {
     else {
       videoEl.setAttribute('t7-video-player-type', 'inline')
     }
-    const attributes = videoAttributes.concat(videoExtAttributes);
     for (let k in this.attributes) {
-      if (this.attributes.hasOwnProperty(k) && attributes.indexOf(k) > -1) {
+      if (this.attributes.hasOwnProperty(k) && videoAttributesName.indexOf(k) > -1) {
         videoEl.setAttribute(k, this.attributes[k])
       }
     }

--- a/packages/mip/src/components/mip-video.js
+++ b/packages/mip/src/components/mip-video.js
@@ -29,7 +29,6 @@ const videoExtAttributes = [
   'playsinline',
   'x5-playsinline',
   'webkit-playsinline',
-  'webkit-playsinline',
   't7-video-player-type',
   'x5-video-player-type',
   'x-webkit-airplay'


### PR DESCRIPTION
**相关 ISSUE:** （ISSUE 链接地址）
[mip-video 在安卓qq浏览器脱离文档流](https://github.com/mipengine/mip2/issues/733)
**1、升级点** （清晰准确的描述升级的功能点）
video属性添加针对浏览器的如下配置:
'playsinline',
'x5-playsinline',
'webkit-playsinline',
't7-video-player-type',
'x5-video-player-type',
'x-webkit-airplay'

**2、影响范围** （描述该需求上线会影响什么功能）
不会影响
**3、自测 Checklist**
android QQ浏览器添加x5-video-player-type属性，让视频没有脱离文档流
**4、需要覆盖的场景和 Case**
- [ ] 是否覆盖了 sf 打开 MIP 页
- [ ] 是否验证了极速服务 MIP 页面效果

**5、自测机型和浏览器**
- [ ] 是否覆盖了 iOS 系统手机
- [ ] 是否覆盖了 Android 系统手机
- [ ] 是否覆盖了 iPhone 版式浏览器（比如 QQ、UC、Chrome、Safari、安卓自带浏览器）
- [ ] 是否覆盖了手百
